### PR TITLE
ignore off-the-page images (CLP-13677 and CLP-13699)

### DIFF
--- a/src/model2/Images.cs
+++ b/src/model2/Images.cs
@@ -279,6 +279,13 @@ public class WImageRef : IImageRef {
                 float inches = DOCX.CSS.ConvertToInches(raw);
                 if (inches > 8.5f)
                     return true;
+                if (inches < 0 && styles.ContainsKey("width")) {
+                    float width = DOCX.CSS.ConvertToInches(styles["width"]);
+                    if (width < Math.Abs(inches)) // [2021] UKUT 82 (TCC)
+                        return true;
+                if (inches < -8.5f) // [2021] UKUT 151 (TCC)
+                    return true;
+                }
             } catch {
                 logger.LogWarning("can't convert to inches: {}", raw);
             }

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.9</VersionPrefix>
+    <VersionPrefix>0.26.10</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This fix ignores images that are positioned off the page, in [2021] UKUT 82 (TCC) and [2021] UKUT 151 (TCC)