### PR TITLE
Backlog: Move config to options and add app host configuration

### DIFF
--- a/backlog/README.md
+++ b/backlog/README.md
@@ -162,20 +162,18 @@ This is created and populated by the Backlog Parser. It tracks which judgments h
 
 ### Environment Variables
 
-The module uses environment variables for configuration. All paths default to the application's base directory if not specified.
+The module uses environment variables for configuration. Backlog Parser settings are bound from the `BacklogParser` configuration section, so environment variables use the `BacklogParser__` prefix.
 
-| Variable              | Description                                                                                            | Default                                                         |
-|-----------------------|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| `COURT_METADATA_PATH` | Path to the CSV file containing court metadata                                                         | `{BaseDir}/court_metadata.csv`                                  |
-| `DATA_FOLDER_PATH`    | Path to the folder containing judgment data files                                                      | `{BaseDir}`                                                     |
-| `TRACKER_PATH`        | Path to the CSV file tracking uploaded judgments                                                       | `{BaseDir}/uploaded-production.csv`                             |
-| `OUTPUT_PATH`         | Path where generated bundle files will be saved                                                        | `{BaseDir}`                                                     |
-| `JUDGMENTS_FILE_PATH` | The filepath prefix used in the court metadata csv (used to crossference with file-metadata.csv paths) | `""`                                                            |
-| `HMCTS_FILES_PATH`    | The filepath prefix used in the file-metadata csv (used to crossference with court metadata csv paths) | `""`                                                            |
-| `AWS_REGION`          | AWS region for S3 bucket operations                                                                    | Defaults to the region configured in AWS deployment environment |
-| `BUCKET_NAME`         | AWS bucket to upload processed files and xml to                                                        | None - must be set if not using dry run mode                    |
-
-where `{BaseDir}` is where the application's assemblies are (usually `backlog/bin/Debug/net8.0` when running locally)
+| Variable                                        | Description                                                                                               | Default                                                         |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `BacklogParser__CourtMetadataFilePath`          | Path to the CSV file containing court metadata                                                            | None - required                                                 |
+| `BacklogParser__DataFolderPath`                 | Path to the folder containing judgment data files                                                         | None - required                                                 |
+| `BacklogParser__TrackerFilePath`                | Path to the CSV file tracking uploaded judgments                                                          | None - required                                                 |
+| `BacklogParser__OutputFolderPath`               | Path to where generated bundle files will be saved                                                        | None - required                                                 |
+| `BacklogParser__MetadataProvidedFilePathPrefix` | The filepath prefix used in the court metadata csv (used to cross-reference with file-metadata.csv paths) | `""`                                                            |
+| `BacklogParser__TransferMetadataFilePathPrefix` | The filepath prefix used in the file-metadata csv (used to cross-reference with court metadata csv paths) | `""`                                                            |
+| `BacklogParser__BucketName`                     | AWS bucket to upload processed files and xml to                                                           | None - must be set unless using dry run mode                    |
+| `AWS_REGION`                                    | AWS region for S3 bucket operations                                                                       | Defaults to the region configured in AWS deployment environment |
 
 #### AWS Configuration
 

--- a/backlog/backlog.csproj
+++ b/backlog/backlog.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.27" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.28" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.23" />
     <ProjectReference Include="../TRE/TRE.csproj" />

--- a/backlog/src/BacklogFiles.cs
+++ b/backlog/src/BacklogFiles.cs
@@ -4,7 +4,10 @@ using System;
 using System.IO;
 using System.Linq;
 
