### PR TITLE
Backlog: Fix dry run option by improving Bucket

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 using Backlog.Csv;
 using Backlog.Options;
@@ -29,7 +30,7 @@ internal class BacklogParserWorker(
     MetadataTransformer metadataTransformer,
     IOptions<BacklogParserOptions> backlogParserOptions)
 {
-    public int Run()
+    public async Task<int> RunAsync()
     {
         var parserRunId = Guid.NewGuid();
         var lines = csvMetadataReader.Read(out var skippedCsvLineIdentifiers, out var csvParseErrors,
@@ -84,7 +85,7 @@ internal class BacklogParserWorker(
                 else
                 {
                     logger.LogInformation("  Uploading {BundleFileName} to S3", bundleFileName);
-                    bucket.UploadBundle(bundleFileName, bundle.TarGz).Wait();
+                    await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
                 }
 
                 tracker.MarkDone(line, bundle.Uuid);

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -26,7 +26,7 @@ internal class BacklogParserWorker(
     BacklogFiles backlogFiles,
     CsvMetadataReader csvMetadataReader,
     Tracker tracker,
-    Bucket bucket,
+    IBucket bucket,
     MetadataTransformer metadataTransformer,
     IOptions<BacklogParserOptions> backlogParserOptions)
 {
@@ -78,15 +78,7 @@ internal class BacklogParserWorker(
                 logger.LogInformation("  Writing to output: {Output}", output);
                 File.WriteAllBytes(output, bundle.TarGz);
 
-                if (backlogParserOptions.Value.IsDryRun)
-                {
-                    logger.LogInformation("  This is a dry run - not uploading to S3");
-                }
-                else
-                {
-                    logger.LogInformation("  Uploading {BundleFileName} to S3", bundleFileName);
-                    await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
-                }
+                await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
 
                 tracker.MarkDone(line, bundle.Uuid);
                 successfulNewLines.Add(line);

--- a/backlog/src/Bucket.cs
+++ b/backlog/src/Bucket.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -8,14 +9,46 @@ using Amazon.S3.Model;
 
 using Backlog.Options;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Backlog.Src;
+namespace Backlog;
 
-public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogParserOptions)
+public interface IBucket
+{
+    Task UploadBundleAsync(string key, byte[] bundle);
+}
+
+public class DryRunBucket : IBucket
+{
+    private readonly ILogger<DryRunBucket> logger;
+
+    public DryRunBucket(IOptions<BacklogParserOptions> backlogParserOptions, ILogger<DryRunBucket> logger)
+    {
+        if (backlogParserOptions.Value.IsDryRun)
+        {
+            this.logger = logger;
+        }
+        else
+        {
+            throw new ArgumentException("Dry run bucket should only be used in dry run mode",
+                nameof(backlogParserOptions));
+        }
+    }
+
+    public Task UploadBundleAsync(string key, byte[] bundle)
+    {
+        logger.LogInformation("This is a dry run - not uploading to S3");
+        return Task.CompletedTask;
+    }
+}
+
+public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogParserOptions, ILogger<Bucket> logger)
+    : IBucket
 {
     public async Task UploadBundleAsync(string key, byte[] bundle)
     {
+        logger.LogInformation("Uploading {BundleFileName} to S3", key);
         PutObjectRequest request = new()
         {
             BucketName = backlogParserOptions.Value.BucketName,

--- a/backlog/src/Bucket.cs
+++ b/backlog/src/Bucket.cs
@@ -14,7 +14,7 @@ namespace Backlog.Src;
 
 public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogParserOptions)
 {
-    public async Task<PutObjectResponse> UploadBundle(string key, byte[] bundle)
+    public async Task UploadBundleAsync(string key, byte[] bundle)
     {
         PutObjectRequest request = new()
         {
@@ -23,6 +23,6 @@ public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogPars
             ContentType = "application/gzip",
             InputStream = new MemoryStream(bundle)
         };
-        return await client.PutObjectAsync(request);
+        await client.PutObjectAsync(request);
     }
 }

--- a/backlog/src/Bucket.cs
+++ b/backlog/src/Bucket.cs
@@ -56,6 +56,9 @@ public class Bucket(IAmazonS3 client, IOptions<BacklogParserOptions> backlogPars
             ContentType = "application/gzip",
             InputStream = new MemoryStream(bundle)
         };
-        await client.PutObjectAsync(request);
+        var response = await client.PutObjectAsync(request);
+
+        if (response.HttpStatusCode != System.Net.HttpStatusCode.OK)
+            throw new ProblemUploadingFileToS3Exception($"Failed to upload {key} to S3");
     }
 }

--- a/backlog/src/Exceptions.cs
+++ b/backlog/src/Exceptions.cs
@@ -2,6 +2,7 @@
 
 using System;
 
-namespace Backlog.Src;
+namespace Backlog;
 
 public class MoreThanOneFileFoundException(string message) : Exception(message);
+public class ProblemUploadingFileToS3Exception(string message) : Exception(message);

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -9,6 +9,7 @@ using Amazon.S3;
 
 using Backlog.Csv;
 using Backlog.Options;
+using Backlog.Src;
 using Backlog.Utilities;
 
 using DotNetEnv.Configuration;
@@ -22,7 +23,7 @@ using Microsoft.Extensions.Options;
 
 using UK.Gov.NationalArchives.Judgments.Api;
 
-namespace Backlog.Src;
+namespace Backlog;
 
 public class Program
 {

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -156,7 +156,7 @@ public class Program
             var backlogParserWorker = scope.ServiceProvider.GetRequiredService<BacklogParserWorker>();
             Directory.CreateDirectory(backlogParserOptions.OutputFolderPath);
 
-            return backlogParserWorker.Run();
+            return backlogParserWorker.RunAsync().Result;
         }
         catch (Exception e)
         {

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -192,7 +192,7 @@ public class Program
                               outputTemplate:
                               "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:w4}] {Message:lj}{NewLine}{Exception}");
         });
-        ConfigureDependencyInjection(builder.Services);
+        ConfigureDependencyInjection(builder.Services, isDryRun);
 
         return builder.Build();
     }
@@ -207,7 +207,7 @@ public class Program
             ? _dependencyInjectionOverrides
             : throw new InvalidOperationException("Cannot use dependency injection overrides in production");
 
-    internal static void ConfigureDependencyInjection(IServiceCollection services)
+    internal static void ConfigureDependencyInjection(IServiceCollection services, bool isDryRun = false)
     {
         services.AddScoped<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator, UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
         services.AddScoped<Parser>();
@@ -215,8 +215,16 @@ public class Program
         services.AddScoped<CsvMetadataReader>();
         services.AddScoped<BacklogFiles>();
         services.AddScoped<Tracker>();
-        services.AddScoped<IAmazonS3, AmazonS3Client>();
-        services.AddScoped<Bucket>();
+        if (isDryRun)
+        {
+            services.AddScoped<IBucket, DryRunBucket>();
+        }
+        else
+        {
+            services.AddScoped<IAmazonS3, AmazonS3Client>();
+            services.AddScoped<IBucket, Bucket>();
+        }
+
         services.AddScoped<MetadataTransformer>();
         services.AddScoped<TimeProvider>(_ => TimeProvider.System);
 

--- a/test/backlog/BacklogParserOptionsHelper.cs
+++ b/test/backlog/BacklogParserOptionsHelper.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Backlog.Options;
 
 using Microsoft.Extensions.Options;
@@ -13,7 +15,9 @@ public static class BacklogParserOptionsHelper
         string courtMetadataFilePath = @"c:\my-data-dir\court-metadata.csv",
         string outputFolderPath = @"c:\my-data-dir\output",
         string trackerFilePath = @"c:\my-data-dir\tracker.csv",
-        bool autoPublish = false
+        bool autoPublish = false,
+        bool isDryRun = false,
+        string? bucketName = null
     )
     {
         return Options.Create(new BacklogParserOptions
@@ -24,7 +28,9 @@ public static class BacklogParserOptionsHelper
             CourtMetadataFilePath = courtMetadataFilePath,
             OutputFolderPath = outputFolderPath,
             TrackerFilePath = trackerFilePath,
-            AutoPublish = autoPublish
+            AutoPublish = autoPublish,
+            IsDryRun = isDryRun,
+            BucketName = bucketName
         });
     }
 }

