### PR TITLE
Add support for BidirectionalOverride (bdo) elements

### DIFF
--- a/src/parsers/common/Inline2.cs
+++ b/src/parsers/common/Inline2.cs
@@ -141,7 +141,7 @@ class Inline2 {
                 i += 1;
                 continue;
             }
-            if (e is BidirectionalOverride bdo) {  // Bidirectional text override element
+            if (e is BidirectionalOverride) {  // Bidirectional text override element
                 var children = ParseRuns(Main, e.ChildElements);
                 parsed.AddRange(children);
                 i += 1;


### PR DESCRIPTION
Add support for BidirectionalOverride (bdo) elements by recursively parsing
their child elements, following the same pattern used for other container
elements like InsertedRun, SdtRun, and smartTag.

This fixes parsing failures when documents contain text with bidirectional
formatting, such as content with HTML entities (e.g., "PPS <1000" or
"<100 members") that Word wraps in bdo elements.

This issue was identified when trying to parse a NI Explanatory Memoranda.