+using Backlog.Options;
+
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Backlog.Src
 {
@@ -12,21 +15,21 @@ namespace Backlog.Src
     /// Provides file operations for processing backlog documents, including UUID lookup,
     /// file reading, and copying operations between tribunal and transfer metadata systems.
     /// </summary>
-    class BacklogFiles
+    internal class BacklogFiles
     {
         private readonly string transferMetadataPath;
         private readonly ILogger<BacklogFiles> logger;
-        private readonly string judgmentsFilePath;
-        private readonly string hmctsFilePath;
+        private readonly IOptions<BacklogParserOptions> backlogParserOptions;
         private readonly DirectoryInfo courtDocumentsDirectory;
 
-        public BacklogFiles(ILogger<BacklogFiles> logger, string pathToDataFolder, string judgmentsFilePath, string hmctsFilePath)
+        public BacklogFiles(ILogger<BacklogFiles> logger, IOptions<BacklogParserOptions> backlogParserOptions)
         {
             this.logger = logger;
-            this.judgmentsFilePath = judgmentsFilePath;
-            this.hmctsFilePath = hmctsFilePath;
+            this.backlogParserOptions = backlogParserOptions;
+
+            var pathToDataFolder = backlogParserOptions.Value.DataFolderPath;
             transferMetadataPath = Path.Combine(pathToDataFolder, TDR_METADATA_DIR, METADATA_FILENAME);
-            
+
             courtDocumentsDirectory = new DirectoryInfo(Path.Combine(pathToDataFolder, COURT_DOCUMENTS_DIR));
             if (!courtDocumentsDirectory.Exists)
             {
@@ -38,7 +41,7 @@ namespace Backlog.Src
         private const string TDR_METADATA_DIR = "tdr_metadata";
         private const string COURT_DOCUMENTS_DIR = "court_documents";
         private const string METADATA_FILENAME = "file-metadata.csv";
-        
+
         private const int MIN_METADATA_COLUMNS = 27; // Minimum columns expected in transfer metadata
 
         private const int FILE_TYPE_COLUMN = 2; // file_type is column 3 (0-indexed)
@@ -49,15 +52,20 @@ namespace Backlog.Src
         /// Extracts the relative file path from tribunal metadata by removing the base judgments file path prefix.
         /// This normalizes full file paths to relative paths for consistent matching against transfer metadata.
         /// </summary>
-        /// <param name="filePath">The full file path from tribunal metadata to normalize</param>
-        /// <param name="judgmentsFilePath">The base judgments file path prefix to remove from the full path</param>
+        /// <param name="metadataProvidedFilePath">The full file path from tribunal metadata to normalize</param>
         /// <returns>The relative file path for matching against transfer metadata</returns>
-        /// <exception cref="ArgumentException">Thrown when filePath does not start with judgmentsFilePath</exception>
-        private static string GetFilePathFromTribunalMetadata(string filePath, string judgmentsFilePath)
+        /// <exception cref="ArgumentException">Thrown when filePath does not start with metadataProvidedFilePathPrefix</exception>
+        private string GetFilePathFromTribunalMetadata(string metadataProvidedFilePath)
         {
-            if (!filePath.StartsWith(judgmentsFilePath))
-                throw new ArgumentException($"FilePath {filePath} must start with {judgmentsFilePath}", nameof(filePath));
-            var relativePath = filePath.Substring(judgmentsFilePath.Length);
+            var metadataProvidedFilePathPrefix = backlogParserOptions.Value.MetadataProvidedFilePathPrefix;
+            if (!metadataProvidedFilePath.StartsWith(metadataProvidedFilePathPrefix))
+            {
+                throw new ArgumentException(
+                    $"FilePath {metadataProvidedFilePath} must start with {metadataProvidedFilePathPrefix}",
+                    nameof(metadataProvidedFilePath));
+            }
+
+            var relativePath = metadataProvidedFilePath.Substring(metadataProvidedFilePathPrefix.Length);
             return relativePath;
         }
 
@@ -65,15 +73,17 @@ namespace Backlog.Src
         /// Retrieves the UUID for a given metadata line by performing path normalization and lookup 
         /// in the transfer metadata CSV file. Combines tribunal metadata path extraction with UUID searching.
         /// </summary>
-        /// <param name="metaFilePath"></param>
+        /// <param name="metadataProvidedFilePath"></param>
         /// <returns>UUID from the transfer metadata file corresponding to the metadata line</returns>
         /// <exception cref="FileNotFoundException">Thrown when no matching UUID is found in transfer metadata</exception>
         /// <exception cref="ArgumentException">Thrown when file path normalization fails</exception>
-        internal string FindUuidInTransferMetadata(string metaFilePath)
+        internal string FindUuidInTransferMetadata(string metadataProvidedFilePath)
         {
-            var tribunalDataFilePath = GetFilePathFromTribunalMetadata(metaFilePath, judgmentsFilePath);
-            
-            logger.LogInformation("Finding UUID for {TribunalDataFilePath} in transfer metadata file {TransferMetadataPath}", tribunalDataFilePath, transferMetadataPath);
+            var tribunalDataFilePath = GetFilePathFromTribunalMetadata(metadataProvidedFilePath);
+
+            logger.LogInformation(
+                "Finding UUID for {TribunalDataFilePath} in transfer metadata file {TransferMetadataPath}",
+                tribunalDataFilePath, transferMetadataPath);
 
             if (!File.Exists(transferMetadataPath))
                 throw new FileNotFoundException($"Metadata file not found at {transferMetadataPath}");
@@ -88,8 +98,9 @@ namespace Backlog.Src
                 if (!fileType.Equals("File")) continue;
 
                 var filePath = parts[FILE_PATH_COLUMN];
-                if (!filePath.StartsWith(hmctsFilePath)) continue;
-                var metadataRelativePath = filePath.Substring(hmctsFilePath.Length);
+                if (!filePath.StartsWith(backlogParserOptions.Value.TransferMetadataFilePathPrefix)) continue;
+
+                var metadataRelativePath = filePath.Substring(backlogParserOptions.Value.TransferMetadataFilePathPrefix.Length);
 
                 if (metadataRelativePath.Replace('\\', '/').Equals(tribunalDataFilePath.Replace('\\', '/')))
                     return parts[UUID_COLUMN];
@@ -124,5 +135,4 @@ namespace Backlog.Src
             return File.ReadAllBytes(filesWithUuid.Single().FullName);
         }
     }
-
 }

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -7,8 +7,10 @@ using System.Linq;
 using System.Security.Cryptography;
 
 using Backlog.Csv;
+using Backlog.Options;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using Api = UK.Gov.NationalArchives.Judgments.Api;
 
@@ -24,26 +26,28 @@ internal class BacklogParserWorker(
     CsvMetadataReader csvMetadataReader,
     Tracker tracker,
     Bucket bucket,
-    MetadataTransformer metadataTransformer)
+    MetadataTransformer metadataTransformer,
+    IOptions<BacklogParserOptions> backlogParserOptions)
 {
-    public int Run(bool isDryRun, uint? id, string pathToCourtMetadataFile, bool autoPublish, string pathToOutputFolder)
+    public int Run()
     {
         var parserRunId = Guid.NewGuid();
-        var lines = csvMetadataReader.Read(pathToCourtMetadataFile, out var skippedCsvLineIdentifiers,
-            out var csvParseErrors, out var numAllLinesInCsv);
+        var lines = csvMetadataReader.Read(out var skippedCsvLineIdentifiers, out var csvParseErrors,
+            out var numAllLinesInCsv);
         if (lines.Count == 0)
         {
             logger.LogCritical("No valid records found in the metadata file");
             return 1;
         }
 
-        if (id.HasValue)
+        var singleIdToRun = backlogParserOptions.Value.SingleIdToRun;
+        if (singleIdToRun.HasValue)
         {
             // Process only the specific ID
-            lines = lines.Where(line => line.id == id.Value.ToString()).ToList();
+            lines = lines.Where(line => line.id == singleIdToRun.ToString()).ToList();
             if (!lines.Any())
             {
-                logger.LogCritical("No valid records found for id {SuppliedId}", id.Value);
+                logger.LogCritical("No valid records found for id {SuppliedId}", singleIdToRun);
                 return 1;
             }
         }
@@ -66,14 +70,14 @@ internal class BacklogParserWorker(
                 }
 
                 logger.LogInformation("Processing file: {FilePath}", line.FilePath);
-                var bundle = GenerateBundle(line, autoPublish, parserRunId);
+                var bundle = GenerateBundle(line, parserRunId);
 
                 var bundleFileName = bundle.Uuid + ".tar.gz";
-                var output = Path.Combine(pathToOutputFolder, bundleFileName);
+                var output = Path.Combine(backlogParserOptions.Value.OutputFolderPath, bundleFileName);
                 logger.LogInformation("  Writing to output: {Output}", output);
                 File.WriteAllBytes(output, bundle.TarGz);
 
-                if (isDryRun)
+                if (backlogParserOptions.Value.IsDryRun)
                 {
                     logger.LogInformation("  This is a dry run - not uploading to S3");
                 }
@@ -99,7 +103,7 @@ internal class BacklogParserWorker(
             }
         }
 
-        LogFinalStatistics(logger, alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
+        LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
             skippedCsvLineIdentifiers, numAllLinesInCsv);
 
         if (failedToProcessLines.Count > 0 || csvParseErrors.Count > 0)
@@ -110,9 +114,9 @@ internal class BacklogParserWorker(
         return 0;
     }
 
-    private static void LogFinalStatistics(ILogger logger, List<CsvLine> alreadyDoneLines,
-        List<CsvLine> successfulNewLines, List<(CsvLine line, Exception exception)> failedToProcessLines,
-        List<string> csvParseErrors, List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
+    private void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
+        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
+        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
@@ -250,7 +254,7 @@ internal class BacklogParserWorker(
         return response;
     }
 
-    private Bundle GenerateBundle(CsvLine csvLine, bool autoPublish, Guid parserRunId)
+    private Bundle GenerateBundle(CsvLine csvLine, Guid parserRunId)
     {
         var tdrUuid = !string.IsNullOrWhiteSpace(csvLine.Uuid)
             ? csvLine.Uuid
@@ -267,7 +271,8 @@ internal class BacklogParserWorker(
 
         var externalMetadataFields = metadataTransformer.CsvLineToMetadataFields(csvLine);
 
-        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, csvLine.FileName, mimeType, contentHash, autoPublish, images, response.Meta, externalMetadataFields, !isStub);
+        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, csvLine.FileName, mimeType, contentHash,
+            images, response.Meta, externalMetadataFields, !isStub);
 
         return Bundle.Make(response, trePipelineMetadata, sourceContent, csvLine.FileName, images);
     }

--- a/backlog/src/Bucket.cs
+++ b/backlog/src/Bucket.cs
@@ -6,15 +6,19 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 
+using Backlog.Options;
+
+using Microsoft.Extensions.Options;
+
 namespace Backlog.Src;
 
-public class Bucket(IAmazonS3 client, string bucketName)
+public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogParserOptions)
 {
     public async Task<PutObjectResponse> UploadBundle(string key, byte[] bundle)
     {
         PutObjectRequest request = new()
         {
-            BucketName = bucketName,
+            BucketName = backlogParserOptions.Value.BucketName,
             Key = key,
             ContentType = "application/gzip",
             InputStream = new MemoryStream(bundle)

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+using Backlog.Options;
 using Backlog.Src;
 
 using CsvHelper;
@@ -15,17 +16,19 @@ using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Backlog.Csv;
 
-internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger)
+internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<BacklogParserOptions> backlogParserOptions)
 {
     private string csvName = "unknown.csv";
     private string csvHash = "unknown";
 
-    internal List<CsvLine> Read(string csvPath, out List<string> skippedCsvLineIdentifiers,
-        out List<string> csvParseErrors, out int numAllLinesInCsv)
+    internal List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
+        out int numAllLinesInCsv)
     {
+        var csvPath = backlogParserOptions.Value.CourtMetadataFilePath;
         csvName = Path.GetFileName(csvPath);
         csvHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
 

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -5,7 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Backlog.Csv;
+using Backlog.Options;
 using Backlog.TreMetadata;
+
+using Microsoft.Extensions.Options;
 
 using TRE.Metadata;
 using TRE.Metadata.Enums;
@@ -17,11 +20,11 @@ using UK.Gov.NationalArchives.Judgments.Api;
 
 namespace Backlog.Src;
 
-internal class MetadataTransformer(TimeProvider timeProvider)
+internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserOptions, TimeProvider timeProvider)
 {
     internal FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string sourceFilename, string sourceMimeType,
-        string contentHash, bool autoPublish, Image[] images, Meta responseMeta,
-        List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText)
+        string contentHash, Image[] images, Meta responseMeta, List<IMetadataField> externalMetadataFields,
+        bool xmlContainsDocumentText)
     {
         var metadata = new FullTreMetadata
         {
@@ -61,7 +64,7 @@ internal class MetadataTransformer(TimeProvider timeProvider)
                 },
                 IngestorOptions = new IngestorOptions
                 {
-                    AutoPublish = autoPublish,
+                    AutoPublish = backlogParserOptions.Value.AutoPublish,
                     Source = new SourceDocument { Format = sourceMimeType, Hash = contentHash }
                 }
             }

--- a/backlog/src/Options/BacklogParserOptions.cs
+++ b/backlog/src/Options/BacklogParserOptions.cs
@@ -1,0 +1,20 @@
+#nullable enable
+namespace Backlog.Options;
+
+public sealed class BacklogParserOptions
+{
+    public static readonly string SectionName = "BacklogParser";
+    public required string MetadataProvidedFilePathPrefix { get; set; }
+    public required string TransferMetadataFilePathPrefix { get; set; }
+    
+    public required string CourtMetadataFilePath { get; set; }
+    public required string DataFolderPath { get; set; }
+    public required string OutputFolderPath { get; set; }
+    public required string TrackerFilePath { get; set; }
+
+    public string? BucketName { get; set; }
+
+    public bool IsDryRun { get; set; }
+    public uint? SingleIdToRun { get; set; }
+    public bool AutoPublish { get; set; }
+}

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -13,6 +13,7 @@ using Backlog.Utilities;
 
 using DotNetEnv.Configuration;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -137,32 +138,7 @@ public class Program
 
     private static int RunBacklogParser(bool isDryRun, uint? id, bool autoPublish)
     {
-        var builder = Host.CreateApplicationBuilder();
-        builder.Configuration.AddDotNetEnv();
-
-        builder.Services.AddOptions<BacklogParserOptions>()
-               .Bind(builder.Configuration.GetSection(BacklogParserOptions.SectionName))
-               .Configure(options =>
-               {
-                   options.IsDryRun = isDryRun;
-                   options.SingleIdToRun = id;
-                   options.AutoPublish = autoPublish;
-               });
-
-        builder.Services.AddLogging(loggingBuilder =>
-        {
-            var serviceProvider = loggingBuilder.Services.BuildServiceProvider();
-            var options = serviceProvider.GetRequiredService<IOptions<BacklogParserOptions>>();
-            var logFilePath = Path.Combine(options.Value.DataFolderPath, $"log_{DateTime.Now:yy-MM-dd_HH-mm}.txt");
-            loggingBuilder.AddConsole()
-                          .AddFile(logFilePath,
-                              outputTemplate:
-                              "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:w4}] {Message:lj}{NewLine}{Exception}");
-        });
-
-        ConfigureDependencyInjection(builder.Services);
-
-        var appHost = builder.Build();
+        var appHost = CreateAppHost(isDryRun, id, autoPublish);
 
         using var scope = appHost.Services.CreateScope();
         var backlogParserOptions = scope.ServiceProvider.GetRequiredService<IOptions<BacklogParserOptions>>().Value;
@@ -186,6 +162,38 @@ public class Program
             logger.LogCritical(e, "Backlog Parser fell over");
             return 1;
         }
+    }
+
+    private static IHost CreateAppHost(bool isDryRun, uint? id, bool autoPublish)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddDotNetEnv();
+
+        builder.Services.AddOptions<BacklogParserOptions>()
+               .Bind(builder.Configuration.GetSection(BacklogParserOptions.SectionName))
+               .Configure(options =>
+               {
+                   options.IsDryRun = isDryRun;
+                   options.SingleIdToRun = id;
+                   options.AutoPublish = autoPublish;
+               });
+
+        // We need access to the DataFolderPath right now to configure where the log file goes, but we can't get to our
+        // bound options object until after the full service configuration has occurred. This means we need to grab the
+        // DataFolderPath value directly, bypassing the options setup
+        var dataFolderPath = builder.Configuration.GetSection(BacklogParserOptions.SectionName)
+                                    .GetValue<string>(nameof(BacklogParserOptions.DataFolderPath))!;
+
+        builder.Services.AddLogging(loggingBuilder =>
+        {
+            loggingBuilder.AddConsole()
+                          .AddFile(Path.Combine(dataFolderPath, $"log_{DateTime.Now:yy-MM-dd_HH-mm}.txt"),
+                              outputTemplate:
+                              "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:w4}] {Message:lj}{NewLine}{Exception}");
+        });
+        ConfigureDependencyInjection(builder.Services);
+
+        return builder.Build();
     }
 
     private static List<(Type serviceType, object instance, bool replace)> _dependencyInjectionOverrides = [];

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -8,13 +8,16 @@ using System.IO;
 using Amazon.S3;
 
 using Backlog.Csv;