--- a/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
+++ b/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
@@ -34,20 +34,20 @@ public abstract class BaseEndToEndTests : IDisposable
 
         // Clear lingering overrides from previous tests (overrides are in a static context)
         Environment.SetEnvironmentVariable("IS_TEST", "true");
-        Backlog.Src.Program.DependencyInjectionOverrides.Clear();
+        Backlog.Program.DependencyInjectionOverrides.Clear();
         
         // Configure S3 client
         Environment.SetEnvironmentVariable("AWS_REGION", "eu-west-2");
-        Backlog.Src.Program.DependencyInjectionOverrides.Add((typeof(IAmazonS3), mockS3Client.Object, true));
+        Backlog.Program.DependencyInjectionOverrides.Add((typeof(IAmazonS3), mockS3Client.Object, true));
 
         // Control time
-        Backlog.Src.Program.DependencyInjectionOverrides.Add((typeof(TimeProvider), fakeTimeProvider, true));
+        Backlog.Program.DependencyInjectionOverrides.Add((typeof(TimeProvider), fakeTimeProvider, true));
 
         // Mock logger
         var mockLoggerProvider = new Mock<ILoggerProvider>();
         mockLoggerProvider.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(() => ConsolidatedLogger.Object);
 
-        Backlog.Src.Program.DependencyInjectionOverrides.Add(
+        Backlog.Program.DependencyInjectionOverrides.Add(
             (typeof(ILoggerProvider), mockLoggerProvider.Object, false));
     }
 
