### PR TITLE
LNI-320

### DIFF
--- a/TRE/lawmaker/Inputs.cs
+++ b/TRE/lawmaker/Inputs.cs
@@ -1,9 +1,6 @@
 
 using System;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Logging;
-
-using Api = UK.Gov.Legislation.Lawmaker.Api;
 
 namespace UK.Gov.NationalArchives.CaseLaw.TRE.Lawmaker
 {
@@ -37,28 +34,10 @@ namespace UK.Gov.NationalArchives.CaseLaw.TRE.Lawmaker
         [JsonPropertyName("document-type")]
         public string DocumentType { get; set; }
 
+        [JsonPropertyName("document-subtype")]
+        public string SubType { get; set; }
+
+        [JsonPropertyName("document-procedure")]
+        public string Procedure { get; set; }
     }
-
-    public partial class InputHelper
-    {
-
-        public static Api.DocType? GetDocType(ParserInputs inputs, ILogger logger)
-        {
-            if (inputs is null)
-                return null;
-            if (string.IsNullOrWhiteSpace(inputs.DocumentType))
-            {
-                logger.LogInformation("document type is null");
-                return null;
-            }
-            Api.DocType docType;
-            if (Enum.TryParse<Api.DocType>(inputs.DocumentType, out docType))
-                return docType;
-            else
-                logger.LogCritical("unrecognized document type: {}", inputs.DocumentType);
-            throw new Exception("unrecognized document type: " + inputs.DocumentType);
-        }
-
-    }
-
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,6 +14,7 @@ using UK.Gov.Legislation;
 using UK.Gov.Legislation.Judgments;
 using Api = UK.Gov.NationalArchives.Judgments.Api;
 using EM = UK.Gov.Legislation.ExplanatoryMemoranda;
+using UK.Gov.Legislation.Lawmaker;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("test")]
 
@@ -29,32 +30,58 @@ class Program {
             new Option<FileInfo>("--log", description: "the log file") { ArgumentHelpName = "file" },
             new Option<bool>("--test", description: "whether to test the result"),
             new Option<FileInfo>("--attachment", description: "an associated file to include") { ArgumentHelpName = "file" },
-            new Option<string>("--hint", description: "the type of document: 'em'")
+            new Option<string>("--hint", description: "the type of document: 'em' or a Lawmaker type such as 'nipubb', 'uksi', or 'ukprib'"),
+            new Option<string>("--subtype", description: "the subtype of document e.g. 'order'"),
+            new Option<string>("--procedure", description: "only applicable --hint is a secondary type - the subtype of document e.g. 'order'"),
         };
-        command.Handler = CommandHandler.Create<FileInfo, FileInfo, FileInfo, FileInfo, bool, FileInfo, string>(Transform);
+        command.Handler = CommandHandler.Create<
+            FileInfo,
+            FileInfo,
+            FileInfo,
+            FileInfo,
+            bool,
+            FileInfo,
+            string,
+            string,
+            string
+        >(Transform);
     }
 
     static int Main(string[] args) {
         return command.InvokeAsync(args).Result;
     }
 