+using Backlog.Options;
 using Backlog.Utilities;
 
-using DotNetEnv;
+using DotNetEnv.Configuration;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using UK.Gov.NationalArchives.Judgments.Api;
 
@@ -134,34 +137,49 @@ public class Program
 
     private static int RunBacklogParser(bool isDryRun, uint? id, bool autoPublish)
     {
-        Env.Load(); // required for bucket name
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddDotNetEnv();
 
-        var judgmentsFilePath = Environment.GetEnvironmentVariable("JUDGMENTS_FILE_PATH") ?? "";
-        var hmctsFilePath = Environment.GetEnvironmentVariable("HMCTS_FILES_PATH") ?? "";
-        var pathToCourtMetadataFile = Environment.GetEnvironmentVariable("COURT_METADATA_PATH") ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "court_metadata.csv");
-        var pathToDataFolder = Environment.GetEnvironmentVariable("DATA_FOLDER_PATH") ?? AppDomain.CurrentDomain.BaseDirectory;
-        var pathToOutputFolder = Environment.GetEnvironmentVariable("OUTPUT_PATH") ?? AppDomain.CurrentDomain.BaseDirectory;
-        Directory.CreateDirectory(pathToOutputFolder);
-        var trackerPath = Environment.GetEnvironmentVariable("TRACKER_PATH") ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "uploaded-production.csv");
-        var bucketName = Environment.GetEnvironmentVariable("BUCKET_NAME") ??
-                         throw new InvalidOperationException("BUCKET_NAME environment variable not set");
+        builder.Services.AddOptions<BacklogParserOptions>()
+               .Bind(builder.Configuration.GetSection(BacklogParserOptions.SectionName))
+               .Configure(options =>
+               {
+                   options.IsDryRun = isDryRun;
+                   options.SingleIdToRun = id;
+                   options.AutoPublish = autoPublish;
+               });
 
