### PR TITLE
Backlog: Add Options validation and testable file io wrapper

### DIFF
--- a/backlog/backlog.csproj
+++ b/backlog/backlog.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../judgments.csproj"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
+    <ProjectReference Include="../judgments.csproj" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.27" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.28" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />

--- a/backlog/src/Options/BacklogParserOptions.cs
+++ b/backlog/src/Options/BacklogParserOptions.cs
@@ -1,15 +1,29 @@
 #nullable enable
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO.Abstractions;
+
+using Microsoft.Extensions.Options;
+
 namespace Backlog.Options;
 
 public sealed class BacklogParserOptions
 {
     public static readonly string SectionName = "BacklogParser";
-    public required string MetadataProvidedFilePathPrefix { get; set; }
-    public required string TransferMetadataFilePathPrefix { get; set; }
-    
+    public string MetadataProvidedFilePathPrefix { get; set; } = string.Empty;
+    public string TransferMetadataFilePathPrefix { get; set; } = string.Empty;
+
+    [Required]
     public required string CourtMetadataFilePath { get; set; }
+
+    [Required]
     public required string DataFolderPath { get; set; }
+
+    [Required]
     public required string OutputFolderPath { get; set; }
+
+    [Required]
     public required string TrackerFilePath { get; set; }
 
     public string? BucketName { get; set; }
@@ -17,4 +31,39 @@ public sealed class BacklogParserOptions
     public bool IsDryRun { get; set; }
     public uint? SingleIdToRun { get; set; }
     public bool AutoPublish { get; set; }
+}
+
+public class BacklogParserOptionsValidation(IFileSystem fileSystem) : IValidateOptions<BacklogParserOptions>
+{
+    public ValidateOptionsResult Validate(string? name, BacklogParserOptions options)
+    {
+        var validateOptionsResultBuilder = new ValidateOptionsResultBuilder();
+        var validationResults = new List<ValidationResult>();
+
+        Validator.TryValidateObject(options, new ValidationContext(options), validationResults, true);
+        if (string.IsNullOrWhiteSpace(options.BucketName) && !options.IsDryRun)
+        {
+            validationResults.Add(new ValidationResult(
+                $"{nameof(options.BucketName)} must be set when {nameof(options.IsDryRun)} is false",
+                [nameof(options.BucketName), nameof(options.IsDryRun)]));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.CourtMetadataFilePath) && !fileSystem.File.Exists(options.CourtMetadataFilePath))
+        {
+            validationResults.Add(new ValidationResult(
+                $"{nameof(options.CourtMetadataFilePath)} \"{options.CourtMetadataFilePath}\" does not exist",
+                [nameof(options.CourtMetadataFilePath)]));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.DataFolderPath) && !fileSystem.Directory.Exists(options.DataFolderPath))
+        {
+            validationResults.Add(new ValidationResult(
+                $"{nameof(options.DataFolderPath)} \"{options.DataFolderPath}\" does not exist",
+                [nameof(options.DataFolderPath)]));
+        }
+
+        validateOptionsResultBuilder.AddResults(validationResults);
+
+        return validateOptionsResultBuilder.Build();
+    }
 }

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -178,7 +178,8 @@ public class Program
                    options.IsDryRun = isDryRun;
                    options.SingleIdToRun = id;
                    options.AutoPublish = autoPublish;
-               });
+               })
+               .Services.AddSingleton<IValidateOptions<BacklogParserOptions>, BacklogParserOptionsValidation>();
 
         // We need access to the DataFolderPath right now to configure where the log file goes, but we can't get to our
         // bound options object until after the full service configuration has occurred. This means we need to grab the

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using System.IO.Abstractions;
 
 using Amazon.S3;
 
@@ -227,6 +228,7 @@ public class Program
 
         services.AddScoped<MetadataTransformer>();
         services.AddScoped<TimeProvider>(_ => TimeProvider.System);
+        services.AddSingleton<IFileSystem, FileSystem>();
 
         if (IsTest())
         {

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -278,6 +278,19 @@ namespace test.backlog.EndToEndTests
         }
 
         [Fact]
