### PR TITLE
Change URI format for EMs

### DIFF
--- a/src/api/URI.cs
+++ b/src/api/URI.cs
@@ -16,6 +16,8 @@ public class URI {
             uri = uri.Substring(3);
         if (uri.EndsWith("/data.xml"))
             uri = uri.Substring(0, uri.Length - 9);
+        if (uri.EndsWith("/data.akn"))
+            uri = uri.Substring(0, uri.Length - 9);
         if (string.IsNullOrWhiteSpace(uri))
             return null;
         return uri;

--- a/src/leg/Builder.cs
+++ b/src/leg/Builder.cs
@@ -95,9 +95,9 @@ class Builder : AkN.Builder {
 
         XmlElement manifestation = CreateAndAppend("FRBRManifestation", identification);
         XmlElement maniThis = CreateAndAppend("FRBRthis", manifestation);
-        maniThis.SetAttribute("value", data.ExpressionUri + "/data.xml");
+        maniThis.SetAttribute("value", data.ExpressionUri + "/data.akn");
         XmlElement maniURI = CreateAndAppend("FRBRuri", manifestation);
-        maniURI.SetAttribute("value",  data.ExpressionUri + "/data.xml");
+        maniURI.SetAttribute("value",  data.ExpressionUri + "/data.akn");
         XmlElement maniDate = CreateAndAppend("FRBRdate", manifestation);
         maniDate.SetAttribute("date", FormatDateAndTime(DateTime.UtcNow));
         maniDate.SetAttribute("name", "transform");

--- a/src/leg/em/Metadata.cs
+++ b/src/leg/em/Metadata.cs
@@ -16,7 +16,7 @@ class Metadata : DocumentMetadata {
     internal static Metadata Make(List<IBlock> header, WordprocessingDocument doc) {
         string name = HeaderSplitter.GetDocumentType(header);
         string number = HeaderSplitter.GetDocumentNumber(header);
-        string uri = number is null ? null : RegulationNumber.MakeURI(number) + "/em";
+        string uri = number is null ? null : RegulationNumber.MakeURI(number) + "/memorandum";
         // Tuple<string, int> altNum = RegulationNumber.ExtractAltNumber(number);
         DateTime? modified = doc.PackageProperties.Modified;
         Dictionary<string, Dictionary<string, string>> css = DOCX.CSS.Extract(doc.MainDocumentPart, "#doc");

--- a/test/leg/em/test1.xml
+++ b/test/leg/em/test1.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/464/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/464/em" />
-          <FRBRdate date="2024-08-12" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/464/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/464/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/464/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/464/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/464/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/464/memorandum" />
           <FRBRdate date="2023-04-25T11:24:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/464/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/464/em/data.xml" />
-          <FRBRdate date="2024-08-12T19:28:32Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/464/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/464/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:22:05Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>317b0cf03b5fe6e9e1b8186bc48e59e249b8a248bbd624726b9acddec8c5bc00</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test2.xml
+++ b/test/leg/em/test2.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/593/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/593/em" />
-          <FRBRdate date="2023-10-30" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/593/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/593/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/593/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/593/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/593/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/593/memorandum" />
           <FRBRdate date="2023-05-31T09:28:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/593/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/593/em/data.xml" />
-          <FRBRdate date="2023-10-30T16:18:02Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/593/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/593/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:22:20Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.17.11</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>9ff1ccf8f769c57f39d5022d13f91d56f5e4f2cc389df3bad3ce3ed92da2287b</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test3.xml
+++ b/test/leg/em/test3.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/720/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/720/em" />
-          <FRBRdate date="2024-07-19" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/720/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/720/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/720/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/720/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/720/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/720/memorandum" />
           <FRBRdate date="2023-06-29T09:58:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/720/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/720/em/data.xml" />
-          <FRBRdate date="2024-07-19T15:13:58Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/720/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/720/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:22:36Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>6cfb5ff3d24247cc773dd6cc5526f000b4a90ab842f035e81671c48f602bd17c</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test4.xml
+++ b/test/leg/em/test4.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2018/1052/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2018/1052/em" />
-          <FRBRdate date="2023-11-27" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2018/1052/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2018/1052/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum" />
           <FRBRdate date="2018-10-09T12:21:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/em/data.xml" />
-          <FRBRdate date="2023-11-27T21:40:07Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:22:47Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.18.3</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>87d9d928c87f763e82617c51f510a1ba7eb461a290fef17225f6ef06ea3b75ea</uk:hash>
       </proprietary>
     </meta>
@@ -339,23 +339,23 @@
           <meta>
             <identification source="#tna">
               <FRBRWork>
-                <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2018/1052/em/annex/1" />
-                <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2018/1052/em/annex/1" />
-                <FRBRdate date="2023-11-27" name="generated" />
+                <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2018/1052/memorandum/annex/1" />
+                <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2018/1052/memorandum/annex/1" />
+                <FRBRdate date="2025-09-16" name="generated" />
                 <FRBRauthor href="#" />
                 <FRBRcountry value="GB-UKM" />
               </FRBRWork>
               <FRBRExpression>
-                <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/em/annex/1" />
-                <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/em/annex/1" />
-                <FRBRdate date="2023-11-27" name="generated" />
+                <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/annex/1" />
+                <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/annex/1" />
+                <FRBRdate date="2025-09-16" name="generated" />
                 <FRBRauthor href="#" />
                 <FRBRlanguage language="eng" />
               </FRBRExpression>
               <FRBRManifestation>
-                <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/em/annex/1/data.xml" />
-                <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/em/annex/1/data.xml" />
-                <FRBRdate date="2023-11-27T21:40:07Z" name="transform" />
+                <FRBRthis value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/annex/1/data.akn" />
+                <FRBRuri value="http://www.legislation.gov.uk/uksi/2018/1052/memorandum/annex/1/data.akn" />
+                <FRBRdate date="2025-09-16T15:22:47Z" name="transform" />
                 <FRBRauthor href="#tna" />
                 <FRBRformat value="application/xml" />
               </FRBRManifestation>

--- a/test/leg/em/test5.xml
+++ b/test/leg/em/test5.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2020/1542/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2020/1542/em" />
-          <FRBRdate date="2024-08-12" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2020/1542/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2020/1542/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2020/1542/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2020/1542/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2020/1542/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2020/1542/memorandum" />
           <FRBRdate date="2020-12-15T19:55:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2020/1542/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2020/1542/em/data.xml" />
-          <FRBRdate date="2024-08-12T19:28:40Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2020/1542/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2020/1542/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:22:59Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>c9da01a14f12ff70dd763c44b96a8bd3acef1eeb7087d6dcd0f53f58dba460ed</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test6.xml
+++ b/test/leg/em/test6.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2023/132/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2023/132/em" />
-          <FRBRdate date="2023-10-09" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2023/132/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2023/132/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/132/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/132/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/132/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/132/memorandum" />
           <FRBRdate date="2023-04-26T10:20:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/132/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/132/em/data.xml" />
-          <FRBRdate date="2023-10-09T18:57:30Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/132/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/132/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:23:10Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.17.6</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>f6de65b2c381e9de70146da96b4f26fe05633cb1318b10fc36bbc0a8c4c30fbc</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test7.xml
+++ b/test/leg/em/test7.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2023/170/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2023/170/em" />
-          <FRBRdate date="2023-10-09" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2023/170/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2023/170/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/170/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/170/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/170/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/170/memorandum" />
           <FRBRdate date="2023-05-31T11:54:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/170/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/170/em/data.xml" />
-          <FRBRdate date="2023-10-09T18:57:30Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2023/170/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2023/170/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:23:25Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.17.6</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>79f07f29c74d6895150b8b691ac620af5b31ec67d36963bb98af579836923888</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test8.xml
+++ b/test/leg/em/test8.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2020/315/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2020/315/em" />
-          <FRBRdate date="2023-10-09" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/ssi/2020/315/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/ssi/2020/315/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2020/315/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2020/315/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2020/315/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2020/315/memorandum" />
           <FRBRdate date="2020-10-08T12:00:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/ssi/2020/315/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/ssi/2020/315/em/data.xml" />
-          <FRBRdate date="2023-10-09T18:57:30Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/ssi/2020/315/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/ssi/2020/315/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:23:40Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.17.6</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>69c8f870ad2486ae2515736f7e79d3f22c3b2e1b6dfcc893acddf46cc0650987</uk:hash>
       </proprietary>
     </meta>

--- a/test/leg/em/test9.xml
+++ b/test/leg/em/test9.xml
@@ -4,23 +4,23 @@
     <meta>
       <identification source="#tna">
         <FRBRWork>
-          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/453/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/453/em" />
-          <FRBRdate date="2024-08-12" name="generated" />
+          <FRBRthis value="http://www.legislation.gov.uk/id/uksi/2023/453/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/id/uksi/2023/453/memorandum" />
+          <FRBRdate date="2025-09-16" name="generated" />
           <FRBRauthor href="#" />
           <FRBRcountry value="GB-UKM" />
         </FRBRWork>
         <FRBRExpression>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/453/em" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/453/em" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/453/memorandum" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/453/memorandum" />
           <FRBRdate date="2023-04-25T09:28:00Z" name="lastModified" />
           <FRBRauthor href="#" />
           <FRBRlanguage language="eng" />
         </FRBRExpression>
         <FRBRManifestation>
-          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/453/em/data.xml" />
-          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/453/em/data.xml" />
-          <FRBRdate date="2024-08-12T19:28:45Z" name="transform" />
+          <FRBRthis value="http://www.legislation.gov.uk/uksi/2023/453/memorandum/data.akn" />
+          <FRBRuri value="http://www.legislation.gov.uk/uksi/2023/453/memorandum/data.akn" />
+          <FRBRdate date="2025-09-16T15:23:51Z" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -29,7 +29,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
       </references>
       <proprietary source="#">
-        <uk:parser>0.26.0</uk:parser>
+        <uk:parser>0.27.1</uk:parser>
         <uk:hash>55f524b2804fd938bb220682582be1e5d8d547223e3187dc9a537ddc24615164</uk:hash>
       </proprietary>
     </meta>


### PR DESCRIPTION
Within the metadata change URI suffix from /em to /memorandum for explanatory memoranda, data.xml to data.akn and rerun test files through parser