-        var services = new ServiceCollection();
-        ConfigureDependencyInjection(services, pathToDataFolder, trackerPath, judgmentsFilePath,
-            hmctsFilePath, bucketName);
-        var serviceProvider = services.BuildServiceProvider();
+        builder.Services.AddLogging(loggingBuilder =>
+        {
+            var serviceProvider = loggingBuilder.Services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<BacklogParserOptions>>();
+            var logFilePath = Path.Combine(options.Value.DataFolderPath, $"log_{DateTime.Now:yy-MM-dd_HH-mm}.txt");
+            loggingBuilder.AddConsole()
+                          .AddFile(logFilePath,
+                              outputTemplate:
+                              "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:w4}] {Message:lj}{NewLine}{Exception}");
+        });
+
+        ConfigureDependencyInjection(builder.Services);
+
+        var appHost = builder.Build();
+
+        var serviceProvider = appHost.Services;
+        var backlogParserOptions = serviceProvider.GetRequiredService<IOptions<BacklogParserOptions>>().Value;
 
         var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
         try
         {
             logger.LogInformation("Using Parser version: {ParserVersion}",
                 UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.GetParserVersion());
-            logger.LogInformation("Using data folder: {PathToDataFolder}", pathToDataFolder);
-            logger.LogInformation("Using court metadata from: {PathToCourtMetadataFile}", pathToCourtMetadataFile);
+            logger.LogInformation("Using data folder: {PathToDataFolder}", backlogParserOptions.DataFolderPath);
+            logger.LogInformation("Using court metadata from: {PathToCourtMetadataFile}",
+                backlogParserOptions.CourtMetadataFilePath);
 
             var backlogParserWorker = serviceProvider.GetRequiredService<BacklogParserWorker>();
+            Directory.CreateDirectory(backlogParserOptions.OutputFolderPath);
 
-            return backlogParserWorker.Run(isDryRun, id, pathToCourtMetadataFile, autoPublish, pathToOutputFolder);
+            return backlogParserWorker.Run();
         }
         catch (Exception e)
         {
@@ -169,7 +187,6 @@ public class Program
             return 1;
         }
     }
-
 
     private static List<(Type serviceType, object instance, bool replace)> _dependencyInjectionOverrides = [];
 
@@ -181,28 +198,16 @@ public class Program
             ? _dependencyInjectionOverrides
             : throw new InvalidOperationException("Cannot use dependency injection overrides in production");
 
