### PR TITLE
FCL-256 allow URI-NCN mismatch

### DIFF
--- a/TRE/Inputs.cs
+++ b/TRE/Inputs.cs
@@ -186,8 +186,8 @@ namespace UK.Gov.NationalArchives.CaseLaw.TRE
 
             if (uri is not null && cite is not null && !uri.StartsWith(Citations.MakeUriComponent(cite))) // handles press-summary URIs
             {
-                logger.LogCritical("cite and URI do not match");
-                throw new Exception("cite and URI do not match");
+                logger.LogWarning("cite and URI do not match");
+                // throw new Exception("cite and URI do not match");
             }
 
             if (court is not null && !Courts.ByCode.ContainsKey(court))

--- a/test/TRE/TestInputInjection.cs
+++ b/test/TRE/TestInputInjection.cs
@@ -127,6 +127,22 @@ namespace UK.Gov.NationalArchives.CaseLaw.TRE.Test
             return Api.Parser.Parse(apiRequest);
         }
 
+        [Fact]
+        public void TestConflictingURIandCite()
+        {
+            string uri = "uksc/1900/1";
+            string cite = "[1900] UKPC 2";
+            string expected = Api.URI.Domain + "id/" + uri;
+            ParserInputs inputs = new()
+            {
+                DocumentType = ParserInputs.JudgmentDocumentType,
+                Metadata = new InputMetadata() { URI = uri, Cite = cite }
+            };
+            Api.Response response = LambdaTest(Docx1, inputs);
+            Assert.Equal(expected, response.Meta.Uri);
+            Assert.Equal(cite, response.Meta.Cite);
+        }
+
     }
 
 }

--- a/test/TRE/TestInputValidation.cs
+++ b/test/TRE/TestInputValidation.cs
@@ -93,6 +93,20 @@ namespace UK.Gov.NationalArchives.CaseLaw.TRE.Test
             Assert.Throws<Exception>(() => { InputHelper.GetMetadata(inputs, Logger); });
         }
 
+        [Fact]
+        public void TestConflictingURIandCite()
+        {
+            string uri = "uksc/1900/1";
+            string cite = "[1900] UKPC 2";
+            ParserInputs inputs = new()
+            {
+                DocumentType = ParserInputs.JudgmentDocumentType,
+                Metadata = new InputMetadata() { URI = uri, Cite = cite }
+            };
+            var exception = Record.Exception(() => { InputHelper.GetMetadata(inputs, Logger); });
+            Assert.Null(exception);
+        }
+
     }
 
 }


### PR DESCRIPTION
No longer throw an exception if the URI and NCN given as inputs don't match