-    static void Transform(FileInfo input, FileInfo output, FileInfo outputZip, FileInfo log, bool test, FileInfo attachment, string hint) {
+    static void Transform(
+        FileInfo input,
+        FileInfo output,
+        FileInfo outputZip,
+        FileInfo log,
+        bool test,
+        FileInfo attachment,
+        string hint,
+        string subType,
+        string procedure
+    ) {
+        ILogger logger = null;
         if (log is not null) {
             Logging.SetConsoleAndFile(log, LogLevel.Debug);
-            ILogger logger = Logging.Factory.CreateLogger<Program>();
+            logger = Logging.Factory.CreateLogger<Program>();
             logger.LogInformation("parsing " + input.FullName);
         }
         if ("em".Equals(hint, StringComparison.InvariantCultureIgnoreCase)) {
             TransformEM(input, output, outputZip, log, test, attachment);
             return;
         }
-        if ("bill".Equals(hint, StringComparison.InvariantCultureIgnoreCase)) {
-            var xml = UK.Gov.Legislation.Lawmaker.Helper.LocalParse(input.FullName).Xml;
+        DocName? docName = DocNames.GetDocName(hint);
+        if (docName != null) {
+            var xml = UK.Gov.Legislation.Lawmaker.Helper.LocalParse(input.FullName, new LegislationClassifier((DocName)docName, subType, procedure)).Xml;
             if (output is not null)
                 File.WriteAllText(output.FullName, xml);
             else
                 Console.WriteLine(xml);
             return;
+        } else {
+            logger?.LogCritical("unrecognized document type: {}", hint);
         }
         byte[] docx = File.ReadAllBytes(input.FullName);
         Api.Request request;

--- a/src/lawmaker/.editorconfig
+++ b/src/lawmaker/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.CS8524.severity = none

--- a/src/lawmaker/Helper.cs
+++ b/src/lawmaker/Helper.cs
@@ -32,7 +32,7 @@ namespace UK.Gov.Legislation.Lawmaker
         public static Bundle Parse(byte[] docx, LegislationClassifier classifier)
         {
 
-            Bill bill = LegislationParser.Parse(docx, classifier);
+            Document bill = LegislationParser.Parse(docx, classifier);
             XmlDocument doc = Builder.Build(bill);
             Simplifier.Simplify(doc, bill.Styles);
             string xml = NationalArchives.Judgments.Api.Parser.SerializeXml(doc);

--- a/src/lawmaker/Helper.cs
+++ b/src/lawmaker/Helper.cs
@@ -6,24 +6,21 @@ using UK.Gov.Legislation.Lawmaker.Api;
 
 namespace UK.Gov.Legislation.Lawmaker
 {
-
-    public enum Hint { Bill }
-
     public class Helper
     {
 
         // Invoked via CLI when running locally
-        public static Bundle LocalParse(string path)
+        public static Bundle LocalParse(string path, LegislationClassifier classifier)
         {
             byte[] docx = File.ReadAllBytes(path);
-            return Parse(docx);
+            return Parse(docx, classifier);
         }
 
-        // Invoked via AWS Lambda function handler 
-        public static Response LambdaParse(Request request)
+        // Invoked via AWS Lambda function handler
+        public static Response LambdaParse(Request request, LegislationClassifier classifier)
         {
             byte[] docx = request.Content;
-            Bundle bundle = Parse(docx);
+            Bundle bundle = Parse(docx, classifier);
             return new Response()
             {
                 Xml = bundle.Xml,
@@ -32,9 +29,10 @@ namespace UK.Gov.Legislation.Lawmaker
         }
 
 
-        public static Bundle Parse(byte[] docx)
+        public static Bundle Parse(byte[] docx, LegislationClassifier classifier)
         {
-            Bill bill = BillParser.Parse(docx);
+
+            Bill bill = LegislationParser.Parse(docx, classifier);
             XmlDocument doc = Builder.Build(bill);
             Simplifier.Simplify(doc, bill.Styles);
             string xml = NationalArchives.Judgments.Api.Parser.SerializeXml(doc);

--- a/src/lawmaker/akn/Builder.cs
+++ b/src/lawmaker/akn/Builder.cs
@@ -31,7 +31,7 @@ namespace UK.Gov.Legislation.Lawmaker
 
 
             XmlElement main = CreateAndAppend("bill", akomaNtoso);
-            main.SetAttribute("name", this.bill.Type);
+            main.SetAttribute("name", this.bill.Type.ToString().ToLower());
 
             string title = Metadata.Extract(bill).Title;
             MetadataBuilder.Add(main, title);
@@ -39,7 +39,7 @@ namespace UK.Gov.Legislation.Lawmaker
             AddCoverPage(main, bill.CoverPage);
             AddPreface(main, bill.Preface);
             AddPreamble(main, bill.Preamble);
-            AddBody(main, bill.Body, bill.Schedules);
+            AddBody(main, bill.Body, bill.Schedules); // bill.Schedules will always be empty here as they are part of bill.Body
 
             return doc;
         }

--- a/src/lawmaker/akn/Builder.cs
+++ b/src/lawmaker/akn/Builder.cs
@@ -236,8 +236,8 @@ namespace UK.Gov.Legislation.Lawmaker
                 e.SetAttribute("indent", UKNS, "indent0");
 
                 // These contexts modify parsing behaviour, but should NOT be reflected in the context attribute
-                if (new[] { Context.REGS, Context.RULES, Context.ORDER }.Contains(qs2.Context))
-                    qs2.Context = Context.BODY;
+                if (new[] { Context.REGULATIONS, Context.RULES, Context.ARTICLES }.Contains(qs2.Context))
+                    qs2.Context = Context.SECTIONS;
                 e.SetAttribute("context", UKNS, qs2.Context.ToString().ToLower());
                 e.SetAttribute("docName", UKNS, qs2.DocName.ToString().ToLower());
 

--- a/src/lawmaker/akn/Builder.cs
+++ b/src/lawmaker/akn/Builder.cs
@@ -12,17 +12,17 @@ using AkN = UK.Gov.Legislation.Judgments.AkomaNtoso;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    partial class Builder(Bill bill) : AkN.Builder
+    partial class Builder(Document bill) : AkN.Builder
     {
 
         override protected string UKNS => "https://www.legislation.gov.uk/namespaces/UK-AKN";
 
-        public static XmlDocument Build(Bill bill)
+        public static XmlDocument Build(Document bill)
         {
             return new Builder(bill).Build();
         }
 
-        private readonly Bill bill = bill;
+        private readonly Document bill = bill;
 
         private XmlDocument Build()
         {

--- a/src/lawmaker/akn/Frame.cs
+++ b/src/lawmaker/akn/Frame.cs
@@ -1,11 +1,11 @@
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public enum DocName { NIA, UKPGA, ASP, NISI, NISR, UKSI, SSI }
 
     public enum Context { BODY, SCH, ORDER, RULES, REGS }
 
@@ -20,10 +20,11 @@ namespace UK.Gov.Legislation.Lawmaker
         public DocName CurrentDocName => frames.Count > 0 ? frames.Peek().DocName : defaultDocName;
         public Context CurrentContext => frames.Count > 0 ? frames.Peek().Context : defaultContext;
 
-        
         public Frames(DocName docName, Context context)
         {
-            defaultDocName = docName;
+            // Frames are primarily used to track quoted structures, because quoted structures are never quoting draft legislation,
+            // we want to ensure the default DocName is the enacted type of the document we're parsing.
+            defaultDocName = DocNames.ToEnacted(docName);
             defaultContext = context;
             frames = new Stack<Frame>();
             frames.Push(new Frame(docName, context));
@@ -64,7 +65,7 @@ namespace UK.Gov.Legislation.Lawmaker
             if (frames.Count == 0)
                 return false;
             frames.Pop();
-            return true; 
+            return true;
         }
 
         private class Frame

--- a/src/lawmaker/akn/Frame.cs
+++ b/src/lawmaker/akn/Frame.cs
@@ -7,7 +7,7 @@ namespace UK.Gov.Legislation.Lawmaker
 {
 
 
-    public enum Context { BODY, SCH, ORDER, RULES, REGS }
+    public enum Context { SECTIONS, SCHEDULES, ARTICLES, RULES, REGULATIONS }
 
 
     class Frames
@@ -42,12 +42,12 @@ namespace UK.Gov.Legislation.Lawmaker
 
         public void PushScheduleContext()
         {
-            frames.Push(new Frame(CurrentDocName, Context.SCH));
+            frames.Push(new Frame(CurrentDocName, Context.SCHEDULES));
         }
 
         public bool IsScheduleContext()
         {
-            return CurrentContext == Context.SCH;
+            return CurrentContext == Context.SCHEDULES;
         }
 
         public bool IsSecondaryDocName()
@@ -57,7 +57,7 @@ namespace UK.Gov.Legislation.Lawmaker
 
         public static bool IsSecondaryDocName(DocName docName)
         {
-            return new[] { DocName.NISI, DocName.NISR, DocName.UKSI, DocName.SSI }.Contains(docName);
+            return DocNames.IsSecondaryDocName(docName);
         }
 
         public bool Pop()

--- a/src/lawmaker/api/Request.cs
+++ b/src/lawmaker/api/Request.cs
@@ -11,7 +11,7 @@ namespace UK.Gov.Legislation.Lawmaker.Api {
         public byte[] Content { get; set; }
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
-        public DocType? DocType { get; set; }
+        public DocName? DocName { get; set; }
 
         private static JsonSerializerOptions options = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
 
@@ -21,5 +21,4 @@ namespace UK.Gov.Legislation.Lawmaker.Api {
 
     }
 
-    public enum DocType { bill }
 }

--- a/src/lawmaker/models/Bill.cs
+++ b/src/lawmaker/models/Bill.cs
@@ -9,7 +9,7 @@ namespace UK.Gov.Legislation.Lawmaker
     public abstract class Bill
     {
 
-        public abstract string Type { get; protected init; }
+        public abstract DocName Type { get; protected init; }
 
         internal Dictionary<string, Dictionary<string, string>> Styles { get; init; }
 
@@ -28,7 +28,7 @@ namespace UK.Gov.Legislation.Lawmaker
     public class NIPublicBill : Bill
     {
 
-        public override string Type { get; protected init; } = "nipubb";
+        public override DocName Type { get; protected init; } = DocName.NIPUBB;
 
     }
 

--- a/src/lawmaker/models/Document.cs
+++ b/src/lawmaker/models/Document.cs
@@ -6,10 +6,10 @@ using UK.Gov.Legislation.Judgments;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public abstract class Bill
+    public class Document
     {
 
-        public abstract DocName Type { get; protected init; }
+        public DocName Type { get; init; }
 
         internal Dictionary<string, Dictionary<string, string>> Styles { get; init; }
 
@@ -24,12 +24,4 @@ namespace UK.Gov.Legislation.Lawmaker
         internal IList<Schedule> Schedules { get; init; }
 
     }
-
-    public class NIPublicBill : Bill
-    {
-
-        public override DocName Type { get; protected init; } = DocName.NIPUBB;
-
-    }
-
 }

--- a/src/lawmaker/models/Metadata.cs
+++ b/src/lawmaker/models/Metadata.cs
@@ -11,7 +11,7 @@ namespace UK.Gov.Legislation.Lawmaker
 
         public string Title { get; init; }
 
-        public static Metadata Extract(Bill bill) {
+        public static Metadata Extract(Document bill) {
             string title = Judgments.Util.Descendants<ShortTitle>(bill.CoverPage)
                 .Select(title => IInline.ToString(title.Contents))
                 .FirstOrDefault();

--- a/src/lawmaker/parsers/Body.cs
+++ b/src/lawmaker/parsers/Body.cs
@@ -9,7 +9,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private readonly List<IDivision> body = [];

--- a/src/lawmaker/parsers/Chapter.cs
+++ b/src/lawmaker/parsers/Chapter.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseChapter(WLine line)

--- a/src/lawmaker/parsers/CrossHeading.cs
+++ b/src/lawmaker/parsers/CrossHeading.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseCrossheading(WLine line)

--- a/src/lawmaker/parsers/Definition.cs
+++ b/src/lawmaker/parsers/Definition.cs
@@ -10,7 +10,7 @@ using UK.Gov.NationalArchives.Enrichment;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private static string defPattern;

--- a/src/lawmaker/parsers/GroupOfParts.cs
+++ b/src/lawmaker/parsers/GroupOfParts.cs
@@ -8,7 +8,7 @@ namespace UK.Gov.Legislation.Lawmaker
 {
     // TODO: Move this responsibility to the actual GroupOfParts object
     // e.g. GroupOfParts.Parse(WLine line)
-    public partial class BillParser
+    public partial class LegislationParser
     {
         private HContainer ParseGroupOfParts(WLine line)
         {
@@ -69,6 +69,7 @@ namespace UK.Gov.Legislation.Lawmaker
                 return false;
             if (!IsCenterAligned(line))
                 return false;
+            // Group of parts **always** has a part num, part heading and something beneath it
             if (i > Document.Body.Count - 3)
                 return false;
             string numText = IgnoreQuotedStructureStart(line.NormalizedContent, quoteDepth);

--- a/src/lawmaker/parsers/GroupingSection.cs
+++ b/src/lawmaker/parsers/GroupingSection.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseGroupingSection(WLine line)

--- a/src/lawmaker/parsers/HContainer.cs
+++ b/src/lawmaker/parsers/HContainer.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private readonly Dictionary<(string, int, int, DocName, Context), (object Result, int NextPosition)> memo = [];
@@ -171,7 +171,7 @@ namespace UK.Gov.Legislation.Lawmaker
 
         /*
          * Returns a list of blocks starting with the current paragraph, plus any
-         * additional blocks (i.e extra paragraphs, quoted structures, and/or tables) 
+         * additional blocks (i.e extra paragraphs, quoted structures, and/or tables)
         */
         private List<IBlock> HandleParagraphs(WLine line)
         {
@@ -236,7 +236,7 @@ namespace UK.Gov.Legislation.Lawmaker
 
             if (next is WDummyDivision dummy && dummy.Contents.Count() == 1 && dummy.Contents.First() is WTable table)
                 return [table];
-            // UnknownLevels are treated as extra paragraphs of the previous division 
+            // UnknownLevels are treated as extra paragraphs of the previous division
             if (next is not UnnumberedLeaf && next is not UnknownLevel)
                 return null;
             Leaf leaf = next as Leaf;
@@ -268,7 +268,7 @@ namespace UK.Gov.Legislation.Lawmaker
             if (children.Count == 0)
                 return wrapUp;
             if (children.Last() is not UnnumberedLeaf leaf)
-                // Closing Words must be the final child 
+                // Closing Words must be the final child
                 return wrapUp;
             if (children.Count == 1)
             {
@@ -297,8 +297,8 @@ namespace UK.Gov.Legislation.Lawmaker
             if (!frames.IsScheduleContext() && PeekProv1(line))
                 return true;
             // Disabled for now, as numbered list items appear identical to SchProv1 elements
-            // and were causing an unnecessary and problematic break  
-            /*          
+            // and were causing an unnecessary and problematic break
+            /*
             if (PeekSchProv1(line))
                 return true;
             */

--- a/src/lawmaker/parsers/Header.cs
+++ b/src/lawmaker/parsers/Header.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private readonly List<IBlock> coverPage = [];

--- a/src/lawmaker/parsers/LegislationParser.cs
+++ b/src/lawmaker/parsers/LegislationParser.cs
@@ -37,7 +37,8 @@ namespace UK.Gov.Legislation.Lawmaker
         {
             Document = doc;
             docName = classifier.DocName;
-            frames = new Frames(classifier.DocName,  Context.BODY);
+            LegislationClassifier legislationClassifier = new LegislationClassifier();
+            frames = new Frames(classifier.DocName,  legislationClassifier.GetContext()); 
         }
 
         private readonly ILogger Logger = Logging.Factory.CreateLogger<LegislationParser>();

--- a/src/lawmaker/parsers/LegislationParser.cs
+++ b/src/lawmaker/parsers/LegislationParser.cs
@@ -17,7 +17,7 @@ namespace UK.Gov.Legislation.Lawmaker
         // at the root.
         private readonly string? subType;
         private readonly string? procedure;
-
+        private readonly DocName docName;
         /*
           This class takes a list of "pre-parsed" blocks, and arranges them into a bill structure.
           The pre-parsed list contains blocks of only four types:
@@ -26,7 +26,7 @@ namespace UK.Gov.Legislation.Lawmaker
            = WTable
            - WTableOfContents
         */
-        public static Bill Parse(byte[] docx, LegislationClassifier classifier)
+        public static Document Parse(byte[] docx, LegislationClassifier classifier)
         {
             WordprocessingDocument doc = AkN.Parser.Read(docx);
             CaseLaw.WordDocument simple = new CaseLaw.PreParser().Parse(doc);
@@ -36,6 +36,7 @@ namespace UK.Gov.Legislation.Lawmaker
         private LegislationParser(CaseLaw.WordDocument doc, LegislationClassifier classifier)
         {
             Document = doc;
+            docName = classifier.DocName;
             frames = new Frames(classifier.DocName,  Context.BODY);
         }
 
@@ -49,7 +50,7 @@ namespace UK.Gov.Legislation.Lawmaker
         int parseAndMemoizeDepth = 0;
         int parseAndMemoizeDepthMax = 0;
 
-        private Bill Parse()
+        private Lawmaker.Document Parse()
         {
             ParseAndEnrichHeader();
             ParseBody();
@@ -68,8 +69,9 @@ namespace UK.Gov.Legislation.Lawmaker
 
             var styles = DOCX.CSS.Extract(Document.Docx.MainDocumentPart, "#bill");
 
-            return new NIPublicBill
+            return new Lawmaker.Document
             {
+                Type = docName,
                 Styles = styles,
                 CoverPage = coverPage,
                 Preface = preface,

--- a/src/lawmaker/parsers/LegislationParser.cs
+++ b/src/lawmaker/parsers/LegislationParser.cs
@@ -37,8 +37,7 @@ namespace UK.Gov.Legislation.Lawmaker
         {
             Document = doc;
             docName = classifier.DocName;
-            LegislationClassifier legislationClassifier = new LegislationClassifier();
-            frames = new Frames(classifier.DocName,  legislationClassifier.GetContext()); 
+            frames = new Frames(classifier.DocName, classifier.GetContext()); 
         }
 
         private readonly ILogger Logger = Logging.Factory.CreateLogger<LegislationParser>();

--- a/src/lawmaker/parsers/Misc.cs
+++ b/src/lawmaker/parsers/Misc.cs
@@ -9,7 +9,7 @@ using UK.Gov.NationalArchives.CaseLaw.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private IBlock Current() => Document.Body[i].Block;

--- a/src/lawmaker/parsers/Para1.cs
+++ b/src/lawmaker/parsers/Para1.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParsePara1(WLine line)
@@ -37,7 +37,7 @@ namespace UK.Gov.Legislation.Lawmaker
                 int save = i;
                 IDivision next = ParseNextBodyDivision();
                 if (next is Para1) {
-                    // Para1 & Para2 nums are both lowercase alphabetical 
+                    // Para1 & Para2 nums are both lowercase alphabetical
                     // Para1 parser has higher precedence, so must force parse as Para2
                     i = save;
                     next = ParseCurrentAsPara2();

--- a/src/lawmaker/parsers/Para2.cs
+++ b/src/lawmaker/parsers/Para2.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseCurrentAsPara2() {

--- a/src/lawmaker/parsers/Para3.cs
+++ b/src/lawmaker/parsers/Para3.cs
@@ -7,7 +7,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParsePara3(WLine line)

--- a/src/lawmaker/parsers/Part.cs
+++ b/src/lawmaker/parsers/Part.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParsePart(WLine line)

--- a/src/lawmaker/parsers/Prov1.cs
+++ b/src/lawmaker/parsers/Prov1.cs
@@ -7,7 +7,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         // matches only a heading above numbered section

--- a/src/lawmaker/parsers/Prov1.cs
+++ b/src/lawmaker/parsers/Prov1.cs
@@ -172,7 +172,7 @@ namespace UK.Gov.Legislation.Lawmaker
             return frames.CurrentContext switch
             {
                 Context.RULES => Prov1Name.rule,
-                Context.ORDER => Prov1Name.article,
+                Context.ARTICLES => Prov1Name.article,
                 _ => Prov1Name.regulation
             };
 

--- a/src/lawmaker/parsers/Prov1.cs
+++ b/src/lawmaker/parsers/Prov1.cs
@@ -171,9 +171,10 @@ namespace UK.Gov.Legislation.Lawmaker
                 return Prov1Name.article;
             return frames.CurrentContext switch
             {
+                Context.REGULATIONS => Prov1Name.regulation,
                 Context.RULES => Prov1Name.rule,
                 Context.ARTICLES => Prov1Name.article,
-                _ => Prov1Name.regulation
+                _ => Prov1Name.article
             };
 
         }

--- a/src/lawmaker/parsers/Prov2.cs
+++ b/src/lawmaker/parsers/Prov2.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseProv2(WLine line)

--- a/src/lawmaker/parsers/QuotedStructure.cs
+++ b/src/lawmaker/parsers/QuotedStructure.cs
@@ -132,7 +132,7 @@ namespace UK.Gov.Legislation.Lawmaker
                 return false;
             }
             Context context;
-            Context defaultContext = Frames.IsSecondaryDocName(docName) ? Context.REGS : Context.BODY;
+            Context defaultContext = Frames.IsSecondaryDocName(docName) ? Context.REGULATIONS : Context.SECTIONS;
             if (!groups["context"].Success)
             {
                 // Frame info has DocName but no Context - valid scenario.

--- a/src/lawmaker/parsers/QuotedStructure.cs
+++ b/src/lawmaker/parsers/QuotedStructure.cs
@@ -11,7 +11,7 @@ using UK.Gov.NationalArchives.Enrichment;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private int quoteDepth = 0;
@@ -136,14 +136,14 @@ namespace UK.Gov.Legislation.Lawmaker
             if (!groups["context"].Success)
             {
                 // Frame info has DocName but no Context - valid scenario.
-                // Resort to default Context. 
+                // Resort to default Context.
                 frames.Push(docName, defaultContext);
                 return true;
             }
             if (!Enum.TryParse(groups["context"].Value.ToUpper(), out context))
             {
                 // Frame info has a Context, but it is malformed - invalid scenario.
-                // Resort to default Context. 
+                // Resort to default Context.
                 frames.Push(docName, defaultContext);
                 return false;
             }
@@ -207,7 +207,7 @@ namespace UK.Gov.Legislation.Lawmaker
             string lastParagraphText = LastLine.GetLastParagraphText(division);
             return IsEndOfQuotedStructure(lastParagraphText);
         }
-        
+
         private static bool IsEndOfQuotedStructure(IList<IBlock> contents, ILine heading = null, IFormattedText number = null, bool headingPrecedesNumber = false)
         {
             // Squash text content into single string
@@ -272,7 +272,7 @@ namespace UK.Gov.Legislation.Lawmaker
                 return [];
             int save = i;
 
-            // Handle the case where the start quote of the first quoted structure is NOT at the 
+            // Handle the case where the start quote of the first quoted structure is NOT at the
             // start of a new line, but rather is at the end of the previous line.
             (int left, int right) = CountStartAndEndQuotes(line);
             bool isAtStartOfLine = (left == right + 1) && Regex.IsMatch(line.NormalizedContent, QuotedStructureStartPattern());
@@ -314,7 +314,7 @@ namespace UK.Gov.Legislation.Lawmaker
                 return null;
             return ParseAndMemoize(line, "QuotedStructure", ParseQuotedStructure);
         }
-  
+
         private BlockQuotedStructure ParseQuotedStructure(WLine line)
         {
             List<IDivision> contents = [];
@@ -440,8 +440,8 @@ namespace UK.Gov.Legislation.Lawmaker
             }
 
             /*
-              Note that the end quote and appended text may span across multiple of the line's inline children. 
-              For example, when portions of the line have different styling.  
+              Note that the end quote and appended text may span across multiple of the line's inline children.
+              For example, when portions of the line have different styling.
             */
             public WLine Invoke(WLine line)
             {

--- a/src/lawmaker/parsers/SchProv1.cs
+++ b/src/lawmaker/parsers/SchProv1.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseSchProv1(WLine line)

--- a/src/lawmaker/parsers/SchProv2.cs
+++ b/src/lawmaker/parsers/SchProv2.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseSchProv2(WLine line)

--- a/src/lawmaker/parsers/Schedule.cs
+++ b/src/lawmaker/parsers/Schedule.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseSchedule(WLine line)

--- a/src/lawmaker/parsers/ScheduleChapter.cs
+++ b/src/lawmaker/parsers/ScheduleChapter.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseScheduleChapter(WLine line)

--- a/src/lawmaker/parsers/ScheduleCrossHeading.cs
+++ b/src/lawmaker/parsers/ScheduleCrossHeading.cs
@@ -7,7 +7,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseScheduleCrossheading(WLine line)

--- a/src/lawmaker/parsers/ScheduleGroupingSection.cs
+++ b/src/lawmaker/parsers/ScheduleGroupingSection.cs
@@ -6,7 +6,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseScheduleGroupingSection(WLine line)

--- a/src/lawmaker/parsers/SchedulePart.cs
+++ b/src/lawmaker/parsers/SchedulePart.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseSchedulePart(WLine line)

--- a/src/lawmaker/parsers/Schedules.cs
+++ b/src/lawmaker/parsers/Schedules.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private Schedules ParseSchedules(WLine line)

--- a/src/lawmaker/parsers/UnnumberedParagraph.cs
+++ b/src/lawmaker/parsers/UnnumberedParagraph.cs
@@ -8,7 +8,7 @@ using UK.Gov.Legislation.Judgments.Parse;
 namespace UK.Gov.Legislation.Lawmaker
 {
 
-    public partial class BillParser
+    public partial class LegislationParser
     {
 
         private HContainer ParseUnnumberedParagraph(WLine line)

--- a/src/lawmaker/util/LegislationClassifier.cs
+++ b/src/lawmaker/util/LegislationClassifier.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Security.Cryptography;
 namespace UK.Gov.Legislation.Lawmaker;
 
 public enum DocName

--- a/src/lawmaker/util/LegislationClassifier.cs
+++ b/src/lawmaker/util/LegislationClassifier.cs
@@ -127,10 +127,10 @@ public readonly record struct LegislationClassifier(
     {
         return this switch
         {
-            { SubType: "reg" } => Context.REGULATIONS,
+            { SubType: "reg" }  => Context.REGULATIONS,
             { SubType: "rules" } => Context.RULES,
-            _ when DocNames.IsSecondaryDocName(DocName) => Context.ARTICLES,
-            _ => Context.SECTIONS
+            { SubType: "order" } => Context.ARTICLES,
+            _ => DocNames.IsSecondaryDocName(DocName) ? Context.ARTICLES : Context.SECTIONS
         };
     }
 }

--- a/src/lawmaker/util/LegislationClassifier.cs
+++ b/src/lawmaker/util/LegislationClassifier.cs
@@ -98,6 +98,11 @@ public static class DocNames
             DocName.NIDSR =>           LegislationType.SECONDARY,
         };
     }
+
+    public static bool IsSecondaryDocName(DocName docName)
+    {
+        return DocNames.GetLegislationType(docName) == LegislationType.SECONDARY;
+    }
 }
 
 public enum LegislationType
@@ -115,7 +120,17 @@ public readonly record struct LegislationClassifier(
     // only applicable for secondary doctypes, ideally we'd have a discriminated union between primary and secondary types since
     // they hold different data, but they're not available until C#14
     string? Procedure
-) {
-
-    public LegislationType LegislationType => DocNames.GetLegislationType(DocName);
+)
+{
+    
+    public Context GetContext()
+    {
+        return this switch
+        {
+            { SubType: "reg" } => Context.REGULATIONS,
+            { SubType: "rules" } => Context.RULES,
+            _ when DocNames.IsSecondaryDocName(DocName) => Context.ARTICLES,
+            _ => Context.SECTIONS
+        };
+    }
 }

--- a/src/lawmaker/util/LegislationClassifier.cs
+++ b/src/lawmaker/util/LegislationClassifier.cs
@@ -1,0 +1,122 @@
+#nullable enable
+using System;
+using System.Security.Cryptography;
+namespace UK.Gov.Legislation.Lawmaker;
+
+public enum DocName
+{
+    // enacted
+    NIA,
+    UKPGA,
+    UKCM,
+    ASP,
+    NISI,
+    NISR,
+    UKSI,
+    SSI,
+    UKPUBB,
+    UKPRIB,
+    UKHYBB,
+    UKDCM,
+    UKDSI,
+    SPPUBB,
+    SPPRIB,
+    SPHYBB,
+    SDSI,
+    NIPUBB,
+    NIDSI,
+    NIDSR
+
+}
+
+public static class DocNames
+{
+    public static DocName? GetDocName(string documentName)
+    {
+        if (String.IsNullOrEmpty(documentName))
+        {
+            return null;
+        }
+        DocName docName;
+        if (Enum.TryParse<DocName>(documentName.ToUpper(), out docName))
+            return docName;
+        else
+            throw new Exception("unrecognized document type: " + documentName);
+    }
+
+    public static DocName ToEnacted(DocName docName)
+    {
+        // C# will never be happy with exhaustive switch statements because you can always pass (DocName)20
+        return docName switch
+        {
+            DocName.NIA => DocName.NIA,
+            DocName.UKPGA => DocName.UKPGA,
+            DocName.UKCM => DocName.UKCM,
+            DocName.ASP => DocName.ASP,
+            DocName.NISI => DocName.NISI,
+            DocName.NISR => DocName.NISR,
+            DocName.UKSI => DocName.UKSI,
+            DocName.SSI => DocName.SSI,
+            DocName.UKPUBB => DocName.UKPGA,
+            DocName.UKPRIB => DocName.UKPGA,
+            DocName.UKHYBB => DocName.UKPGA,
+            DocName.UKDCM => DocName.UKCM,
+            DocName.UKDSI => DocName.UKDSI,
+            DocName.SPPUBB => DocName.ASP,
+            DocName.SPPRIB => DocName.ASP,
+            DocName.SPHYBB => DocName.ASP,
+            DocName.SDSI => DocName.SSI,
+            DocName.NIPUBB => DocName.NIA,
+            DocName.NIDSI => DocName.NISI,
+            DocName.NIDSR => DocName.NISR,
+        };
+    }
+
+    public static LegislationType GetLegislationType(DocName docName)
+    {
+        return docName switch
+        {
+            DocName.NIA =>             LegislationType.PRIMARY,
+            DocName.UKPGA =>           LegislationType.PRIMARY,
+            DocName.UKCM =>            LegislationType.PRIMARY,
+            DocName.ASP =>             LegislationType.PRIMARY,
+            DocName.UKPUBB =>          LegislationType.PRIMARY,
+            DocName.UKPRIB =>          LegislationType.PRIMARY,
+            DocName.UKHYBB =>          LegislationType.PRIMARY,
+            DocName.UKDCM =>           LegislationType.PRIMARY,
+            DocName.UKDSI =>           LegislationType.PRIMARY,
+            DocName.SPPUBB =>          LegislationType.PRIMARY,
+            DocName.SPPRIB =>          LegislationType.PRIMARY,
+            DocName.SPHYBB =>          LegislationType.PRIMARY,
+
+            DocName.NISI =>            LegislationType.SECONDARY,
+            DocName.NISR =>            LegislationType.SECONDARY,
+            DocName.UKSI =>            LegislationType.SECONDARY,
+            DocName.SSI =>             LegislationType.SECONDARY,
+            DocName.SDSI =>            LegislationType.SECONDARY,
+            DocName.NIPUBB =>          LegislationType.SECONDARY,
+            DocName.NIDSI =>           LegislationType.SECONDARY,
+            DocName.NIDSR =>           LegislationType.SECONDARY,
+        };
+    }
+}
+
+public enum LegislationType
+{
+    PRIMARY,
+    SECONDARY,
+    // to be filled in...
+}
+
+public readonly record struct LegislationClassifier(
+    // Every legislation document has a document "name". Not to be confused with the title. A name is the broader category of document.
+    // e.g. "nipubb" is an Northern Ireland Public Bill
+    DocName DocName,
+    string? SubType,
+    // only applicable for secondary doctypes, ideally we'd have a discriminated union between primary and secondary types since
+    // they hold different data, but they're not available until C#14
+    string? Procedure
+) {
+
+    public LegislationType LegislationType => DocNames.GetLegislationType(DocName);
+}

--- a/test/lawmaker/Test.cs
+++ b/test/lawmaker/Test.cs
@@ -21,7 +21,7 @@ namespace UK.Gov.Legislation.Lawmaker
         public void Test(int i)
         {
             var docx = ReadDocx(i);
-            var actual = Helper.Parse(docx).Xml;
+            var actual = Helper.Parse(docx, new LegislationClassifier(DocName.NIPUBB, null, null)).Xml;
             XmlDocument actualDoc = new();
             actualDoc.LoadXml(actual);
 


### PR DESCRIPTION
So far, the support for Lawmaker documents has been restricted to NI Public Bills to simplify implementation. This PR adds support to the parser to handle take in and handle more types of legislation that Lawmaker will supply.
This does include some changes to non-Lawmaker code (see `Program.cs`) to supply the necessary parameters locally though I'm unsure if this is the best approach, it seems a bit ugly to me.

The changes supply the correct `DocName` is available in the `Frame` during parsing, allowing for conditional logic during the parsing and building.