### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Set up .NET environment (assuming C# is the primary language)
       - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '8.0.x' # Adjust to your target version
 


### PR DESCRIPTION
This PR pins third-party GitHub Actions to full commit SHAs for supply-chain security.

This has been done automatically by [pinact](https://github.com/suzuki-shunsuke/pinact). When reviewing please confirm that the SHAs are correct, zizmor will alert if not.

As a maintainer, please merge this PR once approved.