### PR TITLE
feat(backlog): add breakdown by file extension to final stats logging

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -115,19 +115,21 @@ internal class BacklogParserWorker(
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
-            ? $"[{string.Join(", ", skippedCsvLineIdentifiers)}]"
+            ? StringJoinFirstFive(skippedCsvLineIdentifiers, ", ")
             : string.Empty;
-
+        var successfulFileExtensionBreakdown = string.Join(", ", successfulNewLines.GroupBy(l => l.Extension).Select(g => $"{g.Count()} {g.Key}"));
+        
         logger.LogInformation("""
                               ---------------------------
                               Successfully processed {SuccessfulLinesCount} of {CsvLinesCount} csv lines, of which:
-                                - {NewLinesCount} lines were new
-                                - {MarkedToSkipLineCount} lines were marked in the csv to skip {MarkedToSkipIds}
+                                - {NewLinesCount} lines were new ({SuccessfulFileExtensionBreakdown})
+                                - {MarkedToSkipLineCount} lines were marked in the csv to skip ({MarkedToSkipIds})
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
             numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
             numAllLinesInCsv,
             successfulNewLines.Count,
+            successfulFileExtensionBreakdown,
             numSkippedCsvLines, markedAsSkipIds,
             alreadyDoneLines.Count
         );
@@ -162,27 +164,32 @@ internal class BacklogParserWorker(
                     f => f.line.id);
 
             var groupedErrorDescriptions = failedIdsGroupedByErrorMessage.Select(groupOfErrors =>
-            {
-                var affectedIds = groupOfErrors.Count() <= 5
-                    ? string.Join(", ", groupOfErrors)
-                    : string.Join(", ", groupOfErrors.Take(5)) + "...";
-                return
-                    $"  - {groupOfErrors.Count()} lines failed with exception message \"{groupOfErrors.Key}\". Ids affected were: ({affectedIds})";
-            });
-
+                $"  - {groupOfErrors.Count()} lines failed with exception message \"{groupOfErrors.Key}\". Ids affected were: ({StringJoinFirstFive(groupOfErrors, ", ")})");
+            var failedFileExtensionBreakdown = string.Join(", ", failedToProcessLines.GroupBy(l => l.line.Extension).Select(g => $"{g.Count()} {g.Key}"));
 
             logger.LogError("""
                             ---------------------------
-                            Failed to process {FailedLineCount} lines, of which:
+                            Failed to process {FailedLineCount} lines ({FailedFileExtensionBreakdown}), of which:
                             {GroupedErrorDescriptions}
                             """,
-                failedToProcessLines.Count, string.Join(Environment.NewLine, groupedErrorDescriptions));
+                failedToProcessLines.Count,
+                failedFileExtensionBreakdown,
+                StringJoinFirstFive(groupedErrorDescriptions, Environment.NewLine)
+            );
         }
 
         if (failedToProcessLines.Count == 0 && csvParseErrors.Count == 0)
         {
             logger.LogInformation("No failed lines");
         }
+    }
+
+    private static string StringJoinFirstFive(IEnumerable<string> unenumeratedCollection, string separator)
+    {
+        var array = unenumeratedCollection as string[] ?? unenumeratedCollection.ToArray();
+        return array.Length <= 5
+            ? string.Join(separator, array)
+            : string.Join(separator, array.Take(5)) + "...";
     }
 
     private Api.Response CreateResponse(CsvLine csvLine, string mimeType, byte[] sourceContent, bool isStub)

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -228,8 +228,8 @@ namespace test.backlog.EndToEndTests
                               .VerifyLog("""
                                          ---------------------------
                                          Successfully processed 4 of 4 csv lines, of which:
-                                           - 2 lines were new
-                                           - 1 lines were marked in the csv to skip [Line 5]
+                                           - 2 lines were new (1 .docx, 1 .pdf)
+                                           - 1 lines were marked in the csv to skip (Line 5)
                                            - 1 lines were skipped because they had been processed in a previous run
                                          """, LogLevel.Information);
         }


### PR DESCRIPTION
It's useful to know whether or not it's just a particular file type (e.g. `.docx`) is failing to make it through the parser. This PR adds in a little extra logging into the final statistics and truncates large lists to make them more readable