### PR TITLE
CLP-11783 fix for mutated images within tables

### DIFF
--- a/test/judgments/test20.xml
+++ b/test/judgments/test20.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/ipec/2022/941/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/ipec/2022/941/data.xml" />
-          <FRBRdate date="2024-05-27T19:34:32" name="transform" />
+          <FRBRdate date="2024-06-28T16:57:48" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -47,7 +47,7 @@
         <uk:year>2022</uk:year>
         <uk:number>941</uk:number>
         <uk:cite>[2022] EWHC 941 (IPEC)</uk:cite>
-        <uk:parser>0.24.0</uk:parser>
+        <uk:parser>0.25.2</uk:parser>
         <uk:hash>dac04b11c8c1a0d8ace73b7d428599aefc8f8c7e4eccd5b3ea1dfd90f9c9974e</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -228,7 +228,7 @@
               </tr>
               <tr>
                 <td style="border:0.5pt solid #000000;background-color:initial">
-                  <p class="TE11pt"><img src="image2.png" style="width:67.56pt;height:23.53pt" /></p>
+                  <p class="TE11pt"><img src="image2.change1.png" style="width:67.56pt;height:23.53pt" /></p>
                 </td>
                 <td style="border:0.5pt solid #000000;background-color:initial">
                   <p class="TE11pt"><span style="font-family:'Times New Roman'">3 March 2015 </span></p>
@@ -999,7 +999,7 @@
                   <p><span style="font-family:'Times New Roman'">13</span></p>
                 </td>
                 <td style="border:0.5pt solid #000000;background-color:initial;vertical-align:middle">
-                  <p style="text-align:center"><img src="image22.png" style="width:124.26pt;height:55.89pt" /></p>
+                  <p style="text-align:center"><img src="image22.change1.png" style="width:124.26pt;height:55.89pt" /></p>
                 </td>
               </tr>
               <tr>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.25.1</VersionPrefix>
+    <VersionPrefix>0.25.2</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This change is needed to fix the bug affecting [2024] EWHC 1664 (Pat). See CLP-11783.

The problem had to do with the "src" attribute on the <img> elements, which were not being changed to reflected the changed names of mutated images. It was caused by the fact that table cell contents were parsed lazily.