### PR TITLE
CLP-11253 recognize header break in [2024] UKUT 127 (AAC)

### DIFF
--- a/TRE/TRE.csproj
+++ b/TRE/TRE.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.7" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.308.8" />
   </ItemGroup>
 
 </Project>

--- a/src/parsers/optimized/UKUT.cs
+++ b/src/parsers/optimized/UKUT.cs
@@ -51,7 +51,8 @@ class OptimizedUKUTParser : OptimizedParser {
         "APPROVED JUDGMENT",
 
         "REASONS",   // must go here b/c "Decision" might be the heading of the final section: [2022] UKFTT 282 (GRC)
-        "OPEN REASONS" // [2023] UKFTT 00412 (GRC)
+        "OPEN REASONS", // [2023] UKFTT 00412 (GRC)
+        "REASONS FOR DECISION" // [2024] UKUT 127 (AAC)
     };
 
     Regex[] titles2 = new Regex[] {

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.24.1</VersionPrefix>
+    <VersionPrefix>0.24.2</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fix adds the phrase "Reasons for Decision" to the list of recognized breaking points between a decision header and its body.