@@ -59,7 +59,7 @@ public abstract class BaseEndToEndTests : IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        Backlog.Src.Program.DependencyInjectionOverrides.Clear();
+        Backlog.Program.DependencyInjectionOverrides.Clear();
         CleanEnvironmentVariables();
     }
 

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -160,7 +160,7 @@ namespace test.backlog.EndToEndTests
             fakeTimeProvider.AdjustTime(expectedTime);
 
             // Act
-            var exitCode = Backlog.Src.Program.Main("--id", docId.ToString(), "--auto-publish");
+            var exitCode = Backlog.Program.Main("--id", docId.ToString(), "--auto-publish");
 
             // Assert - Program exited successfully
             AssertProgramExitedSuccessfully(exitCode);
@@ -188,7 +188,7 @@ namespace test.backlog.EndToEndTests
             SetMetadataPrefixEnvironmentVariables( "JudgmentFiles\\", "data/HMCTS_Judgment_Files/");
 
             // Act - Run without --id to process full CSV
-            var exitCode = Backlog.Src.Program.Main();
+            var exitCode = Backlog.Program.Main();
             // Assert
             AssertProgramExitedSuccessfully(exitCode);
 
@@ -219,7 +219,7 @@ namespace test.backlog.EndToEndTests
                 TestContext.Current.CancellationToken);
 
             // Act
-            var exitCode = Backlog.Src.Program.Main();
+            var exitCode = Backlog.Program.Main();
 
             // Assert
             AssertProgramExitedSuccessfully(exitCode);
@@ -253,7 +253,7 @@ namespace test.backlog.EndToEndTests
             SetMetadataPrefixEnvironmentVariables( "JudgmentFiles\\", "data/HMCTS_Judgment_Files/");
 
             // Act
