### PR TITLE
CLP-12110 no numbering

### DIFF
--- a/src/docx/Numbering.cs
+++ b/src/docx/Numbering.cs
@@ -11,7 +11,7 @@ namespace UK.Gov.Legislation.Judgments.DOCX {
 class Numbering {
 
     public static NumberingInstance GetNumbering(MainDocumentPart main, int id) {
-        return main.NumberingDefinitionsPart.Numbering.ChildElements
+        return main.NumberingDefinitionsPart?.Numbering.ChildElements
             .OfType<NumberingInstance>()
             .Where(n => n.NumberID.Equals(id))
             .FirstOrDefault();

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.25.5</VersionPrefix>
+    <VersionPrefix>0.25.6</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Some documents have no numbering part in the .docx bundle