### PR TITLE
ignore NCN in draft rubric (FCL-333)

### DIFF
--- a/src/parsers/coa/NeutralCitation.cs
+++ b/src/parsers/coa/NeutralCitation.cs
@@ -96,6 +96,12 @@ class NetrualCitation : Enricher2 {
         return Enumerable.Concat(two.Prepend(one), three);
     }
 
+    override protected WLine Enrich(WLine line) {
+        if (line.NormalizedContent.Contains("the draft judgment is only to be used to"))
+            return line;
+        return base.Enrich(line);
+    }
+
     protected override IEnumerable<IInline> Enrich(IEnumerable<IInline> line) {
         if (line.Any()) {
             IInline first = line.First();

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.6</VersionPrefix>
+    <VersionPrefix>0.26.7</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fix ignores the NCN in language such as

> As explained in Counsel General v. BEIS (No. 2) [2022] EWCA Civ 181, the draft judgment is only to be used to enable the parties to make suggestions for the correction of errors, prepare submissions on consequential matters and draft orders and to prepare themselves for the publication of the judgment. A breach of any of these obligations may be treated as a contempt of court.