+        public void ProcessBacklogJudgment_WithInvalidConfiguration_ReturnsError()
+        {
+            ConfigureTestEnvironment("Sultan Others");
+            SetPathEnvironmentVariables("not/a/data/directory", "", "not/a/courtmetadata.csv");
+            
+            // Act
+            var exitCode = Backlog.Program.Main();
+
+            // Assert
+            Assert.Equal(1, exitCode);
+        }
+
+        [Fact]
         public void ProcessBacklogJudgment_WithInvalidIdArgument_ReturnsError()
         {
             // Act

--- a/test/backlog/TestBacklogParserOptionsValidation.cs
+++ b/test/backlog/TestBacklogParserOptionsValidation.cs
@@ -1,0 +1,141 @@
+#nullable enable
+
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+
+using Backlog.Options;
+
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace test.backlog;
+
+public class TestBacklogParserOptionsValidation
+{
+    private readonly BacklogParserOptionsValidation validator;
+
+    public TestBacklogParserOptionsValidation()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory(@"c:\my-data-dir\");
+        fileSystem.AddFile(@"c:\my-data-dir\court-metadata.csv", new MockFileData(""));
+        validator = new BacklogParserOptionsValidation(fileSystem);
+    }
+
+    private static void AssertSingleFailure(ValidateOptionsResult result, string expectedFailureMessage)
+    {
+        Assert.True(result.Failed);
+        var failureMessage = Assert.Single(result.Failures);
+        Assert.Equal(expectedFailureMessage, failureMessage);
+    }
+
+    [Fact]
+    public void Validate_WithValidOptions_ReturnsSuccess()
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true).Value;
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failures);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WhenNotDryRunAndBucketNameIsNullOrEmpty_ReturnsFailed(string? bucketName)
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: false, bucketName: bucketName).Value;
+
+        var result = validator.Validate(null, options);
+
+        AssertSingleFailure(result, "BucketName, IsDryRun: BucketName must be set when IsDryRun is false");
+    }
+
+    [Fact]
+    public void Validate_WhenNotDryRunAndBucketNameIsSet_ReturnsSuccess()
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: false, bucketName: "my-bucket").Value;
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failures);
+    }
+
+    [Theory]
+    [InlineData("", "CourtMetadataFilePath: The CourtMetadataFilePath field is required.")]
+    [InlineData(" ", "CourtMetadataFilePath: The CourtMetadataFilePath field is required.")]
+    [InlineData("/nonexistent/file.csv", """CourtMetadataFilePath: CourtMetadataFilePath "/nonexistent/file.csv" does not exist""")]
+    public void Validate_WhenCourtMetadataFilePathIsInvalid_ReturnsFailed(string courtMetadataFilePath, string expectedFailureMessage)
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true, courtMetadataFilePath: courtMetadataFilePath).Value;
+
+        var result = validator.Validate(null, options);
+
+        AssertSingleFailure(result, expectedFailureMessage);
+    }
+
+    [Theory]
+    [InlineData("", "DataFolderPath: The DataFolderPath field is required.")]
+    [InlineData(" ", "DataFolderPath: The DataFolderPath field is required.")]
+    [InlineData("/nonexistent/folder", """DataFolderPath: DataFolderPath "/nonexistent/folder" does not exist""")]
+    public void Validate_WhenDataFolderPathIsInvalid_ReturnsFailed(string dataFolderPath, string expectedFailureMessage)
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true, dataFolderPath: dataFolderPath).Value;
+
+        var result = validator.Validate(null, options);
+
+        AssertSingleFailure(result, expectedFailureMessage);
+    }
+
+    [Theory]
+    [InlineData("" )]
+    [InlineData(" ")]
+    public void Validate_WhenTrackerFilePathIsMissing_ReturnsFailed(string trackerFilePath)
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true, trackerFilePath:trackerFilePath).Value;
+
+        var result = validator.Validate(null, options);
+
+        AssertSingleFailure(result, "TrackerFilePath: The TrackerFilePath field is required.");
+    }
+    
+    [Theory]
+    [InlineData("" )]
+    [InlineData(" ")]
+    public void Validate_WhenOutputFolderPathIsMissing_ReturnsFailed(string outputFolderPath)
+    {
+        var options = BacklogParserOptionsHelper.Create(isDryRun: true, outputFolderPath:outputFolderPath).Value;
+
+        var result = validator.Validate(null, options);
+
+        AssertSingleFailure(result, "OutputFolderPath: The OutputFolderPath field is required.");
+    }
+
+    [Fact]
+    public void Validate_WithMultipleErrors_ReportsAllFailures()
+    {
+        var options = BacklogParserOptionsHelper.Create(
+            isDryRun: false,
+            bucketName: null,
+            trackerFilePath: "",
+            courtMetadataFilePath: "/nonexistent/file.csv",
+            dataFolderPath: "/nonexistent/folder").Value;
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Equal(
+            [
+                "TrackerFilePath: The TrackerFilePath field is required.",
+                "BucketName, IsDryRun: BucketName must be set when IsDryRun is false",
+                "CourtMetadataFilePath: CourtMetadataFilePath \"/nonexistent/file.csv\" does not exist",
+                "DataFolderPath: DataFolderPath \"/nonexistent/folder\" does not exist"
+            ],
+            result.Failures
+        );
+    }
+}

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="Xunit.CaptureConsole"/>
+    <AssemblyAttribute Include="Xunit.CaptureConsole" />
   </ItemGroup>
     
   <ItemGroup>
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
 


### PR DESCRIPTION
When configuring the backlog parser it is helpful to see all the configuration errors in one place so they can quickly be resolved. This PR adds that capability and also introduces the `TestableIO.System.IO.Abstractions` package which allows easy mocking of the filesystem

## Changes

- Validate options
- Add `TestableIO.System.IO.Abstractions`