### PR TITLE
CLP-11215 fix for ewfc/b/2023/52

### DIFF
--- a/TRE/TRE.csproj
+++ b/TRE/TRE.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.308.9" />
   </ItemGroup>
 
 </Project>

--- a/src/model2/Metadata.cs
+++ b/src/model2/Metadata.cs
@@ -43,7 +43,7 @@ class WMetadata : IMetadata {
             if (courtType2?.Code is not null)
                 _court = Courts.ByCode[courtType2.Code];
         }
-        if (_court?.Code == Courts.EWFC.Code && Courts.EWFC_B.CitationPattern.IsMatch(Cite))
+        if (_court?.Code == Courts.EWFC.Code && Cite is not null && Courts.EWFC_B.CitationPattern.IsMatch(Cite))
             _court = Courts.EWFC_B;
         if (_court is null && Cite is not null)
             _court = Courts.ExtractFromCitation(Cite);

--- a/src/parsers/optimized/EWHC.cs
+++ b/src/parsers/optimized/EWHC.cs
@@ -173,7 +173,11 @@ class OptimizedEWHCParser : OptimizedParser {
 
     /* enrich */
 
-    private List<Enricher> headerEnrichers = new List<Enricher>() {
+    override protected IEnumerable<IBlock> EnrichCoverPage(IEnumerable<IBlock> coverPage) {
+        return new NetrualCitation().Enrich(coverPage);
+    }
+
+    private readonly List<Enricher> headerEnrichers = [
         new RestrictionsEnricher(),
         new NetrualCitation(),
         new CaseNo(),
@@ -182,7 +186,7 @@ class OptimizedEWHCParser : OptimizedParser {
         new PartyEnricher(),
         new Judge(),
         new LawyerEnricher()
-    };
+    ];
 
     protected override IEnumerable<IBlock> EnrichHeader(IEnumerable<IBlock> header) {
         return Enricher.Enrich(header, headerEnrichers);

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.24.2</VersionPrefix>
+    <VersionPrefix>0.24.3</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fixes a bug, which occurred when trying to determine whether the court should be EWFC-B and the NCN had not been recognized.

Also, we now look for NCNs in the Word header of more documents.