-            var exitCode = Backlog.Src.Program.Main("--id", "102");
+            var exitCode = Backlog.Program.Main("--id", "102");
 
             // Assert
             AssertProgramExitedSuccessfully(exitCode);
@@ -270,7 +270,7 @@ namespace test.backlog.EndToEndTests
             ConfigureTestEnvironment("EmptyCSVTest");
 
             // Act
-            var exitCode = Backlog.Src.Program.Main();
+            var exitCode = Backlog.Program.Main();
 
             // Assert
             Assert.Equal(1, exitCode);
@@ -281,7 +281,7 @@ namespace test.backlog.EndToEndTests
         public void ProcessBacklogJudgment_WithInvalidIdArgument_ReturnsError()
         {
             // Act
-            var exitCode = Backlog.Src.Program.Main("--id", "invalid");
+            var exitCode = Backlog.Program.Main("--id", "invalid");
 
             // Assert
             Assert.Equal(1, exitCode);
@@ -291,7 +291,7 @@ namespace test.backlog.EndToEndTests
         public void ProcessBacklogJudgment_WithInvalidArguments_ReturnsError()
         {
             // Act
-            var exitCode = Backlog.Src.Program.Main("--unknown-arg");
+            var exitCode = Backlog.Program.Main("--unknown-arg");
 
             // Assert
             Assert.Equal(1, exitCode);
@@ -311,7 +311,7 @@ namespace test.backlog.EndToEndTests
 
             // Act
             var args = new[] { "--id", "20" }.Concat(extraArgs).ToArray();
-            var exitCode = Backlog.Src.Program.Main(args);
+            var exitCode = Backlog.Program.Main(args);
 
             // Assert
             AssertProgramExitedSuccessfully(exitCode);

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -125,7 +125,7 @@ TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyr
         WriteCourtMetadataCsv(metadataLine);
 
         // Act
-        var exitCode = Backlog.Src.Program.Main([]);
+        var exitCode = Backlog.Program.Main([]);
 
         //Assert
         AssertProgramExitedSuccessfully(exitCode);
@@ -178,7 +178,7 @@ TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyr
         WriteCourtMetadataCsv(metadataLine);
 
         // Act
-        var exitCode = Backlog.Src.Program.Main([]);
+        var exitCode = Backlog.Program.Main([]);
 
         //Assert
         AssertProgramExitedSuccessfully(exitCode);
@@ -227,7 +227,7 @@ TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyr
         WriteCourtMetadataCsv(metadataLine);
 
         // Act
-        var exitCode = Backlog.Src.Program.Main([]);
+        var exitCode = Backlog.Program.Main([]);
 
         //Assert
         Assert.True(exitCode != 0, "Expected program to error but it exited successfully");
@@ -257,7 +257,7 @@ TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyr
         WriteCourtMetadataCsv(metadataLine);
 
         // Act
-        var exitCode = Backlog.Src.Program.Main([]);
+        var exitCode = Backlog.Program.Main([]);
 
         // Assert program finished successfully
         AssertProgramExitedSuccessfully(exitCode);
@@ -336,7 +336,7 @@ TEST1,{originalFileName},File,1024,{HmctsFilePath}{originalFileName},Crown Copyr
         WriteCourtMetadataCsv(metadataLine);
 
         // Act
-        var exitCode = Backlog.Src.Program.Main([]);
+        var exitCode = Backlog.Program.Main([]);
 
         // Assert
         AssertProgramExitedSuccessfully(exitCode);

--- a/test/backlog/TestBacklogFiles.cs
+++ b/test/backlog/TestBacklogFiles.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 
+using Backlog;
 using Backlog.Options;
 using Backlog.Src;
 

--- a/test/backlog/TestBucket.cs
+++ b/test/backlog/TestBucket.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.S3;
+using Amazon.S3.Model;
+
+using Backlog;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using test.backlog.EndToEndTests;
+using test.Mocks;
+
+using Xunit;
+
+namespace test.backlog;
+
+public class TestBucket(ITestOutputHelper testOutputHelper)
+    : BaseEndToEndTests(testOutputHelper)
+{
+    protected override void Dispose(bool disposing)
+    {
+        Environment.SetEnvironmentVariable("IS_TEST", "true");
+        base.Dispose(disposing);
+    }
+
+    [Fact]
+    public void DryRunBucket_WhenNotInDryRunMode_ThrowsArgumentException()
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: false);
+
+        Assert.Throws<ArgumentException>(() => new DryRunBucket(options, Mock.Of<ILogger<DryRunBucket>>()));
+    }
+
+    [Fact]
+    public void DryRunBucket_InDryRunMode_CanBeCreated()
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true);
+
+        var bucket = new DryRunBucket(options, Mock.Of<ILogger<DryRunBucket>>());
+
+        Assert.NotNull(bucket);
+    }
+
+    [Fact]
+    public async Task DryRunBucket_UploadBundleAsync_Logs()
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true);
+        var mockLogger = new MockLogger<DryRunBucket>();
+        var bucket = new DryRunBucket(options, mockLogger.Object);
+
+        await bucket.UploadBundleAsync("test-key.tar.gz", [1, 2, 3]);
+
+        mockLogger.VerifyLog("This is a dry run - not uploading to S3", LogLevel.Information);
+    }
+
+    [Fact]
+    public async Task Bucket_UploadBundleAsync_PutsObjectInS3()
+    {
+        var options = BacklogParserOptionsHelper.Create(bucketName: "my-bucket");
+        var mockLogger = new MockLogger<Bucket>();
+        var mockAmazonS3 = new Mock<IAmazonS3>();
+        var bucket = new Bucket(mockAmazonS3.Object, options, mockLogger.Object);
+
+        await bucket.UploadBundleAsync("test-key.tar.gz", [1, 2, 3]);
+
+        mockLogger.VerifyLog("Uploading test-key.tar.gz to S3", LogLevel.Information);
+        mockAmazonS3.Verify(x => x.PutObjectAsync(
+            It.Is<PutObjectRequest>(putObjectRequest => putObjectRequest.BucketName == "my-bucket"
+                                                        && putObjectRequest.Key == "test-key.tar.gz"
+                                                        && putObjectRequest.ContentType == "application/gzip"
+                                                        && putObjectRequest.InputStream.Length == 3),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/test/backlog/TestBucket.cs
+++ b/test/backlog/TestBucket.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -65,6 +66,9 @@ public class TestBucket(ITestOutputHelper testOutputHelper)
         var options = BacklogParserOptionsHelper.Create(bucketName: "my-bucket");
         var mockLogger = new MockLogger<Bucket>();
         var mockAmazonS3 = new Mock<IAmazonS3>();
+        mockAmazonS3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+        
         var bucket = new Bucket(mockAmazonS3.Object, options, mockLogger.Object);
 
         await bucket.UploadBundleAsync("test-key.tar.gz", [1, 2, 3]);
@@ -76,5 +80,21 @@ public class TestBucket(ITestOutputHelper testOutputHelper)
                                                         && putObjectRequest.ContentType == "application/gzip"
                                                         && putObjectRequest.InputStream.Length == 3),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Bucket_UploadBundleAsync_WhenS3UploadFails_ThrowsProblemUploadingFileToS3Exception()
+    {
+        var options = BacklogParserOptionsHelper.Create(bucketName: "my-bucket");
+        var mockLogger = new MockLogger<Bucket>();
+        var mockAmazonS3 = new Mock<IAmazonS3>();
+        mockAmazonS3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.InternalServerError });
+
+        var bucket = new Bucket(mockAmazonS3.Object, options, mockLogger.Object);
+
+        await Assert.ThrowsAsync<ProblemUploadingFileToS3Exception>(() =>
+            bucket.UploadBundleAsync("test-key.tar.gz", [1, 2, 3])
+        );
     }
 }

