### PR TITLE
Fix judgments tests in lawmaker branch

### DIFF
--- a/src/parsers/optimized/HardNumbers.cs
+++ b/src/parsers/optimized/HardNumbers.cs
@@ -65,8 +65,8 @@ class HardNumbers {
 
     public static readonly string[] NumberFormats = new string[] {
         @"\d+\.",              @"\(?\d+\)",
-        @"[A-Z]\.",            @"\(?[A-Z]+\)",
-        @"[a-z]\.",            @"\(?[a-z]+\)",
+        @"[A-Z]\.",            @"\(?[A-Z]{1,3}\)",
+        @"[a-z]\.",            @"\(?[a-z]{1,3}\)",
         @"[ivx]+\.",           @"\(?[ivx]+\)",
         // compound
         @"[1-9]\d*\.\d+\.?",        @"\(?[1-9]\d*\.\d+\)",
@@ -75,6 +75,7 @@ class HardNumbers {
         // legislation
         @"[A-Z]*\d+(?:[A-Z]+\d+)*[A-Z]*\.",      // section
         @"\(?[A-Z]*\d+(?:[A-Z]+\d+)*[A-Z]*\)",   // subsection
+        @"\(?[ivx]+[a-z]\)",                     // e.g., (iiia)
 
     }.Select(s => $@"^({QuotedStructureStart}{s})(\s|$)")
     .Append($@"^({QuotedStructureStart}[A-Z]*\d+(?:[A-Z]+\d+)*[A-Z]*\.)—") // em dash, perhaps it could be added to previous line?

--- a/test/judgments/test39.xml
+++ b/test/judgments/test39.xml
@@ -21,7 +21,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/2231/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/2231/data.xml" />
-          <FRBRdate date="2024-08-12T19:21:54" name="transform" />
+          <FRBRdate date="2025-08-20T17:12:55" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -39,7 +39,7 @@
         <uk:year>2022</uk:year>
         <uk:number>2231</uk:number>
         <uk:cite>[2022] EWHC 2231 (SCCO)</uk:cite>
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>36304c21d62fafa39524c8a67e8b61758e76ebe771ba97e9069e8608ae3519fc</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -109,13 +109,15 @@
                         <p style="text-align:justify;margin-left:1.18in;margin-right:0.39in;text-indent:0.32in">either—</p>
                       </intro>
                       <subparagraph>
+                        <num>(aa)</num>
                         <content>
-                          <p style="text-align:justify;margin-left:1.38in;margin-right:0.39in">(aa)   in respect of one or more counts to which the assisted person pleaded guilty, the assisted person did not so plead at the first hearing at which he or she entered a plea; or</p>
+                          <p style="text-align:justify;margin-left:1.38in;margin-right:0.39in;text-indent:0.12in">in respect of one or more counts to which the assisted person pleaded guilty, the assisted person did not so plead at the first hearing at which he or she entered a plea; or</p>
                         </content>
                       </subparagraph>
                       <subparagraph>
+                        <num>(bb)</num>
                         <content>
-                          <p style="text-align:justify;margin-left:1.38in;margin-right:0.39in">(bb)   in respect of one or more counts which did not proceed, the prosecution did not, before or at the first hearing at which the assisted person entered a plea, declare an intention of not proceeding with them; or</p>
+                          <p style="text-align:justify;margin-left:1.38in;margin-right:0.39in;text-indent:0.12in">in respect of one or more counts which did not proceed, the prosecution did not, before or at the first hearing at which the assisted person entered a plea, declare an intention of not proceeding with them; or</p>
                         </content>
                       </subparagraph>
                     </subparagraph>
@@ -337,13 +339,15 @@
                       <p style="text-align:justify;margin-left:0.98in;margin-right:0.39in;text-indent:0.02in">either—</p>
                     </intro>
                     <subparagraph>
+                      <num>(aa)</num>
                       <content>
-                        <p style="text-align:justify;margin-left:1.18in;margin-right:0.39in">(aa)  in respect of one or more counts to which the assisted person pleaded guilty, the assisted person did not so plead at the plea and case management hearing; or</p>
+                        <p style="text-align:justify;margin-left:1.18in;margin-right:0.39in;text-indent:0.32in">in respect of one or more counts to which the assisted person pleaded guilty, the assisted person did not so plead at the plea and case management hearing; or</p>
                       </content>
                     </subparagraph>
                     <subparagraph>
+                      <num>(bb)</num>
                       <content>
-                        <p style="text-align:justify;margin-left:1.18in;margin-right:0.39in">(bb)  in respect of one or more counts which did not proceed, the prosecution did not, before or at the plea and case management hearing, declare an intention of not proceeding with them; or</p>
+                        <p style="text-align:justify;margin-left:1.18in;margin-right:0.39in;text-indent:0.32in">in respect of one or more counts which did not proceed, the prosecution did not, before or at the plea and case management hearing, declare an intention of not proceeding with them; or</p>
                       </content>
                     </subparagraph>
                   </subparagraph>

--- a/test/judgments/test50.xml
+++ b/test/judgments/test50.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2023/45/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2023/45/data.xml" />
-          <FRBRdate date="2025-01-26T21:55:28" name="transform" />
+          <FRBRdate date="2025-08-20T17:13:12" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -47,7 +47,7 @@
         <uk:year>2023</uk:year>
         <uk:number>45</uk:number>
         <uk:cite>[2023] UKFTT 45 (TC)</uk:cite>
-        <uk:parser>0.26.19</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>7653fcf040c1d7f55f82082fef299fc6cf7090d63a7ff2a351feee4d4990cb13</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -623,14 +623,16 @@
             <p class="Taxbodytext1" style="margin-left:0in;text-indent:0.39in">The material provisions insofar as relevant in section 84 VATA read:-</p>
             <block name="embeddedStructure">
               <embeddedStructure>
-                <level>
-                  <content>
-                    <p class="Taxbodytext1" style="margin-left:0.39in;text-indent:-0.39in"><marker name="tab" />“(3A) Subject to subsections (3B) and (3C), where the appeal is against an assessment which is a recovery assessment for the purposes of this subsection, or against the amount of such an assessment, it shall not be entertained unless the amount notified by the assessment has been paid or deposited with HMRC.</p>
-                  </content>
-                </level>
                 <paragraph>
+                  <num>“(3A)</num>
+                  <content>
+                    <p class="Taxbodytext1" style="margin-left:0.39in">Subject to subsections (3B) and (3C), where the appeal is against an assessment which is a recovery assessment for the purposes of this subsection, or against the amount of such an assessment, it shall not be entertained unless the amount notified by the assessment has been paid or deposited with HMRC.</p>
+                  </content>
+                </paragraph>
+                <paragraph>
+                  <num>(3B)</num>
                   <intro>
-                    <p class="Taxbodytext1" style="margin-left:0.39in;text-indent:-0.39in"><marker name="tab" />(3B)  In a case where the amount determined to be payable as VAT or the amount notified by the recovery assessment has not been paid or deposited, an appeal shall be entertained if –</p>
+                    <p class="Taxbodytext1" style="margin-left:0.39in">In a case where the amount determined to be payable as VAT or the amount notified by the recovery assessment has not been paid or deposited, an appeal shall be entertained if –</p>
                   </intro>
                   <subparagraph>
                     <num style="margin-left:0.69in">(a)</num>

--- a/test/judgments/test52.xml
+++ b/test/judgments/test52.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/admin/2023/263/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/admin/2023/263/data.xml" />
-          <FRBRdate date="2024-08-13T18:31:00" name="transform" />
+          <FRBRdate date="2025-08-20T17:13:15" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -48,7 +48,7 @@
         <uk:year>2023</uk:year>
         <uk:number>263</uk:number>
         <uk:cite>[2023] EWHC 263 (Admin)</uk:cite>
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>9934c9fd7d782638b1db767ae7fea76a77ea51ec9131d64489a9ea5e6ce6b9a8</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -576,9 +576,12 @@
                       <p class="Quote" style="margin-left:1.18in;text-indent:0.32in">fairly and reasonably related in scale and kind to the development.</p>
                     </content>
                   </subparagraph>
-                  <wrapUp>
-                    <p class="Quote" style="margin-left:1in">(2A) …</p>
-                  </wrapUp>
+                </paragraph>
+                <paragraph>
+                  <num>(2A)</num>
+                  <content>
+                    <p class="Quote" style="margin-left:1in;text-indent:0.5in">…</p>
+                  </content>
                 </paragraph>
                 <paragraph>
                   <num>(3)</num>

--- a/test/judgments/test57.xml
+++ b/test/judgments/test57.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/kb/2023/579/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/kb/2023/579/data.xml" />
-          <FRBRdate date="2024-08-13T18:31:02" name="transform" />
+          <FRBRdate date="2025-08-20T17:13:23" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -47,7 +47,7 @@
         <uk:year>2023</uk:year>
         <uk:number>579</uk:number>
         <uk:cite>[2023] EWHC 579 (KB)</uk:cite>
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>d09c9253dbac8cf651e8580d0487faf25312104aef3451027aa7471a06916641</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -1443,8 +1443,9 @@
             <p class="BodyA" style="text-align:justify;margin-left:0.39in">By way of further example, Uniserve’s own standard exclusion clause stated:</p>
           </intro>
           <subparagraph>
+            <num style="font-style:italic">26C.</num>
             <content>
-              <p class="NormalWeb" style="text-align:justify;margin-left:0.39in"><span style="font-style:italic;font-size:12pt">26C. Save in respect of such loss or damage as is referred to at sub-clause (B), and subject to clause 2B above and sub- clause (D) below, the Company shall not be liable for indirect or consequential loss such as (but not limited to) loss of profit, loss of market, or the consequence of delay or deviation, however caused</span><span style="font-size:12pt">.</span></p>
+              <p class="NormalWeb" style="text-align:justify;margin-left:0.39in;text-indent:0.11in"><span style="font-style:italic;font-size:12pt">Save in respect of such loss or damage as is referred to at sub-clause (B), and subject to clause 2B above and sub- clause (D) below, the Company shall not be liable for indirect or consequential loss such as (but not limited to) loss of profit, loss of market, or the consequence of delay or deviation, however caused</span><span style="font-size:12pt">.</span></p>
             </content>
           </subparagraph>
         </paragraph>
@@ -1511,8 +1512,9 @@
             <p class="NormalWeb" style="margin-left:0.39in"><span style="font-size:12pt">By way of further example, Uniserve</span><span style="font-family:'Arial Unicode MS';font-size:12pt">’</span><span style="font-size:12pt">s own standard limitation clause stated:</span></p>
           </intro>
           <subparagraph>
+            <num style="font-style:italic">6A.</num>
             <content>
-              <p class="NormalWeb" style="margin-left:0.39in"><span style="font-style:italic;font-size:12pt">6A. Subject to 2B and 11B above and subclause D below, the Company's liability howsoever arising and, notwithstanding that the cause of loss or damage be unexplained, shall not exceed: </span></p>
+              <p class="NormalWeb" style="margin-left:0.39in;text-indent:0.11in"><span style="font-style:italic;font-size:12pt">Subject to 2B and 11B above and subclause D below, the Company's liability howsoever arising and, notwithstanding that the cause of loss or damage be unexplained, shall not exceed: </span></p>
             </content>
           </subparagraph>
           <subparagraph>

--- a/test/judgments/test65.xml
+++ b/test/judgments/test65.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/comm/2023/1481/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/comm/2023/1481/data.xml" />
-          <FRBRdate date="2024-08-13T18:31:15" name="transform" />
+          <FRBRdate date="2025-08-20T17:13:41" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -70,7 +70,7 @@
         <uk:year>2023</uk:year>
         <uk:number>1481</uk:number>
         <uk:cite>[2023] EWHC 1481 (Comm)</uk:cite>
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>d828cb59472c0506412c9c3fc197144d3f387e773c3b71738f83c42e6e49b8b8</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -4849,11 +4849,12 @@
                     <p style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:0.5in">Subject to paragraph 7A below, COVID-19 was “manifested” within QBE1 and RSA1, within a radius of 25 miles of the premises, wherever a person displayed symptoms of, or was diagnosed with, COVID-19 and was/were within a 25 mile radius of the premises.</p>
                   </content>
                 </paragraph>
-                <level>
+                <paragraph>
+                  <num>7A.</num>
                   <content>
-                    <p style="text-align:justify;margin-left:1in;margin-right:0.5in">7A. There was no “occurrence” or “manifestation” of COVID-19, and COVID-19 was not “sustained”, within a given radius of the premises for the purposes of Argenta1, Hiscox4 (hybrid), MSAmlin1-2 (disease clauses), QBE1-3 and RSA1 and 3 merely by reason of the fact that a person travelled through that geographical area and had no contact with anyone living in the area.”</p>
+                    <p style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:0.5in">There was no “occurrence” or “manifestation” of COVID-19, and COVID-19 was not “sustained”, within a given radius of the premises for the purposes of Argenta1, Hiscox4 (hybrid), MSAmlin1-2 (disease clauses), QBE1-3 and RSA1 and 3 merely by reason of the fact that a person travelled through that geographical area and had no contact with anyone living in the area.”</p>
                   </content>
-                </level>
+                </paragraph>
               </embeddedStructure>
             </block>
           </content>
@@ -5361,9 +5362,12 @@
             </content>
           </subparagraph>
         </paragraph>
-        <level eId="lvl_58">
-          <heading style="text-align:justify;margin-left:0.5in;text-indent:-0.5in">12A.    Subject to the above, on the proper construction of the Disease Extension within the policy as whole, </heading>
-          <paragraph>
+        <paragraph eId="lvl_58">
+          <num>12A.</num>
+          <intro>
+            <p style="text-align:justify;margin-left:0.5in">Subject to the above, on the proper construction of the Disease Extension within the policy as whole, </p>
+          </intro>
+          <subparagraph>
             <num style="margin-left:0.75in;text-indent:-0.25in">(a)</num>
             <intro>
               <p style="text-align:justify;margin-left:0.75in;text-indent:0.12in">Is the First Claimant, whose policy was for the period of 12 months from 31 January 2020, entitled to recover its claimed losses </p>
@@ -5390,8 +5394,8 @@
                 <p style="text-align:justify;margin-left:0.75in">And </p>
               </content>
             </subparagraph>
-          </paragraph>
-          <paragraph>
+          </subparagraph>
+          <subparagraph>
             <num style="margin-left:0.75in;text-indent:-0.25in">(b)</num>
             <intro>
               <p style="text-align:justify;margin-left:0.75in;text-indent:0.12in">As regards the Second and Third Claimants, whose policies expired on 6 August 2020, </p>
@@ -5413,13 +5417,13 @@
                 <p style="text-align:justify;margin-left:1in;text-indent:0.25in">is there no cover for losses resulting from occurrences of a Notifiable Disease and/or restrictions imposed or continuing after the end of the policy period, as the Defendants submit? </p>
               </content>
             </subparagraph>
-          </paragraph>
-          <paragraph>
+          </subparagraph>
+          <subparagraph>
             <content>
               <p style="text-align:justify;margin-left:0.5in"><span style="font-weight:bold">Not applicable.</span><authorialNote class="footnote" marker="5"><p class="FootnoteText"> Mr Gruder said (Day 7/page 98), following earlier discussion, that the parties had agreed that issue 3 could be left to a later date.</p></authorialNote></p>
             </content>
-          </paragraph>
-        </level>
+          </subparagraph>
+        </paragraph>
         <level eId="lvl_59">
           <content>
             <p><span style="font-style:italic;font-weight:bold">Mayfair </span></p>

--- a/test/judgments/test77.xml
+++ b/test/judgments/test77.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2024/137/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2024/137/data.xml" />
-          <FRBRdate date="2025-01-26T21:55:35" name="transform" />
+          <FRBRdate date="2025-08-20T17:14:04" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -47,7 +47,7 @@
         <uk:year>2024</uk:year>
         <uk:number>137</uk:number>
         <uk:cite>[2024] UKFTT 137 (TC)</uk:cite>
-        <uk:parser>0.26.19</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>2c4bf18d720132dcbd29f8d50f034b59ced8de8180145037098fc4e1fd5017cb</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -902,8 +902,9 @@
               </content>
             </subparagraph>
             <subparagraph>
+              <num>(1A)</num>
               <intro>
-                <p class="Taxbodytext1" style="margin-left:0.39in;text-indent:-0.39in"><marker name="tab" />(1A)<marker name="tab" />Where the Commissioners:- </p>
+                <p class="Taxbodytext1" style="margin-left:0.39in">Where the Commissioners:- </p>
               </intro>
               <subparagraph>
                 <num style="margin-left:0.79in">(a)</num>

--- a/test/judgments/test93.xml
+++ b/test/judgments/test93.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2024/36/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2024/36/data.xml" />
-          <FRBRdate date="2024-11-13T14:27:20" name="transform" />
+          <FRBRdate date="2025-08-20T17:14:35" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -49,7 +49,7 @@
         <uk:year>2024</uk:year>
         <uk:number>36</uk:number>
         <uk:cite>[2024] UKSC 36</uk:cite>
-        <uk:parser>0.26.12</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>3e000e521e8fb64f56d54e2b9a6e91596d6cf3a44110aff3324a72db70d29ca0</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -5339,11 +5339,12 @@
             <p style="text-align:justify;margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman';font-size:13pt">Thus far I have not mentioned the issue of pending proceedings. These are addressed in paragraph 20 of Schedule 2A to the 1994 Act. This is headed “</span><span style="font-style:italic;font-family:'Times New Roman';font-size:13pt">Existing EUTM: pending proceedings</span><span style="font-family:'Times New Roman';font-size:13pt">” and provides so far as relevant that as of exit day (there being at this stage no IP completion day):</span></p>
             <block name="embeddedStructure">
               <embeddedStructure>
-                <level>
+                <paragraph>
+                  <num style="font-family:'Times New Roman';font-size:13pt">“20.</num>
                   <content>
-                    <p style="text-align:justify;margin-left:1in;margin-right:0.87in"><span style="font-family:'Times New Roman';font-size:13pt">“20.—(1) This paragraph applies where on exit day an existing EUTM is the subject of proceedings which are pending (‘pending proceedings’) before a court in the United Kingdom designated for the purposes of Article 123 (‘EU trade mark court’).</span></p>
+                    <p style="text-align:justify;margin-left:1in;margin-right:0.87in;text-indent:0.5in"><span style="font-family:'Times New Roman';font-size:13pt">—(1) This paragraph applies where on exit day an existing EUTM is the subject of proceedings which are pending (‘pending proceedings’) before a court in the United Kingdom designated for the purposes of Article 123 (‘EU trade mark court’).</span></p>
                   </content>
-                </level>
+                </paragraph>
                 <paragraph>
                   <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
                   <content>
@@ -5408,11 +5409,12 @@
             <p style="text-align:justify;margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman';font-size:13pt"> References in paragraph 20 to “exit day” would soon be changed to IP completion day, as I will explain. The effect of any injunction restraining any infringement of an EU trade mark on what was originally to be exit day but would also become IP completion day is then dealt with in paragraph 21 of Schedule 2A. This is headed “</span><span style="font-style:italic;font-family:'Times New Roman';font-size:13pt">Existing EUTM: effect of an injunction</span><span style="font-family:'Times New Roman';font-size:13pt">” and provides:</span></p>
             <block name="embeddedStructure">
               <embeddedStructure>
-                <level>
+                <paragraph>
+                  <num style="font-family:'Times New Roman';font-size:13pt">“21.</num>
                   <content>
-                    <p style="text-align:justify;margin-left:1in;margin-right:0.87in"><span style="font-family:'Times New Roman';font-size:13pt">“21.—(1) This paragraph applies where immediately before exit day an injunction is in force prohibiting the performance of acts in the United Kingdom which infringe or would infringe an existing EUTM (a ‘relevant injunction').</span></p>
+                    <p style="text-align:justify;margin-left:1in;margin-right:0.87in;text-indent:0.5in"><span style="font-family:'Times New Roman';font-size:13pt">—(1) This paragraph applies where immediately before exit day an injunction is in force prohibiting the performance of acts in the United Kingdom which infringe or would infringe an existing EUTM (a ‘relevant injunction').</span></p>
                   </content>
-                </level>
+                </paragraph>
                 <paragraph>
                   <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
                   <content>
@@ -5558,11 +5560,12 @@
             <p style="text-align:justify;margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman';font-size:13pt">Secondly, a new paragraph 21A was added into Schedule 2A to the 1994 Act by regulation 9. Paragraph 21A is relevant for it deals with the effect in this jurisdiction of the invalidity or revocation of an existing EU trade mark in proceedings instituted but not finally determined before IP completion day. It is headed “Existing EUTM: effect of invalidity or revocation” and provides</span><span style="font-family:'Times New Roman'">:</span></p>
             <block name="embeddedStructure">
               <embeddedStructure>
-                <level>
+                <paragraph>
+                  <num style="font-family:'Times New Roman';font-size:13pt">“21A.</num>
                   <content>
-                    <p class="Quote" style="text-align:justify;margin-left:0.5in"><span style="font-family:'Times New Roman'">“21A.—(1) This paragraph applies where, on IP completion day, an existing EUTM is the subject of proceedings under Article 58 (Grounds for revocation), 59 (Absolute grounds for invalidity) or 60 (Relative grounds for invalidity) which have been instituted but not finally determined before IP completion day (‘cancellation proceedings’).</span></p>
+                    <p class="Quote" style="text-align:justify;margin-left:0.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">—(1) This paragraph applies where, on IP completion day, an existing EUTM is the subject of proceedings under Article 58 (Grounds for revocation), 59 (Absolute grounds for invalidity) or 60 (Relative grounds for invalidity) which have been instituted but not finally determined before IP completion day (‘cancellation proceedings’).</span></p>
                   </content>
-                </level>
+                </paragraph>
                 <paragraph>
                   <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
                   <intro>

--- a/test/judgments/test96.xml
+++ b/test/judgments/test96.xml
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2024/1059/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukftt/tc/2024/1059/data.xml" />
-          <FRBRdate date="2025-01-26T21:55:54" name="transform" />
+          <FRBRdate date="2025-08-20T17:14:43" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -41,7 +41,7 @@
         <uk:year>2024</uk:year>
         <uk:number>1059</uk:number>
         <uk:cite>[2024] UKFTT 1059 (TC)</uk:cite>
-        <uk:parser>0.26.19</uk:parser>
+        <uk:parser>0.28.0</uk:parser>
         <uk:hash>8731591c87c85773482b02b15d8f70c6f8f23a5734bf9b72ce7841c73666bb89</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -3571,8 +3571,9 @@
             </content>
           </subparagraph>
           <subparagraph>
+            <num>A1.</num>
             <content>
-              <p style="margin-left:0.39in"><span style="font-family:'Times New Roman'">A1. A company conducts extensive market research to learn what technical and design characteristics a new DVD player should have in order to be an appealing product. This work is not R&amp;D (paragraph 37). However, it does identify a potential project to create a DVD player incorporating a number of technological improvements which the company’s R&amp;D staff (who are competent professionals) regard as genuine and nontrivial. This project would be seeking to develop an appreciably improved DVD player (paragraphs 23-25) and would therefore be seeking to achieve an advance in science or technology (paragraph 9(c)).</span></p>
+              <p style="margin-left:0.39in;text-indent:0.11in"><span style="font-family:'Times New Roman'">A company conducts extensive market research to learn what technical and design characteristics a new DVD player should have in order to be an appealing product. This work is not R&amp;D (paragraph 37). However, it does identify a potential project to create a DVD player incorporating a number of technological improvements which the company’s R&amp;D staff (who are competent professionals) regard as genuine and nontrivial. This project would be seeking to develop an appreciably improved DVD player (paragraphs 23-25) and would therefore be seeking to achieve an advance in science or technology (paragraph 9(c)).</span></p>
             </content>
           </subparagraph>
           <subparagraph>
@@ -3581,8 +3582,9 @@
             </content>
           </subparagraph>
           <subparagraph>
+            <num>A4.</num>
             <content>
-              <p style="margin-left:0.39in"><span style="font-family:'Times New Roman'">A4. Several copies of this prototype are made (not R&amp;D; paragraphs 4-5 and 26-28) and distributed to a group of consumers to test their reactions (not R&amp;D; paragraph 28((a)). Some of these consumers report concerns about the noise level of the DVD 8 player in operation. Additional work is done to resolve this problem. If this involves a routine adjustment of the existing prototype (i.e. no scientific or technological uncertainty) then it will not be R&amp;D (paragraph 14); if it involves more substantial changes (i.e. there is scientific or technological uncertainty to resolve) then it will be R&amp;D.</span></p>
+              <p style="margin-left:0.39in;text-indent:0.11in"><span style="font-family:'Times New Roman'">Several copies of this prototype are made (not R&amp;D; paragraphs 4-5 and 26-28) and distributed to a group of consumers to test their reactions (not R&amp;D; paragraph 28((a)). Some of these consumers report concerns about the noise level of the DVD 8 player in operation. Additional work is done to resolve this problem. If this involves a routine adjustment of the existing prototype (i.e. no scientific or technological uncertainty) then it will not be R&amp;D (paragraph 14); if it involves more substantial changes (i.e. there is scientific or technological uncertainty to resolve) then it will be R&amp;D.</span></p>
             </content>
           </subparagraph>
           <subparagraph>
@@ -3591,8 +3593,9 @@
             </content>
           </subparagraph>
           <subparagraph>
+            <num>G1.</num>
             <content>
-              <p style="margin-left:0.39in"><span style="font-family:'Times New Roman'">G1. Scientific or technological testing and analysis which directly contributes to the resolution of scientific or technological uncertainty is R&amp;D (paragraph 26). So for example if testing work is carried out as part of the development of a pilot plant, this would be R&amp;D, but once the design of the ‘final’ pilot plant had been finalised and tested, any further testing would not be R&amp;D (paragraph 39). However, if flaws in the design became apparent later on, then work to remedy them would be R&amp;D if they could not readily be resolved by a competent professional working in the field (in other words, if there was scientific or technological uncertainty around how to fix the problem; paragraph 14).</span></p>
+              <p style="margin-left:0.39in;text-indent:0.11in"><span style="font-family:'Times New Roman'">Scientific or technological testing and analysis which directly contributes to the resolution of scientific or technological uncertainty is R&amp;D (paragraph 26). So for example if testing work is carried out as part of the development of a pilot plant, this would be R&amp;D, but once the design of the ‘final’ pilot plant had been finalised and tested, any further testing would not be R&amp;D (paragraph 39). However, if flaws in the design became apparent later on, then work to remedy them would be R&amp;D if they could not readily be resolved by a competent professional working in the field (in other words, if there was scientific or technological uncertainty around how to fix the problem; paragraph 14).</span></p>
             </content>
           </subparagraph>
           <subparagraph>
@@ -3601,13 +3604,15 @@
             </content>
           </subparagraph>
           <subparagraph>
+            <num>J1.</num>
             <content>
-              <p style="margin-left:0.39in"><span style="font-family:'Times New Roman'">J1. A company develops new spark plugs for use in an existing petrol engine. The scientific or technological uncertainty associated with this work is resolved once prototype plugs have been fully tested in the engine. The activities directly contributing to this work, including the construction of prototypes and their testing in the engine, would be R&amp;D.</span></p>
+              <p style="margin-left:0.39in;text-indent:0.11in"><span style="font-family:'Times New Roman'">A company develops new spark plugs for use in an existing petrol engine. The scientific or technological uncertainty associated with this work is resolved once prototype plugs have been fully tested in the engine. The activities directly contributing to this work, including the construction of prototypes and their testing in the engine, would be R&amp;D.</span></p>
             </content>
           </subparagraph>
           <subparagraph>
+            <num>J2.</num>
             <content>
-              <p style="margin-left:0.39in"><span style="font-family:'Times New Roman'">J2. The same company decides to design a new engine to incorporate the new spark plugs, involving a new combustion chamber design, lighter materials and other improvements such that the overall engine is appreciably improved (it uses less petrol to achieve slightly greater power output performance, and generates less pollution than current models). The activities directly contributing to this work, including the design of the separate components (not all of which need be different from those used in previous models) and their integration into a new engine, are R&amp;D. The uncertainty associated with this work is resolved, and R&amp;D is complete. once a functionally final prototype has been tested.” </span></p>
+              <p style="margin-left:0.39in;text-indent:0.11in"><span style="font-family:'Times New Roman'">The same company decides to design a new engine to incorporate the new spark plugs, involving a new combustion chamber design, lighter materials and other improvements such that the overall engine is appreciably improved (it uses less petrol to achieve slightly greater power output performance, and generates less pollution than current models). The activities directly contributing to this work, including the design of the separate components (not all of which need be different from those used in previous models) and their integration into a new engine, are R&amp;D. The uncertainty associated with this work is resolved, and R&amp;D is complete. once a functionally final prototype has been tested.” </span></p>
             </content>
           </subparagraph>
         </paragraph>

--- a/version.targets
+++ b/version.targets
@@ -1,7 +1,7 @@
 <Project>
 
 <PropertyGroup>
-    <VersionPrefix>0.26.19</VersionPrefix>
+    <VersionPrefix>0.28.0</VersionPrefix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Update tests and adjust alphabetic numbered paragraph detection patterns

This PR makes two adjustments to numbered paragraph detection after the lawmaker branch integration:

### Test output adjustments
Updated 8 judgment test files to reflect improvements to the <num> markup.

### Refined regex patterns for alphabetic numbering
The lawmaker branch introduced support for multi-letter paragraph numbering (e.g., `(AA)`, `(BB)`) by changing `[A-Z]` to `[A-Z]+` in the HardNumbers class. However, this was too permissive for judgments and incorrectly matched role labels like `(CLAIMANT)` and `(DEFENDANT)` in test 8.

**Changes made:**
- Limited alphabetic patterns to `{1,3}` characters instead of unlimited `+`
- Added specific pattern `[ivx]+[a-z]` to handle legislative amendment numbering like `(iiia)`. such as in lawmaker/test4.xml