-    internal static void ConfigureDependencyInjection(IServiceCollection services, string pathToDataFolder, string trackerPath,
-        string judgmentsFilePath, string hmctsFilePath, string bucketName)
+    internal static void ConfigureDependencyInjection(IServiceCollection services)
     {
-        services.AddLogging(loggingBuilder =>
-        {
-            var logFilePath = Path.Combine(pathToDataFolder, $"log_{DateTime.Now:yy-MM-dd_HH-mm}.txt");
-            loggingBuilder.AddConsole()
-                          .AddFile(logFilePath,
-                              outputTemplate:
-                              "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:w4}] {Message:lj}{NewLine}{Exception}");
-        });
-        services
-            .AddSingleton<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator,
-                UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
+        services.AddSingleton<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator, UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
         services.AddSingleton<Parser>();
         services.AddSingleton<BacklogParserWorker>();
         services.AddSingleton<CsvMetadataReader>();
-        services.AddSingleton<BacklogFiles>(serviceProvider => new BacklogFiles(serviceProvider.GetRequiredService<ILogger<BacklogFiles>>(), pathToDataFolder,
-            judgmentsFilePath, hmctsFilePath));
-        services.AddSingleton<Tracker>(_ => new Tracker(trackerPath));
+        services.AddSingleton<BacklogFiles>();
+        services.AddSingleton<Tracker>();
         services.AddSingleton<IAmazonS3, AmazonS3Client>();
-        services.AddSingleton<Bucket>(serviceProvider => new Bucket(serviceProvider.GetRequiredService<IAmazonS3>(), bucketName));
+        services.AddSingleton<Bucket>();
         services.AddSingleton<MetadataTransformer>();
         services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
 

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -164,10 +164,10 @@ public class Program
 
         var appHost = builder.Build();
 
-        var serviceProvider = appHost.Services;
-        var backlogParserOptions = serviceProvider.GetRequiredService<IOptions<BacklogParserOptions>>().Value;
+        using var scope = appHost.Services.CreateScope();
+        var backlogParserOptions = scope.ServiceProvider.GetRequiredService<IOptions<BacklogParserOptions>>().Value;
 
-        var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
         try
         {
             logger.LogInformation("Using Parser version: {ParserVersion}",
@@ -176,7 +176,7 @@ public class Program
             logger.LogInformation("Using court metadata from: {PathToCourtMetadataFile}",
                 backlogParserOptions.CourtMetadataFilePath);
 
-            var backlogParserWorker = serviceProvider.GetRequiredService<BacklogParserWorker>();
+            var backlogParserWorker = scope.ServiceProvider.GetRequiredService<BacklogParserWorker>();
             Directory.CreateDirectory(backlogParserOptions.OutputFolderPath);
 
             return backlogParserWorker.Run();
@@ -200,16 +200,16 @@ public class Program
 
     internal static void ConfigureDependencyInjection(IServiceCollection services)
     {
-        services.AddSingleton<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator, UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
-        services.AddSingleton<Parser>();
-        services.AddSingleton<BacklogParserWorker>();
-        services.AddSingleton<CsvMetadataReader>();
-        services.AddSingleton<BacklogFiles>();
-        services.AddSingleton<Tracker>();
-        services.AddSingleton<IAmazonS3, AmazonS3Client>();
-        services.AddSingleton<Bucket>();
-        services.AddSingleton<MetadataTransformer>();
-        services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
+        services.AddScoped<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator, UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
+        services.AddScoped<Parser>();
+        services.AddScoped<BacklogParserWorker>();
+        services.AddScoped<CsvMetadataReader>();
+        services.AddScoped<BacklogFiles>();
+        services.AddScoped<Tracker>();
+        services.AddScoped<IAmazonS3, AmazonS3Client>();
+        services.AddScoped<Bucket>();
+        services.AddScoped<MetadataTransformer>();
+        services.AddScoped<TimeProvider>(_ => TimeProvider.System);
 
         if (IsTest())
         {

--- a/backlog/src/Tracker.cs
+++ b/backlog/src/Tracker.cs
@@ -4,19 +4,22 @@ using System.IO;
 using System.Linq;
 
 using Backlog.Csv;
+using Backlog.Options;
+
+using Microsoft.Extensions.Options;
 
 namespace Backlog.Src;
 
 internal class Tracker
 {
-    private readonly string file;
+    private readonly string trackerFilePath;
 
-    internal Tracker(string file)
+    public Tracker(IOptions<BacklogParserOptions> backlogParserOptions)
     {
-        this.file = file;
-        if (!File.Exists(file))
+        trackerFilePath = backlogParserOptions.Value.TrackerFilePath;
+        if (!File.Exists(trackerFilePath))
         {
-            using var stream = File.Create(file);
+            using var stream = File.Create(trackerFilePath);
             stream.Close();
         }
     }
@@ -29,7 +32,7 @@ internal class Tracker
     internal bool WasDone(CsvLine line)
     {
         var key = MakeKey(line);
-        return File.ReadAllLines(file).Any(entry => entry.Contains(key));
+        return File.ReadAllLines(trackerFilePath).Any(entry => entry.Contains(key));
     }
 
     internal void MarkDone(CsvLine line, string uuid)
@@ -37,6 +40,6 @@ internal class Tracker
         var key = MakeKey(line);
         var timestamp = System.DateTime.Now.ToFileTime();
         var next = key + "," + uuid + "," + timestamp;
-        File.AppendAllLines(file, [next]);
+        File.AppendAllLines(trackerFilePath, [next]);
     }
 }

--- a/test/backlog/BacklogParserOptionsHelper.cs
+++ b/test/backlog/BacklogParserOptionsHelper.cs
@@ -1,0 +1,30 @@
+using Backlog.Options;
+
+using Microsoft.Extensions.Options;
+
+namespace test.backlog;
+
+public static class BacklogParserOptionsHelper
+{
+    public static IOptions<BacklogParserOptions> Create(
+        string dataFolderPath = @"c:\my-data-dir\",
+        string metadataProvidedFilePathPrefix = "",
+        string transferMetadataFilePathPrefix = "",
+        string courtMetadataFilePath = @"c:\my-data-dir\court-metadata.csv",
+        string outputFolderPath = @"c:\my-data-dir\output",
+        string trackerFilePath = @"c:\my-data-dir\tracker.csv",
+        bool autoPublish = false
+    )
+    {
+        return Options.Create(new BacklogParserOptions
+        {
+            DataFolderPath = dataFolderPath,
+            MetadataProvidedFilePathPrefix = metadataProvidedFilePathPrefix,
+            TransferMetadataFilePathPrefix = transferMetadataFilePathPrefix,
+            CourtMetadataFilePath = courtMetadataFilePath,
+            OutputFolderPath = outputFolderPath,
+            TrackerFilePath = trackerFilePath,
+            AutoPublish = autoPublish
+        });
+    }
+}

--- a/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
+++ b/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
@@ -73,16 +73,16 @@ public abstract class BaseEndToEndTests : IDisposable
 
 
         // Clean up environment variables
-        Environment.SetEnvironmentVariable("COURT_METADATA_PATH", null);
-        Environment.SetEnvironmentVariable("DATA_FOLDER_PATH", null);
-        Environment.SetEnvironmentVariable("TRACKER_PATH", null);
-        Environment.SetEnvironmentVariable("OUTPUT_PATH", null);
+        Environment.SetEnvironmentVariable("BacklogParser__CourtMetadataFilePath", null);
+        Environment.SetEnvironmentVariable("BacklogParser__DataFolderPath", null);
+        Environment.SetEnvironmentVariable("BacklogParser__TrackerFilePath", null);
+        Environment.SetEnvironmentVariable("BacklogParser__OutputFolderPath", null);
 
         Environment.SetEnvironmentVariable("IS_TEST", null);
         Environment.SetEnvironmentVariable("AWS_REGION", null);
 
-        Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", null);
-        Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", null);
+        Environment.SetEnvironmentVariable("BacklogParser__MetadataProvidedFilePathPrefix", null);
+        Environment.SetEnvironmentVariable("BacklogParser__TransferMetadataFilePathPrefix", null);
     }
 
     protected static void SetPathEnvironmentVariables(string dataDir, string? outputPath = null,
@@ -92,10 +92,16 @@ public abstract class BaseEndToEndTests : IDisposable
         courtMetadataPath ??= Path.Combine(dataDir, "court_metadata.csv");
         trackerPath ??= Path.Combine(dataDir, "uploaded-production.csv");
 
-        Environment.SetEnvironmentVariable("COURT_METADATA_PATH", courtMetadataPath);
-        Environment.SetEnvironmentVariable("DATA_FOLDER_PATH", dataDir);
-        Environment.SetEnvironmentVariable("TRACKER_PATH", trackerPath);
-        Environment.SetEnvironmentVariable("OUTPUT_PATH", outputPath);
+        Environment.SetEnvironmentVariable("BacklogParser__CourtMetadataFilePath", courtMetadataPath);
+        Environment.SetEnvironmentVariable("BacklogParser__DataFolderPath", dataDir);
+        Environment.SetEnvironmentVariable("BacklogParser__TrackerFilePath", trackerPath);
+        Environment.SetEnvironmentVariable("BacklogParser__OutputFolderPath", outputPath);
+    }
+
+    protected static void SetMetadataPrefixEnvironmentVariables(string metadataProvidedFilePathPrefix, string transferMetadataFilePathPrefix)
+    {
+        Environment.SetEnvironmentVariable("BacklogParser__MetadataProvidedFilePathPrefix", metadataProvidedFilePathPrefix);
+        Environment.SetEnvironmentVariable("BacklogParser__TransferMetadataFilePathPrefix", transferMetadataFilePathPrefix);
     }
 
     protected static void AssertProgramExitedSuccessfully(int exitCode)

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -154,8 +154,7 @@ namespace test.backlog.EndToEndTests
         {
             // Setup test environment
             ConfigureTestEnvironment(testCaseName);
-            Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", judgmentFilePath);
-            Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", hmctsFilesPath);
+            SetMetadataPrefixEnvironmentVariables(judgmentFilePath, hmctsFilesPath);
             // This time is the "now" that is used in the "expected metadata" JSON fixture
             var expectedTime = new DateTimeOffset(1999, 9, 9, 9, 9, 9, TimeSpan.Zero);
             fakeTimeProvider.AdjustTime(expectedTime);
@@ -186,8 +185,7 @@ namespace test.backlog.EndToEndTests
         {
             // Setup test environment for multi-line CSV test
             ConfigureTestEnvironment("MultiLineTest");
-            Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", "JudgmentFiles\\");
-            Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", "data/HMCTS_Judgment_Files/");
+            SetMetadataPrefixEnvironmentVariables( "JudgmentFiles\\", "data/HMCTS_Judgment_Files/");
 
             // Act - Run without --id to process full CSV
             var exitCode = Backlog.Src.Program.Main();
@@ -214,8 +212,7 @@ namespace test.backlog.EndToEndTests
         {
             // Setup test environment
             ConfigureTestEnvironment("MultiLineTest");
-            Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", "JudgmentFiles\\");
-            Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", "data/HMCTS_Judgment_Files/");
+            SetMetadataPrefixEnvironmentVariables("JudgmentFiles\\", "data/HMCTS_Judgment_Files/");
 
             // Pre-populate tracker to mark first item as already processed
             await File.WriteAllTextAsync(trackerPath, "100/JudgmentFiles\\j100\\test1.doc,some-uuid-1,132345678901234567\n",
@@ -253,8 +250,7 @@ namespace test.backlog.EndToEndTests
         {
             // Setup test environment
             ConfigureTestEnvironment("MultiLineTest");
-            Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", "JudgmentFiles\\");
-            Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", "data/HMCTS_Judgment_Files/");
+            SetMetadataPrefixEnvironmentVariables( "JudgmentFiles\\", "data/HMCTS_Judgment_Files/");
 
             // Act
             var exitCode = Backlog.Src.Program.Main("--id", "102");
@@ -310,8 +306,7 @@ namespace test.backlog.EndToEndTests
         {
             // Setup test environment
             ConfigureTestEnvironment("Money Worries Ltd v Office of Fair Trading");
-            Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", "Documents\\");
-            Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", "data/Consumer Credit Appeals/Documents/");
+            SetMetadataPrefixEnvironmentVariables( "Documents\\", "data/Consumer Credit Appeals/Documents/");
             fakeTimeProvider.AdjustTime(new DateTimeOffset(1999, 9, 9, 9, 9, 9, TimeSpan.Zero));
 
             // Act

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -20,6 +20,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
 {
     private const int DocIdWithJurisdiction = 70;
     private const string JudgmentsFilePath = @"JudgmentFiles\";
+    private const string HmctsFilePath = "data/HMCTS_Judgment_Files/";
     private string? courtMetadataPath;
     private string? tempDataDir;
 
@@ -59,23 +60,20 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
         var trackerPath = Path.Combine(tempDataDir, "uploaded-production.csv");
 
         SetPathEnvironmentVariables(tempDataDir, outputPath, courtMetadataPath, trackerPath);
+        SetMetadataPrefixEnvironmentVariables(JudgmentsFilePath, HmctsFilePath);
     }
 
     private static void WriteTransferMetaDataCsv(string uuid, string tdrMetadataDir, string originalFileName)
     {
-        const string hmctsFilePath = "data/HMCTS_Judgment_Files/";
-        Environment.SetEnvironmentVariable("HMCTS_FILES_PATH", hmctsFilePath);
         var transferMetadataContent =
             $@"file_reference,file_name,file_type,file_size,clientside_original_filepath,rights_copyright,legal_status,held_by,date_last_modified,closure_type,closure_start_date,closure_period,foi_exemption_code,foi_exemption_asserted,title_closed,title_alternate,description,description_closed,description_alternate,language,end_date,file_name_translation,original_filepath,parent_reference,former_reference_department,UUID
-TEST1,{originalFileName},File,1024,{hmctsFilePath}{originalFileName},Crown Copyright,Public Record(s),""The National Archives, Kew"",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{uuid}";
+TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyright,Public Record(s),""The National Archives, Kew"",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{uuid}";
         var transferMetadataPath = Path.Combine(tdrMetadataDir, "file-metadata.csv");
         File.WriteAllText(transferMetadataPath, transferMetadataContent);
     }
 
     private void WriteCourtMetadataCsv(params CsvLine[] metadataLines)
     {
-        Environment.SetEnvironmentVariable("JUDGMENTS_FILE_PATH", JudgmentsFilePath);
-
         var headerLine =
             "id,FilePath,Extension,decision_datetime,CaseNo,court,appellants,claimants,respondent,jurisdictions,webarchiving,skip,NCN";
         var csvMetadataLines = new List<string> { headerLine };

--- a/test/backlog/MetadataTests/TestMetadataTransformer.cs
+++ b/test/backlog/MetadataTests/TestMetadataTransformer.cs
@@ -28,7 +28,8 @@ public class TestMetadataTransformer
 
     public TestMetadataTransformer()
     {
-        metadataTransformer = new MetadataTransformer(fakeTimeProvider);
+        var options = BacklogParserOptionsHelper.Create(autoPublish: true);
+        metadataTransformer = new MetadataTransformer(options, fakeTimeProvider);
     }
 
     [Fact]
@@ -45,7 +46,6 @@ public class TestMetadataTransformer
             "test.pdf",
             sourceMimeType,
             contentHash,
-            autoPublish,
             [],
             responseMeta,
             [],
@@ -96,11 +96,7 @@ public class TestMetadataTransformer
 
         // Act
         var result = metadataTransformer.CreateFullTreMetadata(
-            parserRunId,
-            "test.docx",
-            "application/pdf",
-            "1234-456-789",
-            true,
+            parserRunId,"test.docx", "application/pdf", "1234-456-789",
             [],
             responseMeta,
             externalMetadataFields,
@@ -146,7 +142,6 @@ public class TestMetadataTransformer
             sourceFilename,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "sha256:abc",
-            false,
             images,
             new Api.Meta { DocumentType = "decision" },
             [],
@@ -169,7 +164,6 @@ public class TestMetadataTransformer
             "test-file.docx",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "sha256:abc",
-            false,
             [],
             new Api.Meta { DocumentType = "decision" },
             [],
@@ -180,7 +174,6 @@ public class TestMetadataTransformer
             "test-file.docx",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "sha256:abc",
-            false,
             [],
             new Api.Meta { DocumentType = "decision" },
             [],

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -6,7 +6,10 @@ using System.IO;
 using System.Linq;
 
 using Backlog.Csv;
+using Backlog.Options;
 using Backlog.Src;
+
+using Microsoft.Extensions.Options;
 
 using test.Mocks;
 
@@ -16,7 +19,8 @@ namespace test.backlog.MetadataTests;
 
 public class TestRead : IDisposable
 {
-    private readonly CsvMetadataReader csvMetadataReader = new(new MockLogger<CsvMetadataReader>().Object);
+    private readonly CsvMetadataReader csvMetadataReader;
+    private readonly IOptions<BacklogParserOptions> backlogParserOptions;
     private readonly string testDataDirectory;
 
     public TestRead()
@@ -24,14 +28,10 @@ public class TestRead : IDisposable
         // Create a unique temporary directory for test files (used by some tests accessing the real file system)
         testDataDirectory = Path.Combine(Path.GetTempPath(), nameof(TestRead), Guid.NewGuid().ToString());
         Directory.CreateDirectory(testDataDirectory);
-    }
-
-    private string MakeRealCsvFile(string csvContent)
-    {
-        var csvPath = Path.Combine(testDataDirectory, "metadata.csv");
-
-        File.WriteAllText(csvPath, csvContent);
-        return csvPath;
+        
+        var courtMetadataFilePath = Path.Combine(testDataDirectory, "metadata.csv");
+        backlogParserOptions = BacklogParserOptionsHelper.Create(courtMetadataFilePath: courtMetadataFilePath);
+        csvMetadataReader = new(new MockLogger<CsvMetadataReader>().Object, backlogParserOptions);
     }
 
     public void Dispose()
@@ -701,12 +701,12 @@ public class TestRead : IDisposable
     public void Read_WithNonExistentFile_ThrowsFileNotFoundException()
     {
         // Arrange - Create helper with non-existent CSV path
-        var nonExistentPath = Path.Combine(testDataDirectory, "does-not-exist.csv");
+        backlogParserOptions.Value.CourtMetadataFilePath = Path.Combine(testDataDirectory, "does-not-exist.csv");
 
         // Act & Assert
         Assert.Throws<FileNotFoundException>(() =>
         {
-            _ = csvMetadataReader.Read(nonExistentPath, out _, out _, out _);
+            _ = csvMetadataReader.Read(out _, out _, out _);
         });
     }
 
@@ -714,12 +714,11 @@ public class TestRead : IDisposable
     public void Read_WithEmptyFile_ReturnsEmptyList()
     {
         // Arrange - Create empty CSV file with just headers
-        var emptyCsvPath =
-            MakeRealCsvFile(
-                "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
+        File.WriteAllText(backlogParserOptions.Value.CourtMetadataFilePath,
+            "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
 
         // Act
-        var lines = csvMetadataReader.Read(emptyCsvPath, out _, out _, out _);
+        var lines = csvMetadataReader.Read(out _, out _, out _);
 
         // Assert
         Assert.Empty(lines);
@@ -729,13 +728,15 @@ public class TestRead : IDisposable
     public void Read_FromPath_PopulatesCsvPropertiesWithNameAndHash()
     {
         // Arrange
-        const string csvContent = "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip\n" +
-                                  "123,/test/data/test.pdf,.pdf,2025-01-15,IA/2025/001,UKUT-IAC,Smith,HMRC,";
-        var csvPath = MakeRealCsvFile(csvContent);
-        var expectedHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
+        const string csvContent = """
+                                  id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,skip
+                                  123,/test/data/test.pdf,.pdf,2025-01-15,IA/2025/001,UKUT-IAC,Smith,HMRC,
+                                  """;
+        File.WriteAllText(backlogParserOptions.Value.CourtMetadataFilePath, csvContent);
+        var expectedHash = BacklogParserWorker.Hash(File.ReadAllBytes(backlogParserOptions.Value.CourtMetadataFilePath));
 
         // Act
-        var result = csvMetadataReader.Read(csvPath, out _, out _, out _);
+        var result = csvMetadataReader.Read(out _, out _, out _);
 
         // Assert
         var line = Assert.Single(result);

--- a/test/backlog/MockS3Client.cs
+++ b/test/backlog/MockS3Client.cs
@@ -24,7 +24,7 @@ public partial class MockS3Client : Mock<IAmazonS3>, IDisposable
 
     public MockS3Client()
     {
-        Environment.SetEnvironmentVariable("BUCKET_NAME", TestBucket);
+        Environment.SetEnvironmentVariable("BacklogParser__BucketName", TestBucket);
 
         Setup(x => x.PutObjectAsync(
                 It.Is<PutObjectRequest>(req =>
@@ -53,7 +53,7 @@ public partial class MockS3Client : Mock<IAmazonS3>, IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        Environment.SetEnvironmentVariable("BUCKET_NAME", null);
+        Environment.SetEnvironmentVariable("BacklogParser__BucketName", null);
     }
 
     public void AssertNumberOfUploads(int expectedNumberOfUploads)

--- a/test/backlog/TestBacklogFiles.cs
+++ b/test/backlog/TestBacklogFiles.cs
@@ -2,9 +2,11 @@ using System;
 using System.IO;
 using System.Text;
 
+using Backlog.Options;
 using Backlog.Src;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using test.Mocks;
 
@@ -23,6 +25,7 @@ namespace test.backlog
 
         private BacklogFiles backlogFiles;
         private readonly ILogger<BacklogFiles> mockLogger = new MockLogger<BacklogFiles>().Object;
+        private IOptions<BacklogParserOptions> backlogParserOptions;
 
         public TestBacklogFiles()
         {
@@ -35,8 +38,13 @@ namespace test.backlog
             
             Directory.CreateDirectory(courtDocumentsDir);
             Directory.CreateDirectory(tdrMetadataDir);
-            
-            backlogFiles = new(mockLogger, tempTestDir, "", "");
+
+            backlogParserOptions = BacklogParserOptionsHelper.Create(
+                dataFolderPath: tempTestDir,
+                metadataProvidedFilePathPrefix: @"Documents\Decisions",
+                transferMetadataFilePathPrefix: "data/Claims management decisions"
+            );
+            backlogFiles = new(mockLogger, backlogParserOptions);
         }
 
         public void Dispose()
@@ -54,7 +62,7 @@ namespace test.backlog
             Directory.Delete(courtDocumentsDir);
 
             var exception =
-                Assert.Throws<DirectoryNotFoundException>(() => new BacklogFiles(mockLogger, tempTestDir, "", ""));
+                Assert.Throws<DirectoryNotFoundException>(() => new BacklogFiles(mockLogger, backlogParserOptions));
             Assert.Equal($"Couldn't find {courtDocumentsDir}", exception.Message);
         }
 
@@ -111,16 +119,12 @@ namespace test.backlog
         public void FindUuidInTransferMetadata_WithTwoLevelDeepJudgmentsFilePath_ReturnsUuidSuccessfully()
         {
             // Arrange
-            const string judgmentsFilePath = @"Documents\Decisions";
-            const string hmctsFilePath = "data/Claims management decisions";
-            const string expectedUuid = "test-uuid-12345";  
-            
-            backlogFiles = new(mockLogger, tempTestDir, judgmentsFilePath, hmctsFilePath);
+            const string expectedUuid = "test-uuid-12345";
 
             // Create transfer metadata CSV content with 2-level deep judgments file path
             var transferMetadataContent = new StringBuilder();
             transferMetadataContent.AppendLine("file_reference,file_name,file_type,file_size,clientside_original_filepath,rights_copyright,legal_status,held_by,date_last_modified,closure_type,closure_start_date,closure_period,foi_exemption_code,foi_exemption_asserted,title_closed,title_alternate,description,description_closed,description_alternate,language,end_date,file_name_translation,original_filepath,parent_reference,former_reference_department,UUID");
-            transferMetadataContent.AppendLine($"TEST1,test-decision.pdf,File,1024,{hmctsFilePath}/j100/test-decision.pdf,Crown Copyright,Public Record(s),\"The National Archives, Kew\",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{expectedUuid}");
+            transferMetadataContent.AppendLine($"TEST1,test-decision.pdf,File,1024,data/Claims management decisions/j100/test-decision.pdf,Crown Copyright,Public Record(s),\"The National Archives, Kew\",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{expectedUuid}");
 
             // Write the transfer metadata file
             var transferMetadataPath = Path.Combine(tdrMetadataDir, "file-metadata.csv");
@@ -141,16 +145,12 @@ namespace test.backlog
         public void FindUuidInTransferMetadata_WithMixedPathSeparators_HandlesNormalizationCorrectly()
         {
             // Arrange - Set up test data with mixed path separators
-            const string judgmentsFilePath = @"Documents\Decisions";
-            const string hmctsFilePath = "data/Claims management decisions";
             const string expectedUuid = "test-uuid-mixed-paths";
-
-            backlogFiles = new(mockLogger, tempTestDir, judgmentsFilePath, hmctsFilePath);
 
             // Create transfer metadata with forward slashes (Unix style) - should still match
             var transferMetadataContent = new StringBuilder();
             transferMetadataContent.AppendLine("file_reference,file_name,file_type,file_size,clientside_original_filepath,rights_copyright,legal_status,held_by,date_last_modified,closure_type,closure_start_date,closure_period,foi_exemption_code,foi_exemption_asserted,title_closed,title_alternate,description,description_closed,description_alternate,language,end_date,file_name_translation,original_filepath,parent_reference,former_reference_department,UUID");
-            transferMetadataContent.AppendLine($"TEST2,test-file.doc,File,2048,{hmctsFilePath}/subfolder/test-file.doc,Crown Copyright,Public Record(s),\"The National Archives, Kew\",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{expectedUuid}");
+            transferMetadataContent.AppendLine($"TEST2,test-file.doc,File,2048,data/Claims management decisions/subfolder/test-file.doc,Crown Copyright,Public Record(s),\"The National Archives, Kew\",2023-01-01T00:00:00,Open,,,,,false,,,false,,English,,,,,,{expectedUuid}");
 
             // Write the transfer metadata file
             var transferMetadataPath = Path.Combine(tdrMetadataDir, "file-metadata.csv");
@@ -170,12 +170,6 @@ namespace test.backlog
         [Fact]
         public void FindUuidInTransferMetadata_WithMismatchedJudgmentsFilePath_ThrowsArgumentException()
         {
-            // Arrange
-            const string judgmentsFilePath = @"Documents\Decisions";
-            const string hmctsFilePath = "data/Claims management decisions";
-
-            backlogFiles = new(mockLogger, tempTestDir, judgmentsFilePath, hmctsFilePath);
-
             // Act & Assert
             var exception = Assert.Throws<ArgumentException>(() =>
             {

--- a/test/backlog/TestProgram.cs
+++ b/test/backlog/TestProgram.cs
@@ -29,7 +29,7 @@ public class TestProgram(ITestOutputHelper testOutputHelper)
 
         var services = new ServiceCollection();
 
-        Backlog.Src.Program.ConfigureDependencyInjection(services, "pathToDataFolder", "trackerPath", "judgmentsFilePath", "hmctsFilePath", "bucketName");
+        Backlog.Src.Program.ConfigureDependencyInjection(services);
 
         using var serviceProvider = services.BuildServiceProvider();
         var timeProvider = serviceProvider.GetRequiredService<TimeProvider>();


### PR DESCRIPTION
This introduces an [app host](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host?tabs=appbuilder) which will manage the lifecycle of the application and enable us to take configuration from multiple sources.
It also introduces the [options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) to manage configuration which enables much easier refactoring and configuration validation.

## Changes

- Adds apphost
- Adds `BacklogParserOptions`
- Cleans up dependency injection
- Makes configuration values hierarchical