### PR TITLE
'before' and judge name on same line

### DIFF
--- a/test/judgments/test59.xml
+++ b/test/judgments/test59.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukut/iac/2023/117/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukut/iac/2023/117/data.xml" />
-          <FRBRdate date="2024-08-13T18:31:05" name="transform" />
+          <FRBRdate date="2025-04-22T19:45:23" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -40,13 +40,14 @@
         <TLCPerson eId="the-secretary-of-state-for-the-home-department" href="" showAs="THE SECRETARY OF STATE FOR THE HOME DEPARTMENT" />
         <TLCRole eId="appellant" href="" showAs="Appellant" />
         <TLCRole eId="respondent" href="" showAs="Respondent" />
+        <TLCPerson eId="judge-upper-tribunal-judge-plimmer" href="/judge-upper-tribunal-judge-plimmer" showAs="UPPER TRIBUNAL JUDGE PLIMMER" />
       </references>
       <proprietary source="#">
         <uk:court>UKUT-IAC</uk:court>
         <uk:year>2023</uk:year>
         <uk:number>117</uk:number>
         <uk:cite>[2023] UKUT 117 (IAC)</uk:cite>
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.26.21</uk:parser>
         <uk:hash>4afdf77dc3a67ee855f57c3529ae689f3979f0d099366aa71b781dea67f5ca18</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -110,7 +111,7 @@
       <p class="Indentedquote" style="text-align:right;margin-left:0in;margin-right:0in"><span style="font-size:12pt">Heard on </span><span style="font-weight:bold;font-family:Arial;font-size:12pt">13</span><span style="font-weight:bold;vertical-align:super;font-size:12pt;font-family:Arial">th</span><span style="font-weight:bold;font-family:Arial;font-size:12pt">, 14</span><span style="font-weight:bold;vertical-align:super;font-size:12pt;font-family:Arial">th</span><span style="font-weight:bold;font-family:Arial;font-size:12pt"> and </span><docDate date="2022-06-15" refersTo="#hearing"><span style="font-weight:bold;font-family:Arial;font-size:12pt">15</span><span style="font-weight:bold;vertical-align:super;font-size:12pt;font-family:Arial">th</span><span style="font-weight:bold;font-family:Arial;font-size:12pt"> June 2022</span></docDate></p>
       <p class="Indentedquote" style="text-align:right;margin-left:0in;margin-right:0in"><span style="font-size:12pt">Promulgated on </span><span style="font-weight:bold;font-size:12pt">18</span><span style="font-weight:bold;vertical-align:super;font-size:12pt">th</span><span style="font-weight:bold;font-size:12pt"> April 2023</span></p>
       <p style="text-align:center"><span style="font-weight:bold;font-family:'Book Antiqua'">Before</span></p>
-      <p style="text-align:center"><span style="font-weight:bold;font-family:'Book Antiqua';color:#000000">UPPER TRIBUNAL JUDGE PLIMMER</span></p>
+      <p style="text-align:center"><judge refersTo="#judge-upper-tribunal-judge-plimmer" style="font-weight:bold;font-family:'Book Antiqua';color:#000000">UPPER TRIBUNAL JUDGE PLIMMER</judge></p>
       <p style="text-align:center"><span style="font-weight:bold;font-family:'Book Antiqua';color:#000000">and</span></p>
       <p style="text-align:center"><span style="font-weight:bold;font-family:'Book Antiqua';color:#000000">UPPER TRIBUNAL JUDGE MANDALIA</span></p>
       <p style="text-align:center"><span style="font-weight:bold;font-family:'Book Antiqua'">Between</span></p>
@@ -2742,7 +2743,7 @@
               <FRBRManifestation>
                 <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukut/iac/2023/117/annex/1/data.xml" />
                 <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukut/iac/2023/117/data.xml" />
-                <FRBRdate date="2024-08-13T18:31:05" name="transform" />
+                <FRBRdate date="2025-04-22T19:45:23" name="transform" />
                 <FRBRauthor href="#tna" />
                 <FRBRformat value="application/xml" />
               </FRBRManifestation>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.20</VersionPrefix>
+    <VersionPrefix>0.26.21</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The improvement recognizes tribunal judge names, when they appear on the same line as the word "before". (More commonly, the word "Before" appears on its own line, and the judge's name follows.)

See Jira story [FDD-42](https://national-archives.atlassian.net/browse/FDD-42)

Note that I've modified one of the tests: #59. It now contains markup of the judge's name, where before it didn't.

[FDD-42]: https://national-archives.atlassian.net/browse/FDD-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