### PR TITLE
FCLC-1938: Fix parser image uri

### DIFF
--- a/src/Exceptions.cs
+++ b/src/Exceptions.cs
@@ -3,3 +3,4 @@ using System;
 namespace UK.Gov.Legislation.Judgments;
 
 public class MetadataConflictException(string message) : Exception(message);
+public class UnknownDocumentPartException(string message) : Exception(message);

--- a/src/docx/Relationships.cs
+++ b/src/docx/Relationships.cs
@@ -1,6 +1,6 @@
+#nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using DocumentFormat.OpenXml;
@@ -9,67 +9,46 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 using Microsoft.Extensions.Logging;
 
-namespace UK.Gov.Legislation.Judgments.DOCX {
+namespace UK.Gov.Legislation.Judgments.DOCX;
 
-class Relationships {
+internal class Relationships
+{
+    private static readonly ILogger logger = Logging.Factory.CreateLogger<Relationships>();
 
-    private static ILogger logger = Logging.Factory.CreateLogger<UK.Gov.Legislation.Judgments.DOCX.Relationships>();
+    public static Uri? GetUriForImage(StringValue relationshipId, OpenXmlElement context)
+    {
+        var mainPart = GetMainPartFromElement(context);
 
-    // no longer needed in DocumentFormat.OpenXml 3.0; see https://github.com/dotnet/Open-XML-SDK/issues/1637
-    // public static readonly RelationshipErrorHandler.Rewriter MalformedUriRewriter = (part, id, uri) => {
-    //     logger.LogError("malformed URI: {uri}", uri);
-    //     return "http://error?original=" + uri;
-    // };
+        var uri = mainPart.Parts.FirstOrDefault(part => part.RelationshipId == relationshipId.Value).OpenXmlPart?.Uri;
 
-    public static Uri GetUriForImage(StringValue relationshipId, OpenXmlElement context) {
-        OpenXmlElement root = context;
-        while (root.Parent is not null)
-            root = root.Parent;
-        if (root is Document doc) {
-            MainDocumentPart main = doc.MainDocumentPart;
-            return GetUriForImage(main, relationshipId);
+        if (uri != null)
+        {
+            return uri;
         }
-        if (root is Header header) {
-            HeaderPart headerPart = header.HeaderPart;
-            return GetUriForImage(headerPart, relationshipId);
-        }
-        throw new Exception();
+
+        logger.LogCritical("potentially missing image: relationship id = {RelationshipId}", relationshipId);
+        return mainPart.ExternalRelationships.FirstOrDefault(r => r.Id == relationshipId.Value)
+                       ?.Uri; // EWCA/Civ/2003/1067
     }
 
-    public static Uri GetUriForImage(MainDocumentPart main, StringValue relationshipId) {
-        var part = main.Parts.Where(part => part.RelationshipId == relationshipId.Value).FirstOrDefault();
-        if (part != default)
-            return part.OpenXmlPart?.Uri;
-        // IdPartPair changed from class to a readonly struct in DocumentFormat.OpenXml 3.0
-        logger.LogCritical("potentially missing image: relationship id = {}", relationshipId);
-        return main.ExternalRelationships.Where(r => r.Id == relationshipId.Value).FirstOrDefault()?.Uri; // EWCA/Civ/2003/1067
+    private static OpenXmlPart GetMainPartFromElement(OpenXmlElement element)
+    {
+        var root = element.Ancestors<OpenXmlPartRootElement>().Single();
+
+        return root switch
+        {
+            Document document => document.MainDocumentPart!,
+            Header header => header.HeaderPart!,
+            Footnotes footnotes => footnotes.FootnotesPart!,
+            Endnotes endnotes => endnotes.EndnotesPart!,
+            _ => throw new UnknownDocumentPartException(root.GetType().ToString())
+        };
     }
 
-    public static Uri GetUriForImage(HeaderPart header, StringValue relationshipId) {
-        OpenXmlPart part = header.Parts.Where(part => part.RelationshipId == relationshipId.Value).First().OpenXmlPart;
-        return part.Uri;
+    public static Uri GetUriForHyperlink(Hyperlink link)
+    {
+        var mainPart = GetMainPartFromElement(link);
+
+        return mainPart.HyperlinkRelationships.First(r => r.Id == link.Id).Uri;
     }
-
-    public static Uri GetUriForHyperlink(OpenXmlElement e, StringValue relationshipId) {
-        OpenXmlPartRootElement root = e.Ancestors<OpenXmlPartRootElement>().First();
-        IEnumerable<HyperlinkRelationship> relationships;
-        if (root is Document document)
-            relationships = document.MainDocumentPart.HyperlinkRelationships;
-        else if (root is Header header)
-            relationships = header.HeaderPart.HyperlinkRelationships;
-        else if (root is Footnotes footnotes)
-            relationships = footnotes.FootnotesPart.HyperlinkRelationships;
-        else if (root is Endnotes endnotes)
-            relationships = endnotes.EndnotesPart.HyperlinkRelationships;
-        else
-            throw new Exception();
-        return relationships.Where(r => r.Id == relationshipId).First().Uri;
-    }
-
-    public static Uri GetUriForHyperlink(Hyperlink link) {
-        return GetUriForHyperlink(link, link.Id);
-    }
-
-}
-
 }

--- a/test/Docx/TestRelationships.cs
+++ b/test/Docx/TestRelationships.cs
@@ -1,0 +1,79 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+using test.Mocks;
+
+using UK.Gov.Legislation.Judgments.DOCX;
+
+using Xunit;
+
+namespace test.Docx;
+
+public class TestRelationships
+{
+    public static IEnumerable<object[]> RootParts =
+    [
+        [new GetDocumentArea<MainDocumentPart>(d => (d.Body, d.MainDocumentPart))],
+        [new GetDocumentArea<HeaderPart>(d => (d.Header, d.HeaderPart))],
+        [new GetDocumentArea<FootnotesPart>(d => (d.Footnotes, d.FootnotesPart))],
+        [new GetDocumentArea<EndnotesPart>(d => (d.Endnotes, d.EndnotesPart))]
+    ];
+
+    public delegate (OpenXmlCompositeElement rootElement, T part)
+        GetDocumentArea<T>(MockWordprocessingDocument document)
+        where T : OpenXmlPart, ISupportedRelationship<ImagePart>;
+
+    [Theory]
+    [MemberData(nameof(RootParts))]
+    public void GetUriForHyperlink_should_return_correct_uri<T>(GetDocumentArea<T> getDocumentArea)
+        where T : OpenXmlPart, ISupportedRelationship<ImagePart>
+    {
+        using var mockWordprocessingDocument = new MockWordprocessingDocument();
+
+        var docUri = new Uri("https://example.com/some-link");
+        var (rootElement, part) = getDocumentArea(mockWordprocessingDocument);
+
+        var docHyperlink = rootElement.AppendChild(new Paragraph())
+                                      .AddHyperlink(part, docUri);
+
+        Assert.Equal(docUri, Relationships.GetUriForHyperlink(docHyperlink));
+    }
+
+    [Theory]
+    [MemberData(nameof(RootParts))]
+    public void GetUriForImage_should_return_uri_for_internal_image<T>(GetDocumentArea<T> getDocumentArea)
+        where T : OpenXmlPart, ISupportedRelationship<ImagePart>
+    {
+        using var mockWordprocessingDocument = new MockWordprocessingDocument();
+        var (rootElement, part) = getDocumentArea(mockWordprocessingDocument);
+
+        var drawing = rootElement.AppendChild(new Paragraph())
+                                 .AddImage(part, out var imagePart, out var relationshipId);
+        var relId = new StringValue(relationshipId);
+
+        Assert.Equal(imagePart.Uri, Relationships.GetUriForImage(relId, drawing));
+    }
+
+    [Theory]
+    [MemberData(nameof(RootParts))]
+    public void GetUriForImage_should_return_uri_for_external_image<T>(GetDocumentArea<T> getDocumentArea)
+        where T : OpenXmlPart, ISupportedRelationship<ImagePart>
+    {
+        using var mockWordprocessingDocument = new MockWordprocessingDocument();
+
+        var (rootElement, part) = getDocumentArea(mockWordprocessingDocument);
+        var uri = new Uri("https://example.com/external-image.png");
+
+        var drawing = rootElement.AppendChild(new Paragraph())
+                                 .AddExternalImageToDocument(part, uri, out var relationshipId);
+        var relId = new StringValue(relationshipId);
+
+        Assert.Equal(uri, Relationships.GetUriForImage(relId, drawing));
+    }
+}

--- a/test/Mocks/MockWordprocessingDocument.cs
+++ b/test/Mocks/MockWordprocessingDocument.cs
@@ -1,0 +1,175 @@
+#nullable enable
+
+using System;
+using System.IO;
+
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+using Drawing = DocumentFormat.OpenXml.Drawing;
+using DrawingWordProcessing = DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using DrawingPictures = DocumentFormat.OpenXml.Drawing.Pictures;
+
+namespace test.Mocks;
+
+public sealed class MockWordprocessingDocument : IDisposable
+{
+    private readonly WordprocessingDocument wordDocument;
+    public MainDocumentPart MainDocumentPart { get; }
+    public HeaderPart HeaderPart { get; }
+    public FootnotesPart FootnotesPart { get; }
+    public EndnotesPart EndnotesPart { get; }
+    public Body Body { get; } = new();
+    public Header Header { get; } = new();
+    public Footnotes Footnotes { get; } = new();
+    public Endnotes Endnotes { get; } = new();
+
+    public MockWordprocessingDocument()
+    {
+        wordDocument = WordprocessingDocument.Create(new MemoryStream(), WordprocessingDocumentType.Document);
+
+        MainDocumentPart = wordDocument.AddMainDocumentPart();
+        MainDocumentPart.Document = new Document();
+        MainDocumentPart.Document.AppendChild(Body);
+
+        HeaderPart = MainDocumentPart.AddNewPart<HeaderPart>();
+        HeaderPart.Header = Header;
+        Header.AppendChild(new Paragraph(new Run(new Text("This is a header."))));
+        Body.AppendChild(
+            new SectionProperties(
+                new HeaderReference
+                {
+                    Type = HeaderFooterValues.Default, Id = MainDocumentPart.GetIdOfPart(HeaderPart)
+                }));
+
+
+        EndnotesPart = MainDocumentPart.AddNewPart<EndnotesPart>();
+        EndnotesPart.Endnotes = Endnotes;
+        Endnotes.AppendChild(new Endnote(new Paragraph(new Run(new Text("This is endnote content.")))));
+        Body.AppendChild(new Paragraph(new Run(new Text("Body text with an endnote")),
+            new Run(new EndnoteReference())));
+
+        FootnotesPart = MainDocumentPart.AddNewPart<FootnotesPart>();
+        FootnotesPart.Footnotes = Footnotes;
+        Footnotes.AppendChild(new Footnote(new Paragraph(new Run(new Text("This is footnote content.")))));
+        Body.AppendChild(new Paragraph(new Run(new Text("Body text with a footnote")),
+            new Run(new FootnoteReference())));
+    }
+
+    public void Dispose()
+    {
+        wordDocument.Dispose();
+    }
+}
+
+public static class MockWordprocessingDocumentExtensions
+{
+    public static DocumentFormat.OpenXml.Wordprocessing.Drawing AddExternalImageToDocument(
+        this OpenXmlCompositeElement element, OpenXmlPart part, Uri uri, out string relationshipId)
+    {
+        relationshipId =
+            part.AddExternalRelationship("http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+                uri).Id;
+
+        var drawingElement = AddDrawingForImage(relationshipId);
+
+        var run = new Run();
+        run.AppendChild(drawingElement);
+
+        element.AppendChild(run);
+
+        return drawingElement;
+    }
+
+    public static Hyperlink AddHyperlink(this OpenXmlCompositeElement element, OpenXmlPart part, Uri uri)
+    {
+        return element.AppendChild(new Hyperlink(new Run(new Text(uri.ToString())))
+        {
+            Id = part.AddHyperlinkRelationship(uri, true).Id
+        });
+    }
+
+
+    public static DocumentFormat.OpenXml.Wordprocessing.Drawing AddImage<T>(this OpenXmlCompositeElement element,
+        T part, out ImagePart imagePart, out string relationshipId)
+        where T : OpenXmlPart, ISupportedRelationship<ImagePart>
+    {
+        imagePart = part.AddImagePart(ImagePartType.Jpeg);
+        relationshipId = part.GetIdOfPart(imagePart);
+
+        var drawingElement = AddDrawingForImage(relationshipId);
+
+        var run = new Run();
+        run.AppendChild(drawingElement);
+
+        element.AppendChild(run);
+
+        return drawingElement;
+    }
+
+    public static DocumentFormat.OpenXml.Wordprocessing.Drawing AddDrawingForImage(string relationshipId)
+    {
+        var inline = new DrawingWordProcessing.Inline(new DrawingWordProcessing.Extent { Cx = 990000L, Cy = 792000L },
+            new DrawingWordProcessing.EffectExtent
+            {
+                LeftEdge = 0L,
+                TopEdge = 0L,
+                RightEdge = 0L,
+                BottomEdge = 0L
+            }, new DrawingWordProcessing.DocProperties { Id = (UInt32Value)1U, Name = "Picture 1" },
+            new DrawingWordProcessing.NonVisualGraphicFrameDrawingProperties(
+                new Drawing.GraphicFrameLocks { NoChangeAspect = true }), new Drawing.Graphic(
+                new Drawing.GraphicData(
+                    new DrawingPictures.Picture(
+                        new DrawingPictures.NonVisualPictureProperties(
+                            new DrawingPictures.NonVisualDrawingProperties
+                            {
+                                Id = (UInt32Value)0U, Name = "New Bitmap Image.jpg"
+                            },
+                            new DrawingPictures.NonVisualPictureDrawingProperties()
+                        ),
+                        new DrawingPictures.BlipFill(
+                            new Drawing.Blip(
+                                new Drawing.BlipExtensionList(
+                                    new Drawing.BlipExtension
+                                    {
+                                        Uri =
+                                            "{28A0092B-C50C-407E-A947-70E740481C1C}"
+                                    }
+                                )
+                            )
+                            {
+                                Embed = relationshipId,
+                                CompressionState =
+                                    Drawing.BlipCompressionValues.Print
+                            },
+                            new Drawing.Stretch(
+                                new Drawing.FillRectangle()
+                            )
+                        ),
+                        new DrawingPictures.ShapeProperties(
+                            new Drawing.Transform2D(
+                                new Drawing.Offset { X = 0L, Y = 0L },
+                                new Drawing.Extents { Cx = 990000L, Cy = 792000L }
+                            ),
+                            new Drawing.PresetGeometry(
+                                new Drawing.AdjustValueList()
+                            ) { Preset = Drawing.ShapeTypeValues.Rectangle }
+                        )
+                    )
+                ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" }
+            ))
+        {
+            DistanceFromTop = (UInt32Value)0U,
+            DistanceFromBottom = (UInt32Value)0U,
+            DistanceFromLeft = (UInt32Value)0U,
+            DistanceFromRight = (UInt32Value)0U,
+            EditId = "50D07946"
+        };
+
+        var drawingElement = new DocumentFormat.OpenXml.Wordprocessing.Drawing();
+        drawingElement.AppendChild(inline);
+        return drawingElement;
+    }
+}


### PR DESCRIPTION
Fixes issue with getting images from the footer and endnotes and also adds first docx unit tests

## Changes

- Make docx relationships code all look at footer and end notes as well as header and body
- Add unit tests for docx parsing