### PR TITLE
Press summaries for cases beginning with 'Re'

### DIFF
--- a/src/parsers/optimized/ps/Enricher.cs
+++ b/src/parsers/optimized/ps/Enricher.cs
@@ -73,8 +73,8 @@ partial class Enricher {
             return true;
         if (line.NormalizedContent.Contains(@"In the matter of ", StringComparison.InvariantCultureIgnoreCase))
             return true;
-        // if (line.NormalizedContent.Contains(@"R (on the application of ", StringComparison.InvariantCultureIgnoreCase))
-        //     return true;
+        if (line.NormalizedContent.StartsWith(@"Re "))
+            return true;
         if (line.NormalizedContent.Contains("(Appellant") && line.NormalizedContent.Contains("(Respondent"))
             return true;
         if (line.NormalizedContent.Contains("(Applicant") && line.NormalizedContent.Contains("(Intervener"))

--- a/src/parsers/optimized/ps/Header.cs
+++ b/src/parsers/optimized/ps/Header.cs
@@ -180,7 +180,7 @@ class Header {
             return;
         }
         if (NextLineIsCiteOnly()) {
-            // if the next line is the NCN, we'll assume this line is the case name,
+            // if the next line is the NCN, we'll assume the current line is the case name,
             // but only if the case name has not already been found
             if (CaseNameHasBeenFound()) {
                 Enriched.Add(line);

--- a/src/parsers/optimized/ps/Header.cs
+++ b/src/parsers/optimized/ps/Header.cs
@@ -180,8 +180,12 @@ class Header {
             return;
         }
         if (NextLineIsCiteOnly()) {
-            WLine title = WDocTitle2.ConvertContents(line);
-            Enriched.Add(title);
+            if (TitleHasBeenFound()) {
+                Enriched.Add(line);
+            } else {
+                WLine title = WDocTitle2.ConvertContents(line);
+                Enriched.Add(title);
+            }
             return;
         }
         Enriched.Add(line);
@@ -196,6 +200,13 @@ class Header {
         if (nextBlock is not WLine line)
             return false;
         return Enricher.IsCiteOnly(line);
+    }
+
+    private bool TitleHasBeenFound() {
+        return Enriched.Where(block => block is WLine)
+            .Cast<WLine>()
+            .Where(line => line.Contents.Where(inline => inline is WDocTitle || inline is WDocTitle2).Any())
+            .Any();
     }
 
     private void AfterCiteBeforeOnAppealFrom(IBlock block) {

--- a/src/parsers/optimized/ps/Header.cs
+++ b/src/parsers/optimized/ps/Header.cs
@@ -180,7 +180,9 @@ class Header {
             return;
         }
         if (NextLineIsCiteOnly()) {
-            if (TitleHasBeenFound()) {
+            // if the next line is the NCN, we'll assume this line is the case name,
+            // but only if the case name has not already been found
+            if (CaseNameHasBeenFound()) {
                 Enriched.Add(line);
             } else {
                 WLine title = WDocTitle2.ConvertContents(line);
@@ -202,7 +204,7 @@ class Header {
         return Enricher.IsCiteOnly(line);
     }
 
-    private bool TitleHasBeenFound() {
+    private bool CaseNameHasBeenFound() {
         return Enriched.Where(block => block is WLine)
             .Cast<WLine>()
             .Where(line => line.Contents.Where(inline => inline is WDocTitle || inline is WDocTitle2).Any())

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.19</VersionPrefix>
+    <VersionPrefix>0.26.20</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The fix improves the parsing of press summaries, specifically, for those whose case names begin with "Re" (and don't contain normal party names). For example: Re Chief Justice of Gibraltar, [2009] UKPC 43

See [Jira FDD-23](https://national-archives.atlassian.net/browse/FDD-23)