### PR TITLE
CLP-11480 improved dimensions of rotated images

### DIFF
--- a/test/judgments/test64.xml
+++ b/test/judgments/test64.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/pat/2023/1495/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/pat/2023/1495/data.xml" />
-          <FRBRdate date="2024-05-27T19:36:01" name="transform" />
+          <FRBRdate date="2024-06-13T20:07:53" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -47,7 +47,7 @@
         <uk:year>2023</uk:year>
         <uk:number>1495</uk:number>
         <uk:cite>[2023] EWHC 1495 (Pat)</uk:cite>
-        <uk:parser>0.24.0</uk:parser>
+        <uk:parser>0.24.5</uk:parser>
         <uk:hash>f5a256994f9d5137dc3cf3f27441337c260612a54cc6ddcf9a6fa3e5c715c1d6</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -1075,7 +1075,7 @@
           </intro>
           <subparagraph>
             <content>
-              <p class="BodyText" style="margin-left:0.39in"><img src="image3.emf.change1.png" style="width:298.72pt;height:451.7pt" /></p>
+              <p class="BodyText" style="margin-left:0.39in"><img src="image3.emf.change1.png" style="width:451.7pt;height:298.72pt" /></p>
             </content>
           </subparagraph>
         </paragraph>
@@ -1098,7 +1098,7 @@
           </intro>
           <subparagraph>
             <content>
-              <p class="BodyText" style="margin-left:0.39in"><img src="image4.emf.change1.png" style="width:281.2pt;height:397.7pt" /></p>
+              <p class="BodyText" style="margin-left:0.39in"><img src="image4.emf.change1.png" style="width:397.7pt;height:281.2pt" /></p>
             </content>
           </subparagraph>
         </paragraph>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.24.4</VersionPrefix>
+    <VersionPrefix>0.24.5</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fix swaps the width and height sizes for images that are rotated 90 degrees. It's needed for [2024] EWHC 1441 (Ch).
