### PR TITLE
Backlog: Split DI container configuration from DI container creation

### DIFF
--- a/backlog/backlog.csproj
+++ b/backlog/backlog.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <RootNamespace>Backlog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -146,8 +146,10 @@ public class Program
         var bucketName = Environment.GetEnvironmentVariable("BUCKET_NAME") ??
                          throw new InvalidOperationException("BUCKET_NAME environment variable not set");
 
-        var serviceProvider = ConfigureDependencyInjection(pathToDataFolder, trackerPath, judgmentsFilePath,
+        var services = new ServiceCollection();
+        ConfigureDependencyInjection(services, pathToDataFolder, trackerPath, judgmentsFilePath,
             hmctsFilePath, bucketName);
+        var serviceProvider = services.BuildServiceProvider();
 
         var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
         try
@@ -179,10 +181,9 @@ public class Program
             ? _dependencyInjectionOverrides
             : throw new InvalidOperationException("Cannot use dependency injection overrides in production");
 
-    internal static ServiceProvider ConfigureDependencyInjection(string pathToDataFolder, string trackerPath,
+    internal static void ConfigureDependencyInjection(IServiceCollection services, string pathToDataFolder, string trackerPath,
         string judgmentsFilePath, string hmctsFilePath, string bucketName)
     {
-        var services = new ServiceCollection();
         services.AddLogging(loggingBuilder =>
         {
             var logFilePath = Path.Combine(pathToDataFolder, $"log_{DateTime.Now:yy-MM-dd_HH-mm}.txt");
@@ -209,11 +210,9 @@ public class Program
         {
             OverrideDependencyInjection(services);
         }
-
-        return services.BuildServiceProvider();
     }
 
-    private static void OverrideDependencyInjection(ServiceCollection services)
+    private static void OverrideDependencyInjection(IServiceCollection services)
     {
         foreach (var (serviceType, instance, replace) in DependencyInjectionOverrides)
         {

--- a/test/backlog/TestProgram.cs
+++ b/test/backlog/TestProgram.cs
@@ -1,31 +1,39 @@
 #nullable enable
 
-using Microsoft.Extensions.DependencyInjection;
-
 using System;
 
-using Xunit;
-using Microsoft.Extensions.Time.Testing;
-using UK.Gov.Legislation.Judgments.Parse;
+using Microsoft.Extensions.DependencyInjection;
+
 using test.backlog.EndToEndTests;
+
+using Xunit;
 
 namespace test.backlog;
 
-public class TestProgram(ITestOutputHelper testOutputHelper) : BaseEndToEndTests(testOutputHelper)
+public class TestProgram(ITestOutputHelper testOutputHelper)
+    : BaseEndToEndTests(
+        testOutputHelper) // This isn't an end to end test but it does touch static state shared with the end to end tests
 {
-    [Fact]
-    public void ConfigureDependencyInjection_HasAccurateTimeProviderByDefault()
+    protected override void Dispose(bool disposing)
     {
-        // Ensure that we're not running with dependency injections
-        Backlog.Src.Program.DependencyInjectionOverrides.Clear();
-        
-        ServiceProvider serviceProvider = Backlog.Src.Program.ConfigureDependencyInjection("pathToDataFolder", "trackerPath", "judgmentsFilePath", "hmctsFilePath", "bucketName");
-        
-        DateTimeOffset timeProviderTime = serviceProvider.GetRequiredService<TimeProvider>().GetUtcNow();
-        
-        Assert.IsNotType<FakeTimeProvider>(serviceProvider.GetRequiredService<TimeProvider>());
-        Assert.Equal(timeProviderTime, DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        //Set IS_TEST to true so that the main dispose can clean up any state changes
+        Environment.SetEnvironmentVariable("IS_TEST", "true");
+        base.Dispose(disposing);
+    }
 
-        
+    [Fact]
+    public void ConfigureDependencyInjection_RegistersSystemTimeProvider()
+    {
+        // Ensure that we're not running with test dependency injections
+        Environment.SetEnvironmentVariable("IS_TEST", null);
+
+        var services = new ServiceCollection();
+
+        Backlog.Src.Program.ConfigureDependencyInjection(services, "pathToDataFolder", "trackerPath", "judgmentsFilePath", "hmctsFilePath", "bucketName");
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var timeProvider = serviceProvider.GetRequiredService<TimeProvider>();
+
+        Assert.Same(TimeProvider.System, timeProvider);
     }
 }


### PR DESCRIPTION
Configuration and application setup in the Backlog parser is making it harder than necessary to make refactoring changes. This is a step towards using an apphost and more flexible configuration set up

## Changes

- Clearly define root namespace in csproj to stop linter warnings about capitalisation
- Split up DI configuration so it doesn't create a service provider
- Rework `ConfigureDependencyInjection_RegistersSystemTimeProvider` test