--- a/test/backlog/TestProgram.cs
+++ b/test/backlog/TestProgram.cs
@@ -29,7 +29,7 @@ public class TestProgram(ITestOutputHelper testOutputHelper)
 
         var services = new ServiceCollection();
 
-        Backlog.Src.Program.ConfigureDependencyInjection(services);
+        Backlog.Program.ConfigureDependencyInjection(services);
 
         using var serviceProvider = services.BuildServiceProvider();
         var timeProvider = serviceProvider.GetRequiredService<TimeProvider>();

--- a/test/backlog/TestProgram.cs
+++ b/test/backlog/TestProgram.cs
@@ -2,6 +2,9 @@
 
 using System;
 
+using Backlog;
+using Backlog.Options;
+
 using Microsoft.Extensions.DependencyInjection;
 
 using test.backlog.EndToEndTests;
@@ -10,10 +13,14 @@ using Xunit;
 
 namespace test.backlog;
 
-public class TestProgram(ITestOutputHelper testOutputHelper)
-    : BaseEndToEndTests(
-        testOutputHelper) // This isn't an end to end test but it does touch static state shared with the end to end tests
+public class TestProgram : BaseEndToEndTests // This isn't an end to end test but it does touch static state shared with the end to end tests
 {
+    public TestProgram(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+        // Ensure that we're not running with test dependency injections
+        Environment.SetEnvironmentVariable("IS_TEST", null);
+    }
+
     protected override void Dispose(bool disposing)
     {
         //Set IS_TEST to true so that the main dispose can clean up any state changes
@@ -24,9 +31,6 @@ public class TestProgram(ITestOutputHelper testOutputHelper)
     [Fact]
     public void ConfigureDependencyInjection_RegistersSystemTimeProvider()
     {
-        // Ensure that we're not running with test dependency injections
-        Environment.SetEnvironmentVariable("IS_TEST", null);
-
         var services = new ServiceCollection();
 
         Backlog.Program.ConfigureDependencyInjection(services);
@@ -35,5 +39,35 @@ public class TestProgram(ITestOutputHelper testOutputHelper)
         var timeProvider = serviceProvider.GetRequiredService<TimeProvider>();
 
         Assert.Same(TimeProvider.System, timeProvider);
+    }
+
+    [Fact]
+    public void ConfigureDependencyInjection_WhenIsDryRunTrue_RegistersDryRunBucket()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.Configure<BacklogParserOptions>(o => o.IsDryRun = true);
+
+        Backlog.Program.ConfigureDependencyInjection(services, isDryRun: true);
+
+        using var provider = services.BuildServiceProvider();
+        var bucket = provider.GetRequiredService<IBucket>();
+
+        Assert.IsType<DryRunBucket>(bucket);
+    }
+
+    [Fact]
+    public void ConfigureDependencyInjection_WhenIsDryRunFalse_RegistersBucket()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.Configure<BacklogParserOptions>(o => o.IsDryRun = false);
+
+        Backlog.Program.ConfigureDependencyInjection(services, isDryRun: false);
+
+        using var provider = services.BuildServiceProvider();
+        var bucket = provider.GetRequiredService<IBucket>();
+
+        Assert.IsType<Bucket>(bucket);
     }
 }


### PR DESCRIPTION
The dry run flag hasn't been working properly for a while which makes it harder to run the parser locally. The problem was that even in dry run mode, the AWS credentials needed to be set up to configure the `AmazonS3` client (which was needed for the `Bucket` which was needed for the `BacklogParserWorker`).
This PR fixes the issue by registering different buckets depending upon whether or not we are in dry run mode. This has the added bonus of removing some complexity from the main `BacklogParserWorker`

## Changes

 - Add `DryRunBucket` and register when in dry run mode
 - Update some namespaces to remove spurious `.Src`
 - Move async waiting to higher level to enable more async usage
 - Ensure that S3 uploads are successful