### PR TITLE
LNI-283: add class to table heading

### DIFF
--- a/src/lawmaker/akn/Tables.cs
+++ b/src/lawmaker/akn/Tables.cs
@@ -66,11 +66,13 @@ namespace UK.Gov.Legislation.Lawmaker
                     // first caption is inserted as heading
                     // var first = captions.First();
                     XmlElement heading = CreateAndAppend("heading", tblock);
+                    heading.SetAttribute("class", AknNamespace, "left");
                     heading.InnerText = captions.First().TextContent;
                     foreach (WLine caption in captions.Skip(1))
                     {
                         XmlElement subheading = CreateAndAppend("subheading", tblock);
                         subheading.InnerText = caption.TextContent;
+                        subheading.SetAttribute("class", AknNamespace, "left");
                     };
                     // others are inserted as subheading
                 }

--- a/test/lawmaker/uksi/uksi-table-with-caption.xml
+++ b/test/lawmaker/uksi/uksi-table-with-caption.xml
@@ -78,7 +78,7 @@
           <p> This Order may be cited as the Drax Power Station Bioenergy with Carbon Capture and Storage Extension Order 2024 and comes into force on 7th February 2024.</p>
           <tblock class="table">
             <num>Table 1</num>
-            <heading>Operational Rating Noise Limits</heading>
+            <heading class="left">Operational Rating Noise Limits</heading>
             <foreign>
               <table xmlns="http://www.w3.org/1999/xhtml" xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" cols="4" class="allBorders tableleft width100">
                 <tbody class="left">

--- a/test/lawmaker/uksi/uksi-table-with-captions.xml
+++ b/test/lawmaker/uksi/uksi-table-with-captions.xml
@@ -78,9 +78,9 @@
           <p> This Order may be cited as the Drax Power Station Bioenergy with Carbon Capture and Storage Extension Order 2024 and comes into force on 7th February 2024.</p>
           <tblock class="table">
             <num>Table 1</num>
-            <heading>Operational Rating Noise Limits</heading>
-            <subheading>With some additional paragraphs that should</subheading>
-            <subheading>Be inserted as subheadings</subheading>
+            <heading class="left">Operational Rating Noise Limits</heading>
+            <subheading class="left">With some additional paragraphs that should</subheading>
+            <subheading class="left">Be inserted as subheadings</subheading>
             <foreign>
               <table xmlns="http://www.w3.org/1999/xhtml" xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" cols="4" class="allBorders tableleft width100">
                 <tbody class="left">


### PR DESCRIPTION
Lawmaker relies on a table heading having a class attribute for some operations. This commit ensures the builder sets table heading class to "left"