### PR TITLE
chore(iac): mark false positive for Lambda container in `.wiz`

### DIFF
--- a/.wiz
+++ b/.wiz
@@ -1,4 +1,10 @@
 ignore:
+  iac:
+    a933f7a2-ea43-40c8-8816-38ea2a4e36a1:
+      /TRE/DockerfileV2:
+        reason: FALSE_POSITIVE
+        comment: "This image is deployed exclusively as an AWS Lambda container image. Lambda automatically runs container images with a default least-privileged Linux user when no USER instruction is specified, unlike standard Docker runtimes."
+
   sensitive_data:
     ALL:
       /test/judgments/test1.docx:


### PR DESCRIPTION
Our automated renovate docker image updates are failing Wiz checks because there is no USER instruction. Upon investigation, we've found that the USER instruction is not advised for AWS lambda docker images because AWS does its own user creation and allocation.

This PR adds an ignore in wiz for the USER instruction requirement in the TRE docker image