### PR TITLE
Add batches 3 and 4 courts

### DIFF
--- a/src/model/Courts.cs
+++ b/src/model/Courts.cs
@@ -396,6 +396,12 @@ public readonly partial struct Courts {
         CitationPattern = new Regex(@"^\[\d{4}\] UKIPTrib \d+$")
     };
 
+    public static readonly Court ConsumerCreditAppealsTribunal = new() {
+        Code = "UKFTT-Credit",
+        LongName = "Consumer Credit Appeals Tribunal",
+        URL = "https://webarchive.nationalarchives.gov.uk/ukgwa/20090516110219/http://www.consumercreditappeals.tribunals.gov.uk/",
+    };
+
     public static readonly Court[] All = {
         SupremeCourt,
         PrivyCouncil,
@@ -443,7 +449,8 @@ public readonly partial struct Courts {
 
         EmploymentTribunal,
 
-        InvestigatoryPowersTribunal
+        InvestigatoryPowersTribunal,
+        ConsumerCreditAppealsTribunal
     };
 
     public static readonly ImmutableDictionary<string, Court> ByCode =

--- a/src/model/Courts.cs
+++ b/src/model/Courts.cs
@@ -402,6 +402,12 @@ public readonly partial struct Courts {
         URL = "https://webarchive.nationalarchives.gov.uk/ukgwa/20090516110219/http://www.consumercreditappeals.tribunals.gov.uk/",
     };
 
+    public static readonly Court EstateAgentsTribunal = new() {
+        Code = "UKFTT-Estate",
+        LongName = "Estate Agents Tribunal",
+        URL = "https://webarchive.nationalarchives.gov.uk/ukgwa/20130206050212/https://www.justice.gov.uk/tribunals/estate-agents",
+    }; 
+
     public static readonly Court[] All = {
         SupremeCourt,
         PrivyCouncil,
@@ -450,7 +456,8 @@ public readonly partial struct Courts {
         EmploymentTribunal,
 
         InvestigatoryPowersTribunal,
-        ConsumerCreditAppealsTribunal
+        ConsumerCreditAppealsTribunal,
+        EstateAgentsTribunal
     };
 
     public static readonly ImmutableDictionary<string, Court> ByCode =


### PR DESCRIPTION
Add batches 3 and 4 courts

Followup PR to amend the backlog logic to read in which court to use (currently just using `Court court = old ? Courts.OldImmigrationServicesTribunal : Courts.FirstTierTribunal_GRC;`)