### PR TITLE
Separate crests

### DIFF
--- a/src/parsers/optimized/UKSC.cs
+++ b/src/parsers/optimized/UKSC.cs
@@ -44,8 +44,8 @@ class OptimizedUKSCParser : OptimizedParser {
     }
 
     private List<Enricher> headerEnrichers = new List<Enricher>() {
-        // new UKSC.SealRemover(),
         new RestrictionsEnricher(),
+        new CrestSplitter(),
         new Legislation.Judgments.Parse.UKSC.CiteEnricher(),
         new UKSC.OnAppealFromRefEnricher(),
         new Legislation.Judgments.Parse.UKSC.DateEnricher(),

--- a/src/parsers/uksc/CrestSplitter.cs
+++ b/src/parsers/uksc/CrestSplitter.cs
@@ -1,0 +1,47 @@
+
+using System.Collections.Generic;
+using System.Linq;
+
+using UK.Gov.Legislation.Judgments;
+using UK.Gov.Legislation.Judgments.Parse;
+
+namespace UK.Gov.NationalArchives.CaseLaw.Parse
+{
+    class CrestSplitter : Enricher
+    {
+
+        internal override IEnumerable<IBlock> Enrich(IEnumerable<IBlock> blocks)
+        {
+            IEnumerator<IBlock> x = blocks.GetEnumerator();
+            if (!x.MoveNext())
+                return blocks;
+            List<IBlock> enriched = [];
+            if (x.Current is IRestriction)
+            {
+                enriched.Add(x.Current);
+                if (!x.MoveNext())
+                    return blocks;
+            }
+            if (x.Current is not WLine line)
+                return blocks;
+            if (line.Contents.FirstOrDefault() is not IImageRef image)
+                return blocks;
+            WLine one = WLine.Make(line, [image]);
+            enriched.Add(one);
+            if (line.Contents.Skip(1).Any())
+            {
+                WLine two = WLine.Make(line, line.Contents.Skip(1));
+                enriched.Add(two);
+            }
+            while (x.MoveNext())
+                enriched.Add(x.Current);
+            return enriched;
+        }
+
+        protected override IEnumerable<IInline> Enrich(IEnumerable<IInline> line)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+}

--- a/test/judgments/test5.xml
+++ b/test/judgments/test5.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2021/50/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2021/50/data.xml" />
-          <FRBRdate date="2024-02-20T18:52:59" name="transform" />
+          <FRBRdate date="2024-04-25T18:22:42" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -49,7 +49,7 @@
         <uk:year>2021</uk:year>
         <uk:number>50</uk:number>
         <uk:cite>[2021] UKSC 50</uk:cite>
-        <uk:parser>0.22.0</uk:parser>
+        <uk:parser>0.23.7</uk:parser>
         <uk:hash>ed865f2db49c89de0d02aba0e5c9165873cacd8c57f1020b14f16c63209556f6</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -99,7 +99,8 @@
       </presentation>
     </meta>
     <header>
-      <p class="JudgmentReferences"><img src="image1.png" style="width:99.35pt;height:99.35pt" /><span style="font-weight:bold">Michaelmas Term</span><br /><neutralCitation style="font-weight:bold">[2021] UKSC 50</neutralCitation><br /><span style="font-style:italic">On appeal from: </span><ref style="font-style:italic" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2019/1599" uk:origin="parser" uk:canonical="[2019] EWCA Civ 1599" uk:type="case" uk:isNeutral="true">[2019] EWCA Civ 1599</ref></p>
+      <p class="JudgmentReferences"><img src="image1.png" style="width:99.35pt;height:99.35pt" /></p>
+      <p class="JudgmentReferences"><span style="font-weight:bold">Michaelmas Term</span><br /><neutralCitation style="font-weight:bold">[2021] UKSC 50</neutralCitation><br /><span style="font-style:italic">On appeal from: </span><ref style="font-style:italic" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2019/1599" uk:origin="parser" uk:canonical="[2019] EWCA Civ 1599" uk:type="case" uk:isNeutral="true">[2019] EWCA Civ 1599</ref></p>
       <p class="JudgmentTitle">JUDGMENT</p>
       <p class="JudgmentDetail1"><party refersTo="#lloyd" as="#respondent">Lloyd</party> (<role refersTo="#respondent">Respondent</role>) <span style="font-style:italic">v</span><span> </span><party refersTo="#google-llc" as="#appellant">Google LLC</party> (<role refersTo="#appellant">Appellant</role>)</p>
       <p class="JudgmentJudges"><span style="font-weight:normal">before</span><br /><br /><judge refersTo="#judge-lord-reed-president">Lord Reed, President</judge><br /><judge refersTo="#judge-lady-arden">Lady Arden</judge><br /><judge refersTo="#judge-lord-sales">Lord Sales</judge><br /><judge refersTo="#judge-lord-leggatt">Lord Leggatt</judge><br /><judge refersTo="#judge-lord-burrows">Lord Burrows</judge></p>

--- a/test/judgments/test72.xml
+++ b/test/judgments/test72.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2023/42/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2023/42/data.xml" />
-          <FRBRdate date="2024-02-16T18:09:06" name="transform" />
+          <FRBRdate date="2024-04-25T18:22:49" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -49,7 +49,7 @@
         <uk:year>2023</uk:year>
         <uk:number>42</uk:number>
         <uk:cite>[2023] UKSC 42</uk:cite>
-        <uk:parser>0.22.0</uk:parser>
+        <uk:parser>0.23.7</uk:parser>
         <uk:hash>fe44c739208392907ce63435c854bcf323e8c68573970f0de53b691b20960bb3</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -101,8 +101,9 @@
       </presentation>
     </meta>
     <header>
-      <p class="CourtOrder"><span style="font-family:'Times New Roman'">THE COURT ORDERED that no one shall publish or reveal the names or addresses of AAA, HTN, RM, AS, SAA or ASM (the “Claimants”) or publish or reveal any information which would be likely to lead to the identification of the Claimants or of any member of their respective families in connection with these proceedings.</span></p>
-      <p class="JudgmentReferences"><img src="image1.png" style="width:99.35pt;height:99.35pt" /><span style="font-weight:bold;font-family:'Times New Roman'">Michaelmas Term</span><br /><neutralCitation style="font-weight:bold;font-family:'Times New Roman'">[2023] UKSC 42</neutralCitation><br /><span style="font-style:italic;font-family:'Times New Roman'">On appeal from: </span><ref style="font-style:italic;font-family:'Times New Roman'" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/745" uk:origin="parser" uk:canonical="[2023] EWCA Civ 745" uk:type="case" uk:isNeutral="true">[2023] EWCA Civ 745</ref></p>
+      <block name="restriction" class="CourtOrder"><span style="font-family:'Times New Roman'">THE COURT ORDERED that no one shall publish or reveal the names or addresses of AAA, HTN, RM, AS, SAA or ASM (the “Claimants”) or publish or reveal any information which would be likely to lead to the identification of the Claimants or of any member of their respective families in connection with these proceedings.</span></block>
+      <p class="JudgmentReferences"><img src="image1.png" style="width:99.35pt;height:99.35pt" /></p>
+      <p class="JudgmentReferences"><span style="font-weight:bold;font-family:'Times New Roman'">Michaelmas Term</span><br /><neutralCitation style="font-weight:bold;font-family:'Times New Roman'">[2023] UKSC 42</neutralCitation><br /><span style="font-style:italic;font-family:'Times New Roman'">On appeal from: </span><ref style="font-style:italic;font-family:'Times New Roman'" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/745" uk:origin="parser" uk:canonical="[2023] EWCA Civ 745" uk:type="case" uk:isNeutral="true">[2023] EWCA Civ 745</ref></p>
       <p class="JudgmentTitle"><span style="font-family:'Times New Roman';font-size:18pt">JUDGMENT</span></p>
       <p class="JudgmentJudges"><span style="font-family:'Times New Roman';font-size:14pt">R (on the application of AAA (Syria) and others) (Respondents/Cross Appellants) v Secretary of State for the Home Department (Appellant/Cross Respondent); </span><br /><span style="font-family:'Times New Roman';font-size:14pt">R (on the application of HTN (Vietnam)) (Respondent/Cross Appellant) v Secretary of State for the Home Department (Appellant/Cross Respondent);</span><br /><span style="font-family:'Times New Roman';font-size:14pt">R (on the application of RM (Iran)) (Respondent) v Secretary of State for the Home Department (Appellant);</span><br /><span style="font-family:'Times New Roman';font-size:14pt">R (on the application of AS (Iran)) (Respondent/Cross Appellant) v Secretary of State for the Home Department (Appellant/Cross Respondent)</span><br /><span style="font-family:'Times New Roman';font-size:14pt">R (on the application of SAA (Sudan)) (Respondent) v Secretary of State for the Home Department (Appellant); and</span><br /><party refersTo="#r-on-the-application-of-asm-iraq" as="#appellant" style="font-family:'Times New Roman';font-size:14pt">R (on the application of ASM (Iraq))</party><span style="font-family:'Times New Roman';font-size:14pt"> (</span><role refersTo="#appellant" style="font-family:'Times New Roman';font-size:14pt">Appellant</role><span style="font-family:'Times New Roman';font-size:14pt">)</span><span style="font-family:'Times New Roman';font-size:14pt"> v </span><party refersTo="#secretary-of-state-for-the-home-department" as="#respondent" style="font-family:'Times New Roman';font-size:14pt">Secretary of State for the Home Department</party><span style="font-family:'Times New Roman';font-size:14pt"> (</span><role refersTo="#respondent" style="font-family:'Times New Roman';font-size:14pt">Respondent</role><span style="font-family:'Times New Roman';font-size:14pt">)</span></p>
       <p class="JudgmentJudges"><span style="font-weight:normal;font-family:'Times New Roman';font-size:14pt">before</span><br /><br /><judge refersTo="#judge-lord-reed-president" style="font-family:'Times New Roman';font-size:14pt">Lord Reed, President</judge><br /><judge refersTo="#judge-lord-hodge-deputy-president" style="font-family:'Times New Roman';font-size:14pt">Lord Hodge, Deputy President</judge><br /><judge refersTo="#judge-lord-lloyd-jones" style="font-family:'Times New Roman';font-size:14pt">Lord Lloyd-Jones</judge><br /><judge refersTo="#judge-lord-briggs" style="font-family:'Times New Roman';font-size:14pt">Lord Briggs</judge><br /><judge refersTo="#judge-lord-sales" style="font-family:'Times New Roman';font-size:14pt">Lord Sales</judge></p>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.23.6</VersionPrefix>
+    <VersionPrefix>0.23.7</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Crests in Supreme Court judgments are usually absolutely-positioned images within the same paragraph as the first line of text. This change moves them to a separate paragraph, for better positioning on the website.