### PR TITLE
fix inheritance of first line indent (CLP-13577)

### DIFF
--- a/src/docx/Paragraphs.cs
+++ b/src/docx/Paragraphs.cs
@@ -121,6 +121,11 @@ static class Paragraphs {
             return "-" + indentation.Hanging.Value;
         if (indentation?.FirstLine is not null)
             return indentation.FirstLine.Value;
+
+        if (indentation?.Left is not null)  // eat/2024/162
+            return null;
+        // if this doesn't quite work, consider checking for presence of Hanging or FirstLine in style
+
         Style style = Styles.GetStyle(main, pProps);
         indentation = style?.GetInheritedProperty(s => s.StyleParagraphProperties?.Indentation);
         if (indentation?.Hanging is not null)

--- a/test/judgments/test32.xml
+++ b/test/judgments/test32.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewca/civ/2022/840/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewca/civ/2022/840/data.xml" />
-          <FRBRdate date="2024-10-04T18:15:40" name="transform" />
+          <FRBRdate date="2024-10-23T19:32:00" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -50,7 +50,7 @@
         <uk:year>2022</uk:year>
         <uk:number>840</uk:number>
         <uk:cite>[2022] EWCA Civ 840</uk:cite>
-        <uk:parser>0.26.6</uk:parser>
+        <uk:parser>0.26.9</uk:parser>
         <uk:hash>0bc8db175ea1908ea1e36bca130bdb75094a0332cfea49214c8f54fb10a4ac9c</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -243,71 +243,71 @@
           <subparagraph>
             <num>"5.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">This claim has been heralded as a challenge to the Home Secretary's general decision of removal to asylum claimants to Rwanda.  This is a notion that needs to be handled with care.  </span></p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in"><span style="font-family:TimesNewRomanPSMT">This claim has been heralded as a challenge to the Home Secretary's general decision of removal to asylum claimants to Rwanda.  This is a notion that needs to be handled with care.  </span></p>
             </content>
           </subparagraph>
           <subparagraph>
             <num style="font-family:TimesNewRomanPSMT">6.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">There are some documents that are of general effect.  There is a Memorandum of Understanding ("MOU") made between the United Kingdom and the Republic of Rwanda.  That agreement was made on 13 April 2022 and published on 14 April 2022.  The document records arrangements made for the transfer of persons, and responsibilities accepted by the United Kingdom and the Republic of Rwanda, respectively.  The MOU also sets out the arrangements for a Monitoring Committee which will monitor implementation of and compliance with the arrangements, and report.  The MOU is supplemented by two Notes Verbales: one addressing the asylum process in Rwanda; the other concerning the practical support to be provided to persons awaiting decisions on asylum claims, and to be provided to them after those decisions have been taken (both if the claim is accepted, and if it is refused). </span></p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in"><span style="font-family:TimesNewRomanPSMT">There are some documents that are of general effect.  There is a Memorandum of Understanding ("MOU") made between the United Kingdom and the Republic of Rwanda.  That agreement was made on 13 April 2022 and published on 14 April 2022.  The document records arrangements made for the transfer of persons, and responsibilities accepted by the United Kingdom and the Republic of Rwanda, respectively.  The MOU also sets out the arrangements for a Monitoring Committee which will monitor implementation of and compliance with the arrangements, and report.  The MOU is supplemented by two Notes Verbales: one addressing the asylum process in Rwanda; the other concerning the practical support to be provided to persons awaiting decisions on asylum claims, and to be provided to them after those decisions have been taken (both if the claim is accepted, and if it is refused). </span></p>
             </content>
           </subparagraph>
           <subparagraph>
             <num style="font-family:TimesNewRomanPSMT">7.</num>
             <intro>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The Home Secretary has also published several generic documents.  There are five in total; all were published in May 2022.  The first is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of Asylum Processing.  Rwanda: assessment</span><span style="font-family:TimesNewRomanPSMT">".  The preface explains the document as follows: </span></p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in"><span style="font-family:TimesNewRomanPSMT">The Home Secretary has also published several generic documents.  There are five in total; all were published in May 2022.  The first is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of Asylum Processing.  Rwanda: assessment</span><span style="font-family:TimesNewRomanPSMT">".  The preface explains the document as follows: </span></p>
             </intro>
             <subparagraph>
               <content>
                 <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">'This note provides an assessment of Rwanda's asylum system, support provisions, integration opportunities as well as some of the general, related human rights issues, for use by Home Office decision makers handling particular types of protection and human rights claims.' </span></p>
               </content>
             </subparagraph>
+          </subparagraph>
+          <subparagraph>
+            <intro>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The preface goes on to say:</span></p>
+            </intro>
             <subparagraph>
-              <intro>
-                <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The preface goes on to say:</span></p>
-              </intro>
-              <subparagraph>
-                <content>
-                  <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">'[This document] must be read in conjunction with the separate country information reports: </span></p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <content>
-                  <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: county information on the asylum system:</span></p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <content>
-                  <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: country information on general human rights in Rwanda; </span></p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <content>
-                  <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: notes of interviews'</span></p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <content>
-                  <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">Decision makers </span><span style="font-weight:bold;font-family:TimesNewRomanPS-BoldMT">must</span><span style="font-family:TimesNewRomanPSMT">, however, still consider all claims on an individual basis, taking into account each case's full facts.'</span></p>
-                </content>
-              </subparagraph>
+              <content>
+                <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">'[This document] must be read in conjunction with the separate country information reports: </span></p>
+              </content>
             </subparagraph>
             <subparagraph>
               <content>
-                <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The point to note is that this document is the Home Secretary's own assessment of the asylum system and related matters in Rwanda. </span></p>
+                <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: county information on the asylum system:</span></p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <content>
+                <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: country information on general human rights in Rwanda; </span></p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <content>
+                <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:SymbolMT">• </span><span style="font-family:TimesNewRomanPSMT">Review of asylum processing Rwanda: notes of interviews'</span></p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <content>
+                <p class="ParaLevel1" style="margin-left:1.5in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">Decision makers </span><span style="font-weight:bold;font-family:TimesNewRomanPS-BoldMT">must</span><span style="font-family:TimesNewRomanPSMT">, however, still consider all claims on an individual basis, taking into account each case's full facts.'</span></p>
               </content>
             </subparagraph>
           </subparagraph>
           <subparagraph>
+            <content>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The point to note is that this document is the Home Secretary's own assessment of the asylum system and related matters in Rwanda. </span></p>
+            </content>
+          </subparagraph>
+          <subparagraph>
             <num style="font-family:TimesNewRomanPSMT">8.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">The second document is "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of Asylum Processing.  Rwanda: country information on the asylum system</span><span style="font-family:TimesNewRomanPSMT">".  This document contains information from a range of sources.  It is described as providing objective country information about Rwanda's asylum system, support provisions and integration opportunities.  It is stated that the document should not be read as an exhaustive survey of any subject or theme.  The preface to the document also makes the same point made in the first document; that decision makers must consider all the circumstances of each individual case.  The third document is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Inadmissibility: safe third country cases</span><span style="font-family:TimesNewRomanPSMT">".  It provides guidance for the purposes of decisions under paragraphs 345 A - D of the Rules.  The fourth document is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of asylum processing.  Rwanda: country information on general human rights</span><span style="font-family:TimesNewRomanPSMT">".  The fifth is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of asylum processing.  Rwanda: interview notes (Annex A)</span><span style="font-family:TimesNewRomanPSMT">".  This document contains information gathered during visits to Rwanda in January and March 2022.</span></p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in"><span style="font-family:TimesNewRomanPSMT">The second document is "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of Asylum Processing.  Rwanda: country information on the asylum system</span><span style="font-family:TimesNewRomanPSMT">".  This document contains information from a range of sources.  It is described as providing objective country information about Rwanda's asylum system, support provisions and integration opportunities.  It is stated that the document should not be read as an exhaustive survey of any subject or theme.  The preface to the document also makes the same point made in the first document; that decision makers must consider all the circumstances of each individual case.  The third document is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Inadmissibility: safe third country cases</span><span style="font-family:TimesNewRomanPSMT">".  It provides guidance for the purposes of decisions under paragraphs 345 A - D of the Rules.  The fourth document is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of asylum processing.  Rwanda: country information on general human rights</span><span style="font-family:TimesNewRomanPSMT">".  The fifth is titled "</span><span style="font-style:italic;font-family:TimesNewRomanPS-ItalicMT">Review of asylum processing.  Rwanda: interview notes (Annex A)</span><span style="font-family:TimesNewRomanPSMT">".  This document contains information gathered during visits to Rwanda in January and March 2022.</span></p>
             </content>
           </subparagraph>
           <subparagraph>
             <num style="font-family:TimesNewRomanPSMT">9.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in"><span style="font-family:TimesNewRomanPSMT">However, these general documents notwithstanding, the position of each of the individual Claimants in this case has been the subject of a discrete decision taken under the 2004 Act and under the Rules.  These individual decisions are the operative matters.  The challenge in these proceedings, regardless of how it is formulated, must be targeted to the legality of those specific decisions.  There is no single, generic decision that can be the target of an application for judicial review.  As this is a matter of importance I will explain the point in a little more detail."</span></p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in"><span style="font-family:TimesNewRomanPSMT">However, these general documents notwithstanding, the position of each of the individual Claimants in this case has been the subject of a discrete decision taken under the 2004 Act and under the Rules.  These individual decisions are the operative matters.  The challenge in these proceedings, regardless of how it is formulated, must be targeted to the legality of those specific decisions.  There is no single, generic decision that can be the target of an application for judicial review.  As this is a matter of importance I will explain the point in a little more detail."</span></p>
             </content>
           </subparagraph>
           <subparagraph>
@@ -324,25 +324,25 @@
           <subparagraph>
             <num>"10.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in">Section 33 of the 2004 Act gives effect to Schedule 3 to the Act.  Schedule 3 contains provisions about the removal of persons claiming asylum to 'countries known to protect refugees and respect human rights'.  Absent Schedule 3, the operative provision is section 77 of the Nationality, Immigration and Asylum Act 2002 ("the 2002 Act").  That prevents the removal from the United Kingdom of a person who has an asylum claim pending.  Schedule 3 to the 2004 Act contains four distinct schemes that provide exceptions to the default provision in section 77 of the 2002 Act.  Persons who have made asylum claims that have yet to be determined may be removed under any of these exceptions.  The premise of these exceptions is that the person concerned will then be able to pursue an asylum claim in the country to which he has been removed.</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in">Section 33 of the 2004 Act gives effect to Schedule 3 to the Act.  Schedule 3 contains provisions about the removal of persons claiming asylum to 'countries known to protect refugees and respect human rights'.  Absent Schedule 3, the operative provision is section 77 of the Nationality, Immigration and Asylum Act 2002 ("the 2002 Act").  That prevents the removal from the United Kingdom of a person who has an asylum claim pending.  Schedule 3 to the 2004 Act contains four distinct schemes that provide exceptions to the default provision in section 77 of the 2002 Act.  Persons who have made asylum claims that have yet to be determined may be removed under any of these exceptions.  The premise of these exceptions is that the person concerned will then be able to pursue an asylum claim in the country to which he has been removed.</p>
             </content>
           </subparagraph>
           <subparagraph>
             <num>11.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in">Part Two of Schedule 3 to the 2004 Act prescribes a list of countries (all EU or EEA states) and provides that each is to be treated as a country in which a person would not be at risk of ill-treatment on any Refugee Convention ground; would not be sent to another country in breach of the Refugee Convention; and would not be sent to another country in breach of ECHR rights.  Asylum claimants can be removed to such countries so long the Secretary of State certifies the person concerned is not a national of the country concerned.  Part Two is not an issue in these proceedings; Rwanda is not on the list of states.  Parts Three and Four of Schedule 3 permit the Secretary of State to make orders specifying states.  If an order is made, the state concerned is to be treated as being one in which a person would not be a risk of ill-treatment on any Refugee Convention ground; and would not be sent to another country in breach of the Refugee Convention.  Neither Part 3 nor Part 4 is material for present purposes; no such order has been made in respect of Rwanda.</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in">Part Two of Schedule 3 to the 2004 Act prescribes a list of countries (all EU or EEA states) and provides that each is to be treated as a country in which a person would not be at risk of ill-treatment on any Refugee Convention ground; would not be sent to another country in breach of the Refugee Convention; and would not be sent to another country in breach of ECHR rights.  Asylum claimants can be removed to such countries so long the Secretary of State certifies the person concerned is not a national of the country concerned.  Part Two is not an issue in these proceedings; Rwanda is not on the list of states.  Parts Three and Four of Schedule 3 permit the Secretary of State to make orders specifying states.  If an order is made, the state concerned is to be treated as being one in which a person would not be a risk of ill-treatment on any Refugee Convention ground; and would not be sent to another country in breach of the Refugee Convention.  Neither Part 3 nor Part 4 is material for present purposes; no such order has been made in respect of Rwanda.</p>
             </content>
           </subparagraph>
           <subparagraph>
             <num>12.</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in">Part 5 of Schedule 3 is material.  By paragraph 17, the Secretary of State has the power to certify that she proposes to remove a person to a specified state; that the person is not a national of that state; and that it is her opinion that the specified state is a place where the person would not be at risk of ill-treatment on any Refugee Convention ground or be sent to any other country in breach of the Convention.  If the Secretary of State has so certified, paragraph 18 of Schedule 3 disapplies section 77 of the 2002 Act so that the person concerned may be removed from the United Kingdom notwithstanding an extant asylum claim.  The paragraph 17 power is the power that has been exercised in respect of each of the individual Claimants and is the power that is the legal premise for the Secretary of State's policy to remove certain asylum seekers from the United Kingdom to Rwanda.</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in">Part 5 of Schedule 3 is material.  By paragraph 17, the Secretary of State has the power to certify that she proposes to remove a person to a specified state; that the person is not a national of that state; and that it is her opinion that the specified state is a place where the person would not be at risk of ill-treatment on any Refugee Convention ground or be sent to any other country in breach of the Convention.  If the Secretary of State has so certified, paragraph 18 of Schedule 3 disapplies section 77 of the 2002 Act so that the person concerned may be removed from the United Kingdom notwithstanding an extant asylum claim.  The paragraph 17 power is the power that has been exercised in respect of each of the individual Claimants and is the power that is the legal premise for the Secretary of State's policy to remove certain asylum seekers from the United Kingdom to Rwanda.</p>
             </content>
           </subparagraph>
           <subparagraph>
             <num>13.</num>
             <intro>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in">The statutory provisions in the 2004 Act are supplemented by paragraphs 345 A - D of the Rules.  These rules permit the Secretary of State to treat a claim for asylum as 'inadmissible" and not to decide the claim if the asylum claimant has already been recognised as a refugee in a third "safe country", or the claimant "otherwise" enjoys sufficient protection in a safe third country, or:</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:1.02in;text-indent:0.02in">The statutory provisions in the 2004 Act are supplemented by paragraphs 345 A - D of the Rules.  These rules permit the Secretary of State to treat a claim for asylum as 'inadmissible" and not to decide the claim if the asylum claimant has already been recognised as a refugee in a third "safe country", or the claimant "otherwise" enjoys sufficient protection in a safe third country, or:</p>
             </intro>
             <subparagraph>
               <content>
@@ -367,54 +367,54 @@
                 <p style="margin-left:1.89in;margin-right:0.89in">they have a connection to that country, such that it would be reasonable for them to go there to obtain protection.' </p>
               </content>
             </subparagraph>
+          </subparagraph>
+          <subparagraph>
+            <intro>
+              <p style="margin-left:0.39in;margin-right:0.04in;text-indent:0.39in">'Safe third country' is defined at paragraph 345B:</p>
+            </intro>
+            <subparagraph>
+              <content>
+                <p style="margin-left:1.58in">'A country is a safe third country for a particular applicant, if:</p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <num style="margin-left:1.58in">(i)</num>
+              <content>
+                <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.38in">the applicant's life and liberty will not be threatened on account of race, religion, nationality, membership of a particular social group, or political opinion in that country;</p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <num style="margin-left:1.58in">(ii)</num>
+              <content>
+                <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.5in">the principle of non-refoulement will be respected in that country in accordance with the Refugee Convention:</p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <num style="margin-left:1.58in">(iii)</num>
+              <content>
+                <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.62in">the prohibition of removal, in violation of the right to freedom from torture and cruel, inhumane, or degrading treatment as laid down in international law, is respected in that country; and</p>
+              </content>
+            </subparagraph>
+            <subparagraph>
+              <num>(iv)</num>
+              <content>
+                <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.08in">the possibility exists to request refugee status and, if found to be a refugee, to receive protection in accordance with the Refugee Convention in that country."</p>
+              </content>
+            </subparagraph>
             <subparagraph>
               <intro>
-                <p style="margin-left:0.39in;margin-right:0.04in;text-indent:0.39in">'Safe third country' is defined at paragraph 345B:</p>
+                <p style="margin-left:0.98in;margin-right:0.95in;text-indent:0in">Paragraph 345C states the consequences of a decision that a claim is inadmissible.</p>
               </intro>
               <subparagraph>
                 <content>
-                  <p style="margin-left:1.58in">'A country is a safe third country for a particular applicant, if:</p>
+                  <p style="margin-left:1.5in;margin-right:1.02in;text-indent:0in">'When an application is treated as inadmissible, the Secretary of State will attempt to remove the applicant to the safe third country in which they were previously present, or to which they have a connection, or to any other safe third country which may agree to their entry.'</p>
                 </content>
               </subparagraph>
-              <subparagraph>
-                <num style="margin-left:1.58in">(i)</num>
-                <content>
-                  <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.38in">the applicant's life and liberty will not be threatened on account of race, religion, nationality, membership of a particular social group, or political opinion in that country;</p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <num style="margin-left:1.58in">(ii)</num>
-                <content>
-                  <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.5in">the principle of non-refoulement will be respected in that country in accordance with the Refugee Convention:</p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <num style="margin-left:1.58in">(iii)</num>
-                <content>
-                  <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.62in">the prohibition of removal, in violation of the right to freedom from torture and cruel, inhumane, or degrading treatment as laid down in international law, is respected in that country; and</p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <num>(iv)</num>
-                <content>
-                  <p style="margin-left:1.58in;margin-right:0.89in;text-indent:0.08in">the possibility exists to request refugee status and, if found to be a refugee, to receive protection in accordance with the Refugee Convention in that country."</p>
-                </content>
-              </subparagraph>
-              <subparagraph>
-                <intro>
-                  <p style="margin-left:0.98in;margin-right:0.95in;text-indent:0in">Paragraph 345C states the consequences of a decision that a claim is inadmissible.</p>
-                </intro>
-                <subparagraph>
-                  <content>
-                    <p style="margin-left:1.5in;margin-right:1.02in;text-indent:0in">'When an application is treated as inadmissible, the Secretary of State will attempt to remove the applicant to the safe third country in which they were previously present, or to which they have a connection, or to any other safe third country which may agree to their entry.'</p>
-                  </content>
-                </subparagraph>
-              </subparagraph>
-              <subparagraph>
-                <content>
-                  <p style="margin-left:0.98in;margin-right:0.95in;text-indent:0in">So far as concerns the Rules, the premises for the operation of the Secretary of State's policy on removal to Rwanda are: <span style="font-style:italic">first </span>that the person falls within one or other of the categories specified at paragraph 345A (most likely 345A(iii)(b)); and <span style="font-style:italic">second </span>that that being so, Rwanda is, for the purposes of paragraph 345C, a safe country that agrees to the person's entry.'"</p>
-                </content>
-              </subparagraph>
+            </subparagraph>
+            <subparagraph>
+              <content>
+                <p style="margin-left:0.98in;margin-right:0.95in;text-indent:0in">So far as concerns the Rules, the premises for the operation of the Secretary of State's policy on removal to Rwanda are: <span style="font-style:italic">first </span>that the person falls within one or other of the categories specified at paragraph 345A (most likely 345A(iii)(b)); and <span style="font-style:italic">second </span>that that being so, Rwanda is, for the purposes of paragraph 345C, a safe country that agrees to the person's entry.'"</p>
+              </content>
             </subparagraph>
           </subparagraph>
         </paragraph>
@@ -962,13 +962,13 @@
           <subparagraph>
             <num>"(1)</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:0.95in">The High Court may by order (whether interlocutory or final) grant an injunction … in all cases in which it appears to the court to be just and convenient to do so.</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:0.95in;text-indent:0.02in">The High Court may by order (whether interlocutory or final) grant an injunction … in all cases in which it appears to the court to be just and convenient to do so.</p>
             </content>
           </subparagraph>
           <subparagraph>
             <num>(2)</num>
             <content>
-              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:0.95in">Any such order may be made either unconditionally or on such terms and conditions as the court thinks just."</p>
+              <p class="ParaLevel1" style="margin-left:0.98in;margin-right:0.95in;text-indent:0.02in">Any such order may be made either unconditionally or on such terms and conditions as the court thinks just."</p>
             </content>
           </subparagraph>
         </paragraph>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.8</VersionPrefix>
+    <VersionPrefix>0.26.9</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
If a paragraph style sets the first line indent, and an individual paragraph has its own value for left margin (but is silent about the first line), then that paragraph does _not_ inherit the first line value of its style.

See, for example, [2024] EAT 162