### PR TITLE
Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# .dockerignore
+
+# config
+.devcontainer/
+.idea/
+.git/
+.github/
+
+.DS_Store
+.editorconfig
+.gitignore
+.wiz
+renovate.json
+lm-run.ps1
+
+# local .NET build artefacts
+*/bin/
+bin/
+*/obj/
+obj/
+
+# documentation
+docs/
+*.md
+
+# tests
+test/
+NationalArchives.FindCaseLaw.Utils.Tests/
+
+# backlog parser (not needed for normal parser deployment)
+backlog/

--- a/TRE/DockerfileV2
+++ b/TRE/DockerfileV2
@@ -20,8 +20,10 @@ RUN dotnet publish TRE/TRE.csproj -c Release -o /src --no-restore
 
 FROM base AS final
 
-RUN dnf upgrade -y
-RUN dnf clean all --enablerepo=\*
+# Use one RUN so package metadata does not clog image layer
+RUN dnf upgrade -y && \
+    dnf clean all --enablerepo=\* && \
+    rm -rf /var/cache/dnf
 
 WORKDIR /var/task
 

--- a/TRE/DockerfileV2
+++ b/TRE/DockerfileV2
@@ -4,9 +4,15 @@ WORKDIR /var/task
 FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:27ee23dc62a99643cfab2dc291582b6f2611ddc2598a0ff0958ddd0972012e52 AS build-env
 
 WORKDIR /src
-COPY ["TRE/TRE.csproj",""]
-COPY . ./
+# Copy each csproj over then restore so this expensive operation can be cached
+COPY ["NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj", "NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj"]
+RUN dotnet restore NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj
+COPY ["judgments.csproj", "judgments.csproj"]
+RUN dotnet restore judgments.csproj
+COPY ["TRE/TRE.csproj", "TRE/TRE.csproj"]
 RUN dotnet restore TRE/TRE.csproj
+# Copy the rest of the repo over
+COPY . ./
 
 FROM build-env AS publish
 

--- a/TRE/DockerfileV2
+++ b/TRE/DockerfileV2
@@ -16,7 +16,7 @@ COPY . ./
 
 FROM build-env AS publish
 
-RUN dotnet publish TRE/TRE.csproj -c Release -o /src --no-restore
+RUN dotnet publish TRE/TRE.csproj -c Release -o /app/publish --no-restore
 
 FROM base AS final
 
@@ -27,6 +27,6 @@ RUN dnf upgrade -y && \
 
 WORKDIR /var/task
 
-COPY --from=publish /src ${LAMBDA_TASK_ROOT}
+COPY --from=publish /app/publish ${LAMBDA_TASK_ROOT}
 
 CMD ["TRE::UK.Gov.NationalArchives.CaseLaw.TRE.Lambda::FunctionHandler"]


### PR DESCRIPTION
Some optimisations to improve build speed and caching and to control what is in the published TRE parser docker image.

## Changes:

- Add .dockerignore to stop entire repo being copied to build stage
- Only copy publishable files to final Docker image (rather than the entire source code)
- Cache dotnet restore for individual projects
- Combine dnf upgrade and cleanup steps to optimise image size
