### PR TITLE
CLP-12007 annex in the middle

### DIFF
--- a/src/parsers/optimized/OptimzedParser.cs
+++ b/src/parsers/optimized/OptimzedParser.cs
@@ -49,6 +49,14 @@ abstract class OptimizedParser {
         if (conclusions is null)
             i = save;
         IEnumerable<IAnnex> annexes = Annexes();
+        if (i != PreParsed.Body.Count && !conclusions.Any() && annexes.Any()) {
+            var converted = annexes.Select(a => new GroupOfUnnumberedParagraphs(a.Number, a.Contents)).ToList();
+            Decision decision = new() { Contents = converted };
+            body.Add(decision);
+            annexes = [];
+            List<IDecision> rest = Decisions();
+            body.AddRange(rest);
+        }
         if (i != PreParsed.Body.Count) {
             logger.LogDebug("parsing did not complete: " + i);
             throw new Exception();

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.25.3</VersionPrefix>
+    <VersionPrefix>0.25.4</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fix does a better job with documents containing an annex _in the middle_, that is, after one judge's opinion and before another's. See, e.g., [2024] UKSC 24