### PR TITLE
Make CSV validation errors clearer

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -15,7 +15,7 @@ using Api = UK.Gov.NationalArchives.Judgments.Api;
 namespace Backlog.Src;
 
 /// <summary>
-/// This is the main entry point to the bulk backlog parsing process
+///     This is the main entry point to the bulk backlog parsing process
 /// </summary>
 internal class BacklogParserWorker(
     ILogger<BacklogParserWorker> logger,
@@ -28,7 +28,8 @@ internal class BacklogParserWorker(
 {
     public int Run(bool isDryRun, uint? id, string pathToCourtMetadataFile, bool autoPublish, string pathToOutputFolder)
     {
-        var lines = csvMetadataReader.Read(pathToCourtMetadataFile, out var csvParseErrors);
+        var lines = csvMetadataReader.Read(pathToCourtMetadataFile, out var skippedCsvLineIdentifiers,
+            out var csvParseErrors);
         if (lines.Count == 0)
         {
             logger.LogCritical("No valid records found in the metadata file");
@@ -47,7 +48,6 @@ internal class BacklogParserWorker(
         }
 
         var alreadyDoneLines = new List<CsvLine>();
-        var markedAsSkipLines = new List<CsvLine>();
         var successfulNewLines = new List<CsvLine>();
         var failedToProcessLines = new List<(CsvLine line, Exception exception)>();
 
@@ -57,13 +57,6 @@ internal class BacklogParserWorker(
 
             try
             {
-                if (line.Skip)
-                {
-                    logger.LogWarning("Skipping {LineId} because it was marked to skip in the csv", line.id);
-                    markedAsSkipLines.Add(line);
-                    continue;
-                }
-
                 if (tracker.WasDone(line))
                 {
                     logger.LogWarning("Skipping {LineId} because it was previously processed", line.id);
@@ -105,8 +98,8 @@ internal class BacklogParserWorker(
             }
         }
 
-        LogFinalStatistics(logger, markedAsSkipLines, alreadyDoneLines, successfulNewLines, lines,
-            failedToProcessLines, csvParseErrors);
+        LogFinalStatistics(logger, alreadyDoneLines, successfulNewLines, lines, failedToProcessLines, csvParseErrors,
+            skippedCsvLineIdentifiers);
 
         if (failedToProcessLines.Count > 0 || csvParseErrors.Count > 0)
         {
@@ -116,14 +109,14 @@ internal class BacklogParserWorker(
         return 0;
     }
 
-    private static void LogFinalStatistics(ILogger logger, List<CsvLine> markedAsSkipLines,
-        List<CsvLine> alreadyDoneLines,
+    private static void LogFinalStatistics(ILogger logger, List<CsvLine> alreadyDoneLines,
         List<CsvLine> successfulNewLines, List<CsvLine> parsedLinesFromCsv,
-        List<(CsvLine line, Exception exception)> failedToProcessLines,
-        List<string> csvParseErrors)
+        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
+        List<string> skippedCsvLineIdentifiers)
     {
-        var markedAsSkipIds = markedAsSkipLines.Any()
-            ? $"[{string.Join(", ", markedAsSkipLines.Select(l => l.id))}]"
+        var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
+        var markedAsSkipIds = numSkippedCsvLines > 0
+            ? $"[{string.Join(", ", skippedCsvLineIdentifiers)}]"
             : string.Empty;
 
         logger.LogInformation("""
@@ -133,10 +126,10 @@ internal class BacklogParserWorker(
                                 - {MarkedToSkipLineCount} lines were marked in the csv to skip {MarkedToSkipIds}
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
-            markedAsSkipLines.Count + alreadyDoneLines.Count + successfulNewLines.Count,
+            numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
             parsedLinesFromCsv.Count + csvParseErrors.Count,
             successfulNewLines.Count,
-            markedAsSkipLines.Count, markedAsSkipIds,
+            numSkippedCsvLines, markedAsSkipIds,
             alreadyDoneLines.Count
         );
 
@@ -224,7 +217,7 @@ internal class BacklogParserWorker(
                     Court = csvLine.Court,
                     Date = csvLine.DecisionDateTime.ToString("yyyy-MM-dd"),
                     Name = csvLine.FirstPartyName + " v " + csvLine.Respondent,
-                JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
+                    JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
                     Extensions = new Api.Extensions
                     {
                         SourceFormat = mimeType,
@@ -239,9 +232,12 @@ internal class BacklogParserWorker(
             };
 
             response = parser.Parse(request);
-            
+
             if (response.Xml.Contains("<header />"))
-                throw new NotSupportedException("Couldn't parse header - try updating titles used to identify the end of header in OptimizedUKUTParser.titles");
+            {
+                throw new NotSupportedException(
+                    "Couldn't parse header - try updating titles used to identify the end of header in OptimizedUKUTParser.titles");
+            }
         }
 
         return response;

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -29,7 +29,7 @@ internal class BacklogParserWorker(
     public int Run(bool isDryRun, uint? id, string pathToCourtMetadataFile, bool autoPublish, string pathToOutputFolder)
     {
         var lines = csvMetadataReader.Read(pathToCourtMetadataFile, out var skippedCsvLineIdentifiers,
-            out var csvParseErrors);
+            out var csvParseErrors, out var numAllLinesInCsv);
         if (lines.Count == 0)
         {
             logger.LogCritical("No valid records found in the metadata file");
@@ -59,7 +59,7 @@ internal class BacklogParserWorker(
             {
                 if (tracker.WasDone(line))
                 {
-                    logger.LogWarning("Skipping {LineId} because it was previously processed", line.id);
+                    logger.LogInformation("Skipping {LineId} because it was previously processed", line.id);
                     alreadyDoneLines.Add(line);
                     continue;
                 }
@@ -98,8 +98,8 @@ internal class BacklogParserWorker(
             }
         }
 
-        LogFinalStatistics(logger, alreadyDoneLines, successfulNewLines, lines, failedToProcessLines, csvParseErrors,
-            skippedCsvLineIdentifiers);
+        LogFinalStatistics(logger, alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
+            skippedCsvLineIdentifiers, numAllLinesInCsv);
 
         if (failedToProcessLines.Count > 0 || csvParseErrors.Count > 0)
         {
@@ -110,9 +110,8 @@ internal class BacklogParserWorker(
     }
 
     private static void LogFinalStatistics(ILogger logger, List<CsvLine> alreadyDoneLines,
-        List<CsvLine> successfulNewLines, List<CsvLine> parsedLinesFromCsv,
-        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
-        List<string> skippedCsvLineIdentifiers)
+        List<CsvLine> successfulNewLines, List<(CsvLine line, Exception exception)> failedToProcessLines,
+        List<string> csvParseErrors, List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
@@ -127,7 +126,7 @@ internal class BacklogParserWorker(
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
             numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
-            parsedLinesFromCsv.Count + csvParseErrors.Count,
+            numAllLinesInCsv,
             successfulNewLines.Count,
             numSkippedCsvLines, markedAsSkipIds,
             alreadyDoneLines.Count

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -57,24 +57,31 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
         {
             try
             {
-                var record = csv.GetRecord<CsvLine>();
-
-                // Use DataAnnotations validation
-                var validationContext = new ValidationContext(record);
-                var validationResults = new List<ValidationResult>();
-
-                if (Validator.TryValidateObject(record, validationContext, validationResults, true))
+                try
                 {
-                    records.Add(record);
+                    var record = csv.GetRecord<CsvLine>();
+
+                    // Use DataAnnotations validation
+                    var validationContext = new ValidationContext(record);
+                    var validationResults = new List<ValidationResult>();
+
+                    if (Validator.TryValidateObject(record, validationContext, validationResults, true))
+                    {
+                        records.Add(record);
+                    }
+                    else
+                    {
+                        var errors = string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
+                                                                        .Select(r => r.ErrorMessage));
+
+                        csvParseErrors.Add($"Line {csv.Context.Parser!.Row}: {errors}");
+                        logger.LogError("CSV validation errors [{Errors}] at row {ParserRow}", errors,
+                            csv.Context.Parser?.Row);
+                    }
                 }
-                else
+                catch (FieldValidationException ex) //created by failed `Validate`s in `CsvLineMap`
                 {
-                    var errors = string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
-                                                                    .Select(r => r.ErrorMessage));
-
-                    csvParseErrors.Add($"Line {csv.Context.Parser!.Row}: {errors}");
-                    logger.LogError("CSV validation errors [{Errors}] at row {ParserRow}", errors,
-                        csv.Context.Parser?.Row);
+                    csvParseErrors.Add($"Line {csv.Context.Parser!.Row}: \"{ex.Field}\" failed validation with message: {ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal))} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
                 }
             }
             catch (Exception ex)
@@ -111,7 +118,10 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
 
             Map(l => l.DecisionDateTime)
                 .TypeConverterOption.DateTimeStyles(DateTimeStyles.AllowWhiteSpaces & DateTimeStyles.AssumeUniversal)
-                .Validate(v => Regex.IsMatch(v.Field.Trim(), @"^\d\d\d\d")); // Ensure dates start with the year
+                .Validate(v => Regex.IsMatch(v.Field.Trim(), @"^\d\d\d\d"),
+                    v => string.IsNullOrWhiteSpace(v.Field)
+                        ? "Decision date must be provided"
+                        : "Unsupported decision date. Ensure dates are in yyyy-MM-dd format");
 
             Map(l => l.Jurisdictions)
                 .Optional()

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -12,33 +12,36 @@ using Backlog.Src;
 
 using CsvHelper;
 using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 
 using Microsoft.Extensions.Logging;
 
 namespace Backlog.Csv;
 
-class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
+internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
 {
     private string csvName = "unknown.csv";
     private string csvHash = "unknown";
 
-    internal List<CsvLine> Read(string csvPath, out List<string> csvParseErrors)
+    internal List<CsvLine> Read(string csvPath, out List<string> skippedCsvLineIdentifiers,
+        out List<string> csvParseErrors)
     {
         csvName = Path.GetFileName(csvPath);
         csvHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
-        
+
         using var streamReader = new StreamReader(csvPath);
-        return Read(streamReader, out csvParseErrors);
+        return Read(streamReader, out skippedCsvLineIdentifiers, out csvParseErrors);
     }
 
-    internal List<CsvLine> Read(TextReader textReader, out List<string> csvParseErrors)
+    internal List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
+        out List<string> csvParseErrors)
     {
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)
         {
             ShouldSkipRecord = args => false,
             IgnoreBlankLines = true,
             PrepareHeaderForMatch = args => args.Header.ToLower().Replace("_", ""),
-            TrimOptions = TrimOptions.Trim | TrimOptions.InsideQuotes,
+            TrimOptions = TrimOptions.Trim | TrimOptions.InsideQuotes
         };
         using var csv = new CsvReader(textReader, config);
 
@@ -46,6 +49,7 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
         csv.Context.RegisterClassMap(new CsvLineMap(csvName, csvHash));
 
         var records = new List<CsvLine>();
+        skippedCsvLineIdentifiers = [];
         csvParseErrors = [];
 
         // Read the header first
@@ -61,6 +65,13 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
                 {
                     var record = csv.GetRecord<CsvLine>();
 
+                    if (record.Skip)
+                    {
+                        skippedCsvLineIdentifiers.Add($"Line {csv.Context.Parser!.Row}");
+                        logger.LogWarning("Skipping {LineId} because it was marked to skip in the csv", record.id);
+                        continue;
+                    }
+
                     // Use DataAnnotations validation
                     var validationContext = new ValidationContext(record);
                     var validationResults = new List<ValidationResult>();
@@ -68,36 +79,71 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
                     if (Validator.TryValidateObject(record, validationContext, validationResults, true))
                     {
                         records.Add(record);
+                        continue;
                     }
-                    else
-                    {
-                        var errors = string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
-                                                                        .Select(r => r.ErrorMessage));
 
-                        csvParseErrors.Add($"Line {csv.Context.Parser!.Row}: {errors}");
-                        logger.LogError("CSV validation errors [{Errors}] at row {ParserRow}", errors,
-                            csv.Context.Parser?.Row);
-                    }
+                    var validationErrors = string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
+                                                                              .Select(r => r.ErrorMessage));
+                    SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv, validationErrors);
                 }
                 catch (FieldValidationException ex) //created by failed `Validate`s in `CsvLineMap`
                 {
-                    csvParseErrors.Add($"Line {csv.Context.Parser!.Row}: \"{ex.Field}\" failed validation with message: {ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal))} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
+                    SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
+                        $"\"{ex.Field}\" failed validation with message: {GetCsvHelperExceptionMessage(ex)}");
                 }
+            }
+            catch (TypeConverterException ex)
+            {
+                SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
+                    $"Could not convert field `{ex.MemberMapData.Member?.Name ?? "unknown"}` with value \"{ex.Text}\" to type `{ex.MemberMapData.Type.Name}`");
+            }
+            catch (CsvHelperException ex)
+            {
+                SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
+                    GetCsvHelperExceptionMessage(ex));
             }
             catch (Exception ex)
             {
-                var exceptionMessage = ex is CsvHelperException
-                    ? ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal))
-                    : ex.Message;
-
-                var rawLine = csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty);
-                csvParseErrors.Add(
-                    $"Line {csv.Context.Parser!.Row}: {exceptionMessage} [{rawLine}]");
-                logger.LogError(ex, "Error parsing row {ParserRow}", csv.Context.Parser?.Row);
+                logger.LogCritical(ex, "Critical issue: {ParseError}",
+                    CreateParseErrorWithRowInformation(csv, ex.Message));
             }
         }
 
         return records;
+    }
+
+    private static void SkipOrRecordCsvParseError(List<string> csvParseErrors, List<string> skippedCsvLineIdentifiers,
+        CsvReader csv, string errorMessage)
+    {
+        var successfullyRetrievedSkipField = csv.TryGetField<bool>(
+            nameof(CsvLine.Skip),
+            csv.Context.TypeConverterCache.GetConverter<BooleanSkipConverter>(),
+            out var skipFieldValue
+        );
+
+        if (successfullyRetrievedSkipField && skipFieldValue)
+        {
+            skippedCsvLineIdentifiers.Add($"Line {csv.Context.Parser!.Row}");
+        }
+        else
+        {
+            csvParseErrors.Add(CreateParseErrorWithRowInformation(csv, errorMessage));
+        }
+    }
+
+    /// <summary>
+    ///     CsvHelperException.Message contains a lot of irrelevant information on multiple lines, but we only want the first
+    ///     part which says why something failed
+    /// </summary>
+    private static string GetCsvHelperExceptionMessage(CsvHelperException ex)
+    {
+        return ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal));
+    }
+
+    private static string CreateParseErrorWithRowInformation(CsvReader csv, string errorMessage)
+    {
+        return
+            $"Line {csv.Context.Parser!.Row}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]";
     }
 
     private sealed class CsvLineMap : ClassMap<CsvLine>
@@ -122,14 +168,14 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
                     v => string.IsNullOrWhiteSpace(v.Field)
                         ? "Decision date must be provided"
                         : "Unsupported decision date. Ensure dates are in yyyy-MM-dd format");
-
             Map(l => l.Jurisdictions)
                 .Optional()
                 .Convert(convertFromStringArgs =>
                 {
                     // Get value
                     convertFromStringArgs.Row.TryGetField<string>("jurisdictions", out var field);
-                    return field?.Split(',').Select(item => item.Trim()).Where(jurisdiction => !string.IsNullOrWhiteSpace(jurisdiction)).ToArray() ?? [];
+                    return field?.Split(',').Select(item => item.Trim())
+                                .Where(jurisdiction => !string.IsNullOrWhiteSpace(jurisdiction)).ToArray() ?? [];
                 });
 
             Map(l => l.FullCsvLineContents)
@@ -137,7 +183,7 @@ class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
                 {
                     var headerNames = convertFromStringArgs.Row.HeaderRecord!;
                     return headerNames.ToDictionary(headerName => headerName.Trim(),
-                                          headerName => convertFromStringArgs.Row[headerName] ?? string.Empty);
+                        headerName => convertFromStringArgs.Row[headerName] ?? string.Empty);
                 });
 
             Map(l => l.CsvProperties)

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -24,17 +24,17 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
     private string csvHash = "unknown";
 
     internal List<CsvLine> Read(string csvPath, out List<string> skippedCsvLineIdentifiers,
-        out List<string> csvParseErrors)
+        out List<string> csvParseErrors, out int numAllLinesInCsv)
     {
         csvName = Path.GetFileName(csvPath);
         csvHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
 
         using var streamReader = new StreamReader(csvPath);
-        return Read(streamReader, out skippedCsvLineIdentifiers, out csvParseErrors);
+        return Read(streamReader, out skippedCsvLineIdentifiers, out csvParseErrors, out numAllLinesInCsv);
     }
 
     internal List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
-        out List<string> csvParseErrors)
+        out List<string> csvParseErrors, out int numAllLinesInCsv)
     {
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)
         {
@@ -51,6 +51,7 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
         var records = new List<CsvLine>();
         skippedCsvLineIdentifiers = [];
         csvParseErrors = [];
+        numAllLinesInCsv = 0;
 
         // Read the header first
         csv.Read();
@@ -59,75 +60,70 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
         // Now read data rows
         while (csv.Read())
         {
-            try
+            numAllLinesInCsv++;
+            var currentLineNumber = csv.Context.Parser!.Row;
+
+            var successfullyRetrievedSkipField = csv.TryGetField<bool>(
+                nameof(CsvLine.Skip),
+                csv.Context.TypeConverterCache.GetConverter<BooleanSkipConverter>(),
+                out var skipFieldValue
+            );
+
+            if (successfullyRetrievedSkipField && skipFieldValue)
             {
-                try
-                {
-                    var record = csv.GetRecord<CsvLine>();
-
-                    if (record.Skip)
-                    {
-                        skippedCsvLineIdentifiers.Add($"Line {csv.Context.Parser!.Row}");
-                        logger.LogWarning("Skipping {LineId} because it was marked to skip in the csv", record.id);
-                        continue;
-                    }
-
-                    // Use DataAnnotations validation
-                    var validationContext = new ValidationContext(record);
-                    var validationResults = new List<ValidationResult>();
-
-                    if (Validator.TryValidateObject(record, validationContext, validationResults, true))
-                    {
-                        records.Add(record);
-                        continue;
-                    }
-
-                    var validationErrors = string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
-                                                                              .Select(r => r.ErrorMessage));
-                    SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv, validationErrors);
-                }
-                catch (FieldValidationException ex) //created by failed `Validate`s in `CsvLineMap`
-                {
-                    SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
-                        $"\"{ex.Field}\" failed validation with message: {GetCsvHelperExceptionMessage(ex)}");
-                }
+                skippedCsvLineIdentifiers.Add($"Line {currentLineNumber}");
+                logger.LogInformation("Skipping line {LineNumber} because it was marked to skip in the csv",
+                    currentLineNumber);
+                continue;
             }
-            catch (TypeConverterException ex)
+
+            var processCsvRecordResult = ProcessCsvRecord(csv);
+
+            switch (processCsvRecordResult)
             {
-                SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
-                    $"Could not convert field `{ex.MemberMapData.Member?.Name ?? "unknown"}` with value \"{ex.Text}\" to type `{ex.MemberMapData.Type.Name}`");
-            }
-            catch (CsvHelperException ex)
-            {
-                SkipOrRecordCsvParseError(csvParseErrors, skippedCsvLineIdentifiers, csv,
-                    GetCsvHelperExceptionMessage(ex));
-            }
-            catch (Exception ex)
-            {
-                logger.LogCritical(ex, "Critical issue: {ParseError}",
-                    CreateParseErrorWithRowInformation(csv, ex.Message));
+                case { ErrorMessage: { } errorMessage, Record: null }:
+                    csvParseErrors.Add($"Line {currentLineNumber}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
+                    break;
+                case { Record: { } record, ErrorMessage: null }:
+                    records.Add(record);
+                    break;
+                default:
+                    throw new NotSupportedException("ProcessCsvRecord always returns either a record or an error message");
             }
         }
 
         return records;
     }
 
-    private static void SkipOrRecordCsvParseError(List<string> csvParseErrors, List<string> skippedCsvLineIdentifiers,
-        CsvReader csv, string errorMessage)
+    private static (CsvLine? Record, string? ErrorMessage) ProcessCsvRecord(CsvReader csv)
     {
-        var successfullyRetrievedSkipField = csv.TryGetField<bool>(
-            nameof(CsvLine.Skip),
-            csv.Context.TypeConverterCache.GetConverter<BooleanSkipConverter>(),
-            out var skipFieldValue
-        );
+        try
+        {
+            var record = csv.GetRecord<CsvLine>();
 
-        if (successfullyRetrievedSkipField && skipFieldValue)
-        {
-            skippedCsvLineIdentifiers.Add($"Line {csv.Context.Parser!.Row}");
+            // Use DataAnnotations validation
+            var validationResults = new List<ValidationResult>();
+
+            if (Validator.TryValidateObject(record, new ValidationContext(record), validationResults, true))
+            {
+                return (record, null);
+            }
+
+            return (null, string.Join(", ", validationResults.Where(r => r != ValidationResult.Success)
+                                                             .Select(r => r.ErrorMessage)));
         }
-        else
+        catch (FieldValidationException ex) //created by failed `Validate`s in `CsvLineMap`
         {
-            csvParseErrors.Add(CreateParseErrorWithRowInformation(csv, errorMessage));
+            return (null, $"\"{ex.Field}\" failed validation with message: {GetCsvHelperExceptionMessage(ex)}");
+        }
+        catch (TypeConverterException ex)
+        {
+            return (null,
+                $"Could not convert field `{ex.MemberMapData.Member?.Name ?? "unknown"}` with value \"{ex.Text}\" to type `{ex.MemberMapData.Type.Name}`");
+        }
+        catch (CsvHelperException ex)
+        {
+            return (null, GetCsvHelperExceptionMessage(ex));
         }
     }
 
@@ -138,12 +134,6 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
     private static string GetCsvHelperExceptionMessage(CsvHelperException ex)
     {
         return ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal));
-    }
-
-    private static string CreateParseErrorWithRowInformation(CsvReader csv, string errorMessage)
-    {
-        return
-            $"Line {csv.Context.Parser!.Row}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]";
     }
 
     private sealed class CsvLineMap : ClassMap<CsvLine>

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -223,13 +223,13 @@ namespace test.backlog.EndToEndTests
             Assert.True(trackerLines[0].Contains("some-uuid-1"), "First line should be the pre-existing entry");
 
             // Log file should mention skips
-            ConsolidatedLogger.VerifyLog("Skipping 103 because it was marked to skip in the csv", LogLevel.Warning)
-                              .VerifyLog("Skipping 100 because it was previously processed", LogLevel.Warning)
+            ConsolidatedLogger.VerifyLog("Skipping line 5 because it was marked to skip in the csv", LogLevel.Information)
+                              .VerifyLog("Skipping 100 because it was previously processed", LogLevel.Information)
                               .VerifyLog("""
                                          ---------------------------
                                          Successfully processed 4 of 4 csv lines, of which:
                                            - 2 lines were new
-                                           - 1 lines were marked in the csv to skip [103]
+                                           - 1 lines were marked in the csv to skip [Line 5]
                                            - 1 lines were skipped because they had been processed in a previous run
                                          """, LogLevel.Information);
         }

--- a/test/backlog/MetadataTests/TestBooleanSkipConverter.cs
+++ b/test/backlog/MetadataTests/TestBooleanSkipConverter.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using Backlog.Csv;
+
+using CsvHelper;
+using CsvHelper.Configuration;
+
+using Moq;
+
+using Xunit;
+
+namespace test.backlog.MetadataTests;
+
+public class TestBooleanSkipConverter
+{
+    private readonly BooleanSkipConverter converter = new();
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("n")]
+    [InlineData("N")]
+    [InlineData("no")]
+    [InlineData("No")]
+    [InlineData("NO")]
+    [InlineData("f")]
+    [InlineData("F")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("FALSE")]
+    [InlineData(null)]
+    public void ConvertFromString_WithFalsySkipValues_ReturnsFalse(string? skipValue)
+    {
+        var result = converter.ConvertFromString(skipValue, Mock.Of<IReaderRow>(), new MemberMapData(null));
+
+        var skip = Assert.IsType<bool>(result);
+        Assert.False(skip);
+    }
+
+    [Theory]
+    [InlineData("skip")]
+    [InlineData("Skip")]
+    [InlineData("skip - for reasons")]
+    [InlineData("Already in FCL")]
+    [InlineData("Duplicate")]
+    [InlineData("1")]
+    [InlineData("yes")]
+    [InlineData("T")]
+    public void ConvertFromString_WithTruthySkipValues_ReturnsTrue(string skipValue)
+    {
+        var result = converter.ConvertFromString(skipValue, Mock.Of<IReaderRow>(), new MemberMapData(null));
+
+        var skip = Assert.IsType<bool>(result);
+        Assert.True(skip);
+    }
+}

--- a/test/backlog/MetadataTests/TestBooleanSkipConverter.cs
+++ b/test/backlog/MetadataTests/TestBooleanSkipConverter.cs
@@ -17,6 +17,7 @@ public class TestBooleanSkipConverter
 
     [Theory]
     [InlineData("")]
+    [InlineData("\u00A0")]
     [InlineData("   ")]
     [InlineData("n")]
     [InlineData("N")]

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -687,4 +687,39 @@ public class TestRead: IDisposable
         // Assert
         Assert.Empty(lines);
     }
+
+    [Fact]
+    public void Read_FromPath_PopulatesCsvPropertiesWithNameAndHash()
+    {
+        // Arrange
+        const string csvContent = "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip\n" +
+                                  "123,/test/data/test.pdf,.pdf,2025-01-15,IA/2025/001,UKUT-IAC,Smith,HMRC,";
+        var csvPath = MakeRealCsvFile(csvContent);
+        var expectedHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
+
+        // Act
+        var result = csvMetadataReader.Read(csvPath, out _, out _);
+
+        // Assert
+        var line = Assert.Single(result);
+        Assert.Equal("metadata.csv", line.CsvProperties.Name);
+        Assert.Equal(expectedHash, line.CsvProperties.Hash);
+    }
+
+    [Fact]
+    public void Read_FromTextReader_PopulatesCsvPropertiesWithUnknown()
+    {
+        // Arrange
+        const string csvContent = "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip\n" +
+                                  "123,/test/data/test.pdf,.pdf,2025-01-15,IA/2025/001,UKUT-IAC,Smith,HMRC,";
+        using var reader = new StringReader(csvContent);
+
+        // Act
+        var result = csvMetadataReader.Read(reader, out _, out _);
+
+        // Assert
+        var line = Assert.Single(result);
+        Assert.Equal("unknown.csv", line.CsvProperties.Name);
+        Assert.Equal("unknown", line.CsvProperties.Hash);
+    }
 }

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -54,7 +54,8 @@ public class TestRead : IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
+        var result =
+            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
         Assert.Empty(csvParseErrors);
 
         var parsedLine = Assert.Single(result);
@@ -87,7 +88,8 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
+        var result =
+            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
 
         Assert.Empty(csvParseErrors);
         Assert.Empty(skippedCsvLineIdentifiers);
@@ -114,13 +116,32 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
+        var result =
+            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
 
         Assert.Empty(csvParseErrors);
         Assert.Empty(result);
         Assert.Single(skippedCsvLineIdentifiers);
     }
 
+    [Fact]
+    public void Read_WithVarietyOfRows_OutputsFullRowCount()
+    {
+        using var csvStream = new StringReader(
+            """
+            id,FilePath,Extension,decision_datetime,CaseNo,court,appellants,respondent,skip
+            123 , this_is_a_good_unskipped_line.pdf , .pdf , 2025-01-15 09:00:00 , IA/2025/001,UKUT-IAC , Smith , Secretary of State for the Home Department,
+            124 , this_is_a_good_skipped_line.pdf , .pdf , 2025-01-15 09:00:00 , IA/2025/001,UKUT-IAC , Smith , Secretary of State for the Home Department,skip me
+            125, missing_extension_skipped_line.docx  ,  ,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,skip me
+            126, missing_extension_unskipped_line.docx  ,  ,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,
+            """
+        );
+        
+        _ = csvMetadataReader.Read(csvStream, out _, out _, out var fullRowCount);
+
+        Assert.Equal(4, fullRowCount);
+    }
+    
     [Fact]
     public void Read_WithDodgySkippedLines_DoesNotOutputValidationErrors()
     {
@@ -136,7 +157,8 @@ public class TestRead : IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
+        var result =
+            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
 
         // Assert that the good line is returned
         var parsedLine = Assert.Single(result);
@@ -175,7 +197,7 @@ public class TestRead : IDisposable
             csvWithMissingColumn
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors, out _);
 
         Assert.Empty(result);
         Assert.All(csvParseErrors, csvParseError => Assert.Contains(missingColumn, csvParseError));
@@ -202,7 +224,7 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out _);
+        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
 
         var line = Assert.Single(result);
         Assert.Equal(expectedJurisdictions, line.Jurisdictions);
@@ -220,7 +242,7 @@ public class TestRead : IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out _);
+        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
 
         Assert.Collection(result,
             line => Assert.Equivalent(new Dictionary<string, string>
@@ -302,7 +324,7 @@ public class TestRead : IDisposable
         using var csvStream = new StringReader(csvContent);
 
         // Act
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _, out _);
 
         // Assert - results
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
@@ -527,7 +549,7 @@ public class TestRead : IDisposable
             """
         );
 
-        var validLines = csvMetadataReader.Read(csvStream, out _, out var failedToParseLines);
+        var validLines = csvMetadataReader.Read(csvStream, out _, out var failedToParseLines, out _);
 
         Assert.Equal(3, validLines.Count);
         Assert.Equal(5, failedToParseLines.Count);
@@ -556,7 +578,7 @@ public class TestRead : IDisposable
         using var csvStream = new StringReader(csvContent);
 
         //Act
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _, out _);
 
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
             new CsvLine
@@ -607,7 +629,8 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
+        var result =
+            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
 
         Assert.Empty(csvParseErrors);
         var line = Assert.Single(result);
@@ -639,7 +662,7 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors, out _);
 
         Assert.Empty(result);
         var error = Assert.Single(csvParseErrors);
@@ -655,7 +678,7 @@ public class TestRead : IDisposable
         // Act & Assert
         Assert.Throws<FileNotFoundException>(() =>
         {
-            _ = csvMetadataReader.Read(nonExistentPath, out _, out _);
+            _ = csvMetadataReader.Read(nonExistentPath, out _, out _, out _);
         });
     }
 
@@ -668,7 +691,7 @@ public class TestRead : IDisposable
                 "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
 
         // Act
-        var lines = csvMetadataReader.Read(emptyCsvPath, out _, out _);
+        var lines = csvMetadataReader.Read(emptyCsvPath, out _, out _, out _);
 
         // Assert
         Assert.Empty(lines);
@@ -684,7 +707,7 @@ public class TestRead : IDisposable
         var expectedHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
 
         // Act
-        var result = csvMetadataReader.Read(csvPath, out _, out _);
+        var result = csvMetadataReader.Read(csvPath, out _, out _, out _);
 
         // Assert
         var line = Assert.Single(result);
@@ -701,7 +724,7 @@ public class TestRead : IDisposable
         using var reader = new StringReader(csvContent);
 
         // Act
-        var result = csvMetadataReader.Read(reader, out _, out _);
+        var result = csvMetadataReader.Read(reader, out _, out _, out _);
 
         // Assert
         var line = Assert.Single(result);

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -656,8 +656,8 @@ public class TestRead: IDisposable
         Assert.Equivalent(
             new List<string>
             {
-                "Line 6: Field '01/16/2025 10:00:00' is not valid. [125,bad.pdf,.pdf,  01/16/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]",
-                "Line 7: Field '31/01/2025 10:00:00' is not valid. [125,bad.pdf,.pdf,  31/01/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]"
+                "Line 6: \"01/16/2025 10:00:00\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format [125,bad.pdf,.pdf,  01/16/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]",
+                "Line 7: \"31/01/2025 10:00:00\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format [125,bad.pdf,.pdf,  31/01/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]"
             },
             csvParseErrors);
     }

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 
 using Backlog.Csv;
+using Backlog.Src;
 
 using test.Mocks;
 
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace test.backlog.MetadataTests;
 
-public class TestRead: IDisposable
+public class TestRead : IDisposable
 {
     private readonly CsvMetadataReader csvMetadataReader = new(new MockLogger<CsvMetadataReader>().Object);
     private readonly string testDataDirectory;
@@ -24,11 +25,11 @@ public class TestRead: IDisposable
         testDataDirectory = Path.Combine(Path.GetTempPath(), nameof(TestRead), Guid.NewGuid().ToString());
         Directory.CreateDirectory(testDataDirectory);
     }
-    
+
     private string MakeRealCsvFile(string csvContent)
     {
         var csvPath = Path.Combine(testDataDirectory, "metadata.csv");
-      
+
         File.WriteAllText(csvPath, csvContent);
         return csvPath;
     }
@@ -43,7 +44,7 @@ public class TestRead: IDisposable
     }
 
     [Fact]
-    public void Read_WithOnlyRequiredColumnsAndClaimants_ParsesCsvIntoLines()
+    public void Read_WithOnlyRequiredColumnsAndClaimants_ParsesCsvWithoutError()
     {
         using var csvStream = new StringReader(
             """
@@ -53,51 +54,14 @@ public class TestRead: IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
         Assert.Empty(csvParseErrors);
 
-        CsvMetadataLineHelper.AssertCsvLinesMatch(result,
-            new CsvLine
-            {
-                id = "123",
-                Court = "UKUT-IAC",
-                FilePath = "/test/data/test-case.pdf",
-                Extension = ".pdf",
-                DecisionDateTime = new DateTime(2025, 01, 15, 09, 00, 00, DateTimeKind.Utc),
-                CaseNo = "IA/2025/001",
-                Jurisdictions = [],
-                Claimants = "Smith",
-                Appellants = null,
-                Respondent = "Secretary of State for the Home Department",
-                MainCategory = null,
-                MainSubcategory = null,
-                SecCategory = null,
-                SecSubcategory = null,
-                Ncn = null,
-                HeadnoteSummary = null,
-                Skip = false
-            },
-            new CsvLine
-            {
-                id = "124",
-                Court = "UKFTT-TC",
-                FilePath = "/test/data/test-case2.docx",
-                Extension = ".docx",
-                DecisionDateTime = new DateTime(2025, 01, 16, 10, 00, 00, DateTimeKind.Utc),
-                CaseNo = "IA/2025/002",
-                Jurisdictions = [],
-                Claimants = "Jones",
-                Appellants = null,
-                Respondent = "HMRC",
-                MainCategory = null,
-                MainSubcategory = null,
-                SecCategory = null,
-                SecSubcategory = null,
-                Ncn = null,
-                HeadnoteSummary = null,
-                Skip = true
-            }
-        );
+        var parsedLine = Assert.Single(result);
+        Assert.Equal("123", parsedLine.id);
+        Assert.False(parsedLine.Skip);
+
+        Assert.Equal(["Line 3"], skippedCsvLineIdentifiers);
     }
 
     [Theory]
@@ -114,7 +78,7 @@ public class TestRead: IDisposable
     [InlineData("false")]
     [InlineData("False")]
     [InlineData("FALSE")]
-    public void Read_WithFalsySkipValues_ParsesSkipAsFalse(string skipValue)
+    public void Read_WithFalsySkipValues_ReturnsLine(string skipValue)
     {
         using var csvStream = new StringReader(
             $"""
@@ -123,9 +87,11 @@ public class TestRead: IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
 
         Assert.Empty(csvParseErrors);
+        Assert.Empty(skippedCsvLineIdentifiers);
+
         var line = Assert.Single(result);
         Assert.False(line.Skip);
     }
@@ -139,7 +105,7 @@ public class TestRead: IDisposable
     [InlineData("1")]
     [InlineData("yes")]
     [InlineData("T")]
-    public void Read_WithTruthySkipValues_ParsesSkipAsTrue(string skipValue)
+    public void Read_WithTruthySkipValues_DoesNotReturnLine(string skipValue)
     {
         using var csvStream = new StringReader(
             $"""
@@ -148,11 +114,39 @@ public class TestRead: IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
 
         Assert.Empty(csvParseErrors);
-        var line = Assert.Single(result);
-        Assert.True(line.Skip);
+        Assert.Empty(result);
+        Assert.Single(skippedCsvLineIdentifiers);
+    }
+
+    [Fact]
+    public void Read_WithDodgySkippedLines_DoesNotOutputValidationErrors()
+    {
+        using var csvStream = new StringReader(
+            """
+            id,FilePath,Extension,decision_datetime,CaseNo,court,appellants,respondent,skip
+            123 , this_is_a_good_unskipped_line.pdf , .pdf , 2025-01-15 09:00:00 , IA/2025/001,UKUT-IAC , Smith , Secretary of State for the Home Department,
+            124, missing_extension.docx  ,  ,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,skip me
+            125, missing_appellant.docx  ,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,  ,HMRC,skip me
+            126, missing_date.docx  ,.docx,  ,IA/2025/002,UKFTT-TC,Jones,HMRC,skip me
+            127, date_fails_validation.docx  ,.docx, not-a-date ,IA/2025/002,UKFTT-TC,Jones,HMRC,skip me
+            128, date_fails_conversion.docx  ,.docx, 2025-99-99 ,IA/2025/002,UKFTT-TC,Jones,HMRC,skip me
+            """
+        );
+
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors);
+
+        // Assert that the good line is returned
+        var parsedLine = Assert.Single(result);
+        Assert.Equal("123", parsedLine.id);
+
+        // Assert all skipped lines are returned despite validation errors        
+        Assert.Equal(5, skippedCsvLineIdentifiers.Count);
+
+        // Assert that there are no validation errors returned
+        Assert.Empty(csvParseErrors);
     }
 
     [Theory]
@@ -167,20 +161,21 @@ public class TestRead: IDisposable
     [InlineData(nameof(CsvLine.Skip))]
     public void Read_WithMissingRequiredColumns_ReturnsParseErrors(string missingColumn)
     {
-        var validCsvWithAllRequiredColumns = """
-                id,FilePath,Extension,DecisionDateTime,CaseNo,Court,claimants,Respondent,Skip
-                123 , /test/data/test-case.pdf , .pdf , 2025-01-15 09:00:00 , IA/2025/001,UKUT-IAC , Smith , Secretary of State for the Home Department,
-                124,/test/data/test-case2.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,
-                125,/test/data/test-case2.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,skip
-                """;
-        
+        var validCsvWithAllRequiredColumns =
+            """
+            id,FilePath,Extension,DecisionDateTime,CaseNo,Court,claimants,Respondent,Skip
+            123 , /test/data/test-case.pdf , .pdf , 2025-01-15 09:00:00 , IA/2025/001,UKUT-IAC , Smith , Secretary of State for the Home Department,
+            124,/test/data/test-case2.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,
+            125,/test/data/test-case2.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,skip
+            """;
+
         var csvWithMissingColumn = validCsvWithAllRequiredColumns.Replace(missingColumn, "missing_column");
-        
+
         using var csvStream = new StringReader(
             csvWithMissingColumn
         );
 
-        var result = csvMetadataReader.Read(csvStream, out var csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
 
         Assert.Empty(result);
         Assert.All(csvParseErrors, csvParseError => Assert.Contains(missingColumn, csvParseError));
@@ -191,11 +186,14 @@ public class TestRead: IDisposable
     [InlineData("     ", new string[] { })]
     [InlineData(",   ,  ", new string[] { })]
     [InlineData("\"Community,Environment\"", new[] { "Community", "Environment" })]
-    [InlineData("\"Community, Environment,Other , Another ,\"", new[] { "Community", "Environment", "Other", "Another" })]
-    [InlineData("\"Community, Environment,,  ,Other , Another ,\"", new[] { "Community", "Environment", "Other", "Another" })]
+    [InlineData("\"Community, Environment,Other , Another ,\"",
+        new[] { "Community", "Environment", "Other", "Another" })]
+    [InlineData("\"Community, Environment,,  ,Other , Another ,\"",
+        new[] { "Community", "Environment", "Other", "Another" })]
     [InlineData("\"Environment\"", new[] { "Environment" })]
     [InlineData("Environment", new[] { "Environment" })]
-    public void Read_WithJurisdictions_StoresTrimmedNonEmptyJurisdictions(string csvJurisdictions, string[] expectedJurisdictions)
+    public void Read_WithJurisdictions_StoresTrimmedNonEmptyJurisdictions(string csvJurisdictions,
+        string[] expectedJurisdictions)
     {
         using var csvStream = new StringReader(
             $"""
@@ -204,7 +202,7 @@ public class TestRead: IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _);
+        var result = csvMetadataReader.Read(csvStream, out _, out _);
 
         var line = Assert.Single(result);
         Assert.Equal(expectedJurisdictions, line.Jurisdictions);
@@ -222,7 +220,7 @@ public class TestRead: IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _);
+        var result = csvMetadataReader.Read(csvStream, out _, out _);
 
         Assert.Collection(result,
             line => Assert.Equivalent(new Dictionary<string, string>
@@ -303,9 +301,10 @@ public class TestRead: IDisposable
         // Arrange - set up stream reader
         using var csvStream = new StringReader(csvContent);
 
-        //Act
-        var result = csvMetadataReader.Read(csvStream, out _);
+        // Act
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _);
 
+        // Assert - results
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
             new CsvLine
             {
@@ -459,7 +458,8 @@ public class TestRead: IDisposable
                 WebArchiving = null,
                 HeadnoteSummary = "One Jurisdiction",
                 Uuid = null
-            }, new CsvLine
+            },
+            new CsvLine
             {
                 id = "129",
                 Court = "UKUT-IAC",
@@ -502,30 +502,12 @@ public class TestRead: IDisposable
                 HeadnoteSummary = "With UUID",
                 Uuid = "ba2c15ca-6d3d-4550-8975-b516e3c0ed2d",
                 Skip = false
-            },
-            new CsvLine
-            {
-                id = "131",
-                Court = "UKUT-IAC",
-                FilePath = "/test/data/test-case10.pdf",
-                Extension = ".pdf",
-                DecisionDateTime = new DateTime(2025, 01, 20, 14, 00, 00, DateTimeKind.Utc),
-                CaseNo = "IA/2025/009",
-                Jurisdictions = [],
-                Claimants = "Berry",
-                Appellants = null,
-                Respondent = "Home Office",
-                MainCategory = null,
-                MainSubcategory = null,
-                SecCategory = null,
-                SecSubcategory = null,
-                Ncn = null,
-                WebArchiving = null,
-                HeadnoteSummary = "With Skip",
-                Uuid = null,
-                Skip = true
             }
         );
+
+        // Assert - marked as skip lines
+        var skippedLine = Assert.Single(skippedCsvLineIdentifiers);
+        Assert.Equal("Line 11", skippedLine);
     }
 
     [Fact]
@@ -545,7 +527,7 @@ public class TestRead: IDisposable
             """
         );
 
-        var validLines = csvMetadataReader.Read(csvStream, out var failedToParseLines);
+        var validLines = csvMetadataReader.Read(csvStream, out _, out var failedToParseLines);
 
         Assert.Equal(3, validLines.Count);
         Assert.Equal(5, failedToParseLines.Count);
@@ -553,11 +535,11 @@ public class TestRead: IDisposable
         Assert.Equivalent(
             new List<string>
             {
-                "Line 4: Id 123 - Must have either claimants or appellants. At least one is required.",
+                "Line 4: Id 123 - Must have either claimants or appellants. At least one is required. [123,NoClaimants.pdf,.pdf,2025-01-15 09:00:00,IA/2025/001,UKUT-IAC,,Secretary of State for the Home Department,,,,,]",
                 "Line 5: Field at index '5' does not exist. You can ignore missing fields by setting MissingFieldFound to null. [completely invalid line]",
                 "Line 6: Field at index '12' does not exist. You can ignore missing fields by setting MissingFieldFound to null. [124,MissingAComma.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,Bad subcategory,,]",
-                "Line 7: Id 125 - main_subcategory 'Bad main subcategory' cannot exist without main_category being defined",
-                "Line 8: Id 126 - sec_subcategory 'Bad secondary subcategory' cannot exist without sec_category being defined"
+                "Line 7: Id 125 - main_subcategory 'Bad main subcategory' cannot exist without main_category being defined [125,MissingMainCategory.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,Bad main subcategory,,,]",
+                "Line 8: Id 126 - sec_subcategory 'Bad secondary subcategory' cannot exist without sec_category being defined [126,MissingSecondaryCategory.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,,,Bad secondary subcategory,]"
             },
             failedToParseLines);
     }
@@ -574,7 +556,7 @@ public class TestRead: IDisposable
         using var csvStream = new StringReader(csvContent);
 
         //Act
-        var result = csvMetadataReader.Read(csvStream, out _);
+        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _);
 
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
             new CsvLine
@@ -598,68 +580,70 @@ public class TestRead: IDisposable
                 HeadnoteSummary = "This is a test headnote summary",
                 Uuid = null,
                 Skip = false
-            },
-            new CsvLine
-            {
-                id = "124",
-                Court = "UKFTT-TC",
-                FilePath = "/test/data/test-case2.docx",
-                Extension = ".docx",
-                DecisionDateTime = new DateTime(2025, 01, 16, 10, 00, 00, DateTimeKind.Utc),
-                CaseNo = "IA/2025/002",
-                Jurisdictions = [],
-                Claimants = null,
-                Appellants = "Jones",
-                Respondent = "HMRC",
-                MainCategory = "Tax",
-                MainSubcategory = "VAT Appeals",
-                SecCategory = "Employment",
-                SecSubcategory = "Tribunal Procedure",
-                Ncn = null,
-                WebArchiving = null,
-                HeadnoteSummary = "Another test case",
-                Uuid = null,
-                Skip = true
             }
         );
+
+        Assert.Equal(["Line 3"], skippedCsvLineIdentifiers);
     }
 
-    [Fact]
-    public void Read_WithMixedDateFormats_ParsesValidLines()
+    [Theory]
+    [InlineData("2025-01-15", 2025, 01, 15, 0, 0, 0)]
+    [InlineData("2025/01/15", 2025, 01, 15, 0, 0, 0)]
+    [InlineData("2025 01 15", 2025, 01, 15, 0, 0, 0)]
+    [InlineData("2025-1-15", 2025, 01, 15, 0, 0, 0)]
+    [InlineData("2025-01-1", 2025, 01, 01, 0, 0, 0)]
+    [InlineData("2025-02-28", 2025, 02, 28, 0, 0, 0)]
+    [InlineData("2024-02-29", 2024, 02, 29, 0, 0, 0)] // Leap year
+    [InlineData("2025-01-15 09:00:00", 2025, 01, 15, 09, 00, 00)]
+    [InlineData("2025-01-15T09:00:00Z", 2025, 01, 15, 09, 00, 00)]
+    [InlineData("  2025-01-15  ", 2025, 01, 15, 0, 0, 0)]
+    public void Read_WithValidDecisionDates_ParsesCorrectDate(string dateString, int year, int month, int day, int hour,
+        int minute, int second)
     {
-        const string csvContent =
-            """
-            id,filepath,extension,decision_datetime,caseno,court,appellants,claimants,respondent,skip
-            123,good.pdf,.pdf,  2025-01-15  ,IA/2025/001,UKUT-IAC,,Smith,Secretary of State for the Home Department,
-            123,good.pdf,.pdf,  2025/01/15  ,IA/2025/001,UKUT-IAC,,Smith,Secretary of State for the Home Department,
-            123,good.pdf,.pdf,  2025 01 15  ,IA/2025/001,UKUT-IAC,,Smith,Secretary of State for the Home Department,
-
-            125,bad.pdf,.pdf,  01/16/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,
-            125,bad.pdf,.pdf,  31/01/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,
-
-            124,good_with_time.docx,.docx,  2025-01-16 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,
-            """;
-
-        // Arrange - set up stream reader
-        using var csvStream = new StringReader(csvContent);
-
-        //Act
-        var result = csvMetadataReader.Read(csvStream, out var csvParseErrors);
-
-        Assert.Collection(result,
-            line => Assert.Equal(new DateTime(2025, 01, 15, 0, 0, 0, DateTimeKind.Utc), line.DecisionDateTime),
-            line => Assert.Equal(new DateTime(2025, 01, 15, 0, 0, 0, DateTimeKind.Utc), line.DecisionDateTime),
-            line => Assert.Equal(new DateTime(2025, 01, 15, 0, 0, 0, DateTimeKind.Utc), line.DecisionDateTime),
-            line => Assert.Equal(new DateTime(2025, 01, 16, 10, 00, 00, DateTimeKind.Utc), line.DecisionDateTime)
+        using var csvStream = new StringReader(
+            $"""
+             id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip
+             123,/test/data/test.pdf,.pdf,{dateString},IA/2025/001,UKUT-IAC,Smith,HMRC,
+             """
         );
 
-        Assert.Equivalent(
-            new List<string>
-            {
-                "Line 6: \"01/16/2025 10:00:00\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format [125,bad.pdf,.pdf,  01/16/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]",
-                "Line 7: \"31/01/2025 10:00:00\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format [125,bad.pdf,.pdf,  31/01/2025 10:00:00  ,IA/2025/002,UKFTT-TC,Jones,,HMRC,]"
-            },
-            csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
+
+        Assert.Empty(csvParseErrors);
+        var line = Assert.Single(result);
+        Assert.Equal(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc), line.DecisionDateTime);
+    }
+
+    [Theory]
+    [InlineData("9315-01-2025",
+        "Could not convert field `DecisionDateTime` with value \"9315-01-2025\" to type `DateTime`")]
+    [InlineData("15-01-2025",
+        "\"15-01-2025\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format")]
+    [InlineData("01/15/2025",
+        "\"01/15/2025\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format")]
+    [InlineData("not-a-date",
+        "\"not-a-date\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format")]
+    [InlineData("202",
+        "\"202\" failed validation with message: Unsupported decision date. Ensure dates are in yyyy-MM-dd format")]
+    [InlineData("", "\"\" failed validation with message: Decision date must be provided")]
+    [InlineData("    ", "\"\" failed validation with message: Decision date must be provided")]
+    public void Read_WithInvalidDecisionDates_ReturnsParseError(string dateString, string expectedErrorMessage)
+    {
+        var line = $"123,/test/data/test.pdf,.pdf,{dateString},IA/2025/001,UKUT-IAC,Smith,HMRC,";
+        expectedErrorMessage = $"Line 2: {expectedErrorMessage} [{line}]";
+
+        using var csvStream = new StringReader(
+            $"""
+             id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip
+             {line}
+             """
+        );
+
+        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors);
+
+        Assert.Empty(result);
+        var error = Assert.Single(csvParseErrors);
+        Assert.Equal(expectedErrorMessage, error);
     }
 
     [Fact]
@@ -667,11 +651,11 @@ public class TestRead: IDisposable
     {
         // Arrange - Create helper with non-existent CSV path
         var nonExistentPath = Path.Combine(testDataDirectory, "does-not-exist.csv");
-     
+
         // Act & Assert
         Assert.Throws<FileNotFoundException>(() =>
         {
-            _ = csvMetadataReader.Read(nonExistentPath, out _);
+            _ = csvMetadataReader.Read(nonExistentPath, out _, out _);
         });
     }
 
@@ -679,10 +663,12 @@ public class TestRead: IDisposable
     public void Read_WithEmptyFile_ReturnsEmptyList()
     {
         // Arrange - Create empty CSV file with just headers
-        var emptyCsvPath = MakeRealCsvFile("id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
-            
+        var emptyCsvPath =
+            MakeRealCsvFile(
+                "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
+
         // Act
-        var lines = csvMetadataReader.Read(emptyCsvPath, out _);
+        var lines = csvMetadataReader.Read(emptyCsvPath, out _, out _);
 
         // Assert
         Assert.Empty(lines);


### PR DESCRIPTION
When processing backlog CSV files, any row with a validation problem was reported as a parse error - even rows that had been deliberately marked to skip. This made the error output noisy and harder to act on and the errors for those rows often also lacked enough context to understand what went wrong.

## Changes

- Add missing tests for CsvProperties population in Read method (no changes anticipated here but added whilst in the area)
- Add dedicated converter tests - previously the ones in `TestRead` were good enough but now we're not able to test the output of the skipped lines directly, just the logic surrounding the results of it.
- Improve date validation error messages
- Don't class validation issues on skipped lines as errors
- Remove skipped lines from overall records returned (as some validation issues prevent records being made)
- Improve validation messages to always include the name and value of field and full line contents
- Identify skipped lines by csv line number instead of identifier - this is because the id field is not unique and not always present on skipped records