### PR TITLE
Move 'unknownImport' class to lawmaker package

### DIFF
--- a/src/akn/Builder.cs
+++ b/src/akn/Builder.cs
@@ -375,19 +375,10 @@ abstract class Builder {
             AddInline(block, inline);
         ContainingParagraphStyle = null;
     }
-    protected void p(XmlElement parent, ILine line) {
+    virtual protected void p(XmlElement parent, ILine line) {
         if (line is IRestriction restriction)
             AddNamedBlock(parent, line, "restriction");
-        else if (line is IUnknownLine) {
-            // Putting this here for now, this should eventually be moved to a method IUnknownLine.Add(parent)
-            // but for now we need access to the AddInline method
-            XmlElement p = parent.OwnerDocument.CreateElement("p", parent.NamespaceURI);
-            p.SetAttribute("class", parent.NamespaceURI, "unknownImport");
-            foreach(IInline inline in line.Contents) {
-                AddInline(p, inline);
-            }
-            parent.AppendChild(p);
-        } else
+        else
             Block(parent, line, "p");
     }
 

--- a/src/lawmaker/akn/Builder.cs
+++ b/src/lawmaker/akn/Builder.cs
@@ -206,6 +206,20 @@ namespace UK.Gov.Legislation.Lawmaker
             }
         }
 
+        override protected void p(XmlElement parent, ILine line) {
+        if (line is IUnknownLine) {
+            // Putting this here for now, this should eventually be moved to a method IUnknownLine.Add(parent)
+            // but for now we need access to the AddInline method
+            XmlElement p = parent.OwnerDocument.CreateElement("p", parent.NamespaceURI);
+            p.SetAttribute("class", parent.NamespaceURI, "unknownImport");
+            foreach(IInline inline in line.Contents) {
+                AddInline(p, inline);
+            }
+            parent.AppendChild(p);
+        } else
+            base.p(parent, line);
+        }
+
         private int quoteDepth = 0;
 
         protected override void AddQuotedStructure(XmlElement parent, IQuotedStructure qs)


### PR DESCRIPTION
@mcpheed1 @chatawayf I couldn't figure out how to work around the UnkownLine entirely. I thought they were only ever children of an UnknownLevel, but then I saw that they can be top-level children of a Mod, obviously.

So, as a compromise, I've proposed moving the bit about adding the "unknownImport" class attribute from the root Builder to the Lawmaker builder. My thinking is that the meaning of that class seems specific to Lawmaker, and unlikely to be used anywhere else.