### PR TITLE
Simplify csv metadata validation

### DIFF
--- a/backlog/src/batch/one/Metadata.cs
+++ b/backlog/src/batch/one/Metadata.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 
 using CsvHelper;
+using CsvHelper.Configuration.Attributes;
 
 using UK.Gov.Legislation.Judgments;
 using UK.Gov.Legislation.Judgments.Parse;
@@ -27,8 +28,11 @@ namespace Backlog.Src.Batch.One
             public string file_no_3 { get; set; }
             public string claimants { get; set; }
             public string respondent { get; set; }
+            [Optional]
             public string main_subcategory_description { get; set; }
+            [Optional]
             public string sec_subcategory_description { get; set; }
+            [Optional]
             public string headnote_summary { get; set; }
             
             private readonly string DateFormat = "yyyy-MM-dd HH:mm:ss";
@@ -40,34 +44,9 @@ namespace Backlog.Src.Batch.One
 
         internal static List<Line> Read(string path)
         {
-            ValidateCsvHeaders(path);
             using var reader = new StreamReader(path);
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
             return csv.GetRecords<Line>().ToList();
-        }
-
-        private static void ValidateCsvHeaders(string path)
-        {
-            using var reader = new StreamReader(path);
-            using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-            
-            // Read the header to get column names
-            csv.Read();
-            csv.ReadHeader();
-            var headers = csv.HeaderRecord;
-
-            // Get required columns
-            var requiredColumns = new[] { "id", "FilePath", "Extension", "decision_datetime", "file_no_1", "file_no_2", "file_no_3", "claimants", "respondent"};
-            var missingColumns = requiredColumns.Where(col => !headers.Contains(col, StringComparer.OrdinalIgnoreCase)).ToList();
-
-            if (missingColumns.Any())
-            {
-                throw new InvalidOperationException(
-                    $"CSV validation failed. Missing required columns: {string.Join(", ", missingColumns)}.\n\n" +
-                    $"Found headers:\n{string.Join(", ", headers)}\n\n" +
-                    "Please preprocess your CSV to match the expected column names exactly."
-                );
-            }
         }
 
         internal static List<Line> FindLines(List<Line> lines, uint id)


### PR DESCRIPTION
Simplify csv metadata validation.
Realised that the csvreader has its own inbuilt validation and so use [Optional] attribute in lines class