### PR TITLE
FCLC 1841 - Add bulk upload playbook

### DIFF
--- a/backlog/README.md
+++ b/backlog/README.md
@@ -29,6 +29,8 @@ This module provides a specialized entry point to the parser specifically design
 
 Please refer to the [internal documentation](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1437794305/) for details on the full process including retrieving and validating inputs, performing file conversions and what to look for when doing a dry run.
 
+Please refer to [wider bulk upload process](./bulk-upload-process.md) for more details on how bulk upload affects the rest of the system and how to ensure that it is successful.
+
 ### Pre-requisites
 
 - .NET 8 SDK

--- a/backlog/docs/bulk-upload-process.md
+++ b/backlog/docs/bulk-upload-process.md
@@ -1,0 +1,162 @@
+# Wider Bulk Upload process
+
+<!-- TOC -->
+* [Wider Bulk Upload process](#wider-bulk-upload-process)
+  * [Bulk ingestion events](#bulk-ingestion-events-)
+  * [Running a bulk upload](#running-a-bulk-upload)
+  * [Verifying document status after a bulk upload](#verifying-document-status-after-a-bulk-upload)
+    * [Get logs as csv](#get-logs-as-csv)
+      * [Backlog tracker csv](#backlog-tracker-csv)
+      * [AWS Ingester logs](#aws-ingester-logs)
+      * [MarkLogic logs](#marklogic-logs)
+    * [Consolidating log CSVs with DuckDB](#consolidating-log-csvs-with-duckdb)
+    * [Analysing the logs](#analysing-the-logs)
+<!-- TOC -->
+
+The Bulk upload process is triggered by the backlog parser but runs through multiple services. 
+
+When bulk uploading a batch we need to:
+
+- Ensure inputs are valid (see [internal documentation](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1437794305/))
+- Run a batch through the parser (see [readme backlog parser instructions](../README.md#backlog-parser))
+- See where in the overall process each document got to so we can:
+  - Rerun transient failures
+  - Ensure that the correct documents are getting published
+  - Catalog / fix other errors
+
+## Bulk ingestion events  
+
+  ```mermaid
+  graph TD
+
+    subgraph Log locations
+      direction LR  
+      tracker[Parser tracker csv]
+      cloudwatch[AWS Cloudwatch logs]
+      marklogic[Marklogic query]
+    end
+    tracker -.- backlog_Parser 
+    subgraph backlog_Parser [Backlog parser]
+      parse_csv[Parse external csv metadata]
+      parse_doc[Parse document]
+      build_stub[Build stub]
+      write_output[Write output locally]
+      upload_to_s3[Upload to S3 bulk ingest bucket]
+      
+      parse_csv -- if docx --> parse_doc
+      parse_csv -- if pdf --> build_stub
+
+      parse_doc & build_stub --> write_output --> upload_to_s3
+    end
+
+    cloudwatch -.- sns_topic[SNS] & sqs_queue[SQS]
+    backlog_Parser -- object creation event --> sns_topic
+    sns_topic --> sqs_queue
+    sqs_queue --> lambda_triggered
+
+    cloudwatch -.- Ingester
+    subgraph Ingester [Ingester]
+      lambda_triggered[Lambda triggered]
+      retrieve_doc[Retrieve document from s3]
+      ingest_doc[Ingest document]
+      enrich_doc[Send for enrichment]
+      publish_doc[Publish document]
+
+      lambda_triggered --> retrieve_doc
+      retrieve_doc --> ingest_doc
+      ingest_doc --> publish_doc & enrich_doc
+      publish_doc
+    end
+
+    ingest_doc -.-> eui([Document accessible on EUI])
+    publish_doc -.-> pui([Document accessible on PUI])
+    marklogic -.- eui & pui
+  ```
+
+## Running a bulk upload
+
+Please refer to the [internal documentation](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1437794305/) for details on the full process including retrieving and validating inputs, performing file conversions and what to look for when doing a dry run.
+See [configure and run backlog parser](../README.md#backlog-parser) for details on commands and flags.
+
+## Verifying document status after a bulk upload
+
+### Get logs as csv
+
+#### Backlog tracker csv
+
+Found in [backlog parser outputs](../README.md#tracker-csv)
+
+#### AWS Ingester logs
+
+- Go to Cloudwatch Logs Insights and filter on appropriate log group in dropdown
+- Run:
+    ```
+    fields @requestId, @message
+    | filter ispresent(@requestId)                                                                                                   
+    | parse @message /(?<markLogic>d-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+    | parse @message /(?<tre>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.tar\.gz/                                 
+    | parse @message /^\[(?<logSeverity>.*?)\]\s+(?<logTimestamp>[^ ]+?)\s+[-0-9a-f]*\s+(?<logMessage>.*?)$/                       
+    | parse @message /(?<ncn>\[\d{4}\]\s+[A-Z]+\s+\d+(\s+\([A-Z0-9]+\))?)/                       
+    | fields                                                                                                                         
+        if(logSeverity = 'INFO',    concat(logTimestamp, ' | ', logMessage), '') as _i,                                              
+        if(logSeverity = 'WARNING', concat(logTimestamp, ' | ', logMessage), '') as _w,                                              
+        if(logSeverity = 'ERROR',   concat(logTimestamp, ' | ', logMessage), '') as _e                                               
+    | stats                                                                                                                          
+        sortsFirst(markLogic) as markLogicUri,                                                                                       
+        sortsFirst(tre) as treReference,                                                                         
+        sortsFirst(ncn) as ncnReference,
+        sortsLast(_i) as lastInfoMessage,                                                                                            
+        sortsLast(_w) as lastWarningMessage,                                                                                       
+        sortsLast(_e) as lastErrorMessage,                                                                                           
+        latest(@message) as lambdaReport                                                                                           
+      by @requestId
+    ```
+- Export results to csv
+
+#### MarkLogic logs
+
+- Go to MarkLogic Query Console
+- Run [marklogic-ingested-parser-run.xquery](./marklogic-ingested-parser-run.xquery) with parser-run-id from the tracker
+- Copy results as raw text and paste into a new csv file
+
+### Consolidating log CSVs with DuckDB
+
+Use [DuckDB](https://duckdb.org/docs/current/clients/cli/overview) to query the csv files and consolidate into a single csv file.
+
+```bash
+brew install duckdb
+```
+
+Then run:
+
+```bash
+consolidate_bulk_logs.sh
+```
+
+### Analysing the logs
+
+Open the consolidated csv ([OpenRefine](https://openrefine.org/) is a good tool for this) and investigate any documents that are **not** in `Published` or `ParserFailed` states. These are the documents that encountered errors during the ingestion and publishing process and could indicate wider issues.
+
+```mermaid
+graph TD
+    each[[For each document]] --> statePublished
+    statePublished{Is state Published?}
+    statePublished -- yes --> stateParserFailed
+    statePublished -- no --> ok([Not a concern])
+    stateParserFailed{Is state ParserFailed?}
+    stateParserFailed -- yes --> log(["
+    Document not sent to S3. 
+    Record reasons for parser failure and fix later
+    "])
+    stateParserFailed -- no --> isDuplicate
+    isDuplicate{Does the NCN match a published document?}
+    isDuplicate -- yes --> dedupe(["
+    Work out which duplicate we want
+    to keep - it might not be the one
+    that actually got published"])
+    isDuplicate -- no --> analyse(["
+    Analyse the error further to make sure
+    there's not a wider issue.
+    Use AWS_request_id to get all the
+    logs about a specific ingestion in AWS"])
+```

--- a/backlog/docs/consolidate_bulk_logs.sh
+++ b/backlog/docs/consolidate_bulk_logs.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [--parser <file>] [--cloudwatch <file>] [--marklogic <file>] [--output <file>]"
+    echo "  Any omitted file argument will open a file picker dialog."
+    exit "${1:-1}"
+}
+
+pick_file() {
+    osascript -e "POSIX path of (choose file with prompt \"$1\")" \
+        || { echo "Selection cancelled."; exit 1; }
+}
+
+pick_save() {
+    osascript -e "POSIX path of (choose file name with prompt \"$1\" default name \"$2\")" \
+        || { echo "Selection cancelled."; exit 1; }
+}
+
+show_if_any() {
+    local status="$1" query="$2"
+    local count
+    count=$(duckdb -csv -c "SELECT COUNT(*) FROM '${OUTPUT_CSV}' WHERE status = '${status}';" | tail -1)
+    [[ "$count" -gt 0 ]] || return 0
+    echo ""
+    echo "────────────────────────────── ${status} (${count}) ──────────────────────────────"
+    duckdb -c "${query}"
+}
+
+command -v duckdb >/dev/null 2>&1 || { echo "duckdb is not installed."; exit 1; }
+
+PARSER_CSV="" CLOUDWATCH_CSV="" MARKLOGIC_CSV="" OUTPUT_CSV=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --parser)     PARSER_CSV="$2";     shift 2 ;;
+        --cloudwatch) CLOUDWATCH_CSV="$2"; shift 2 ;;
+        --marklogic)  MARKLOGIC_CSV="$2";  shift 2 ;;
+        --output)     OUTPUT_CSV="$2";     shift 2 ;;
+        --help|-h) usage 0 ;;
+        *) echo "Unknown argument: $1"; usage ;;
+    esac
+done
+
+[[ -z "$PARSER_CSV"     ]] && PARSER_CSV=$(pick_file     "Select Parser Tracker CSV")
+[[ -z "$CLOUDWATCH_CSV" ]] && CLOUDWATCH_CSV=$(pick_file "Select CloudWatch CSV")
+[[ -z "$MARKLOGIC_CSV"  ]] && MARKLOGIC_CSV=$(pick_file  "Select MarkLogic CSV")
+[[ -z "$OUTPUT_CSV"     ]] && OUTPUT_CSV=$(pick_save     "Save consolidated output as…" "output.csv")
+
+for f in "$PARSER_CSV" "$CLOUDWATCH_CSV" "$MARKLOGIC_CSV"; do
+    [[ -f "$f" ]] || { echo "File not found: $f"; exit 1; }
+done
+
+duckdb -c "
+COPY (
+    SELECT pt.* EXCLUDE rn, cw.* EXCLUDE treReference, ml.*,
+        CASE
+            WHEN ml.AWS_request_id IS NOT NULL AND ml.published = 'true'  THEN 'Published'
+            WHEN ml.AWS_request_id IS NOT NULL AND ml.published = 'false' THEN 'Ingested'
+            WHEN ml.AWS_request_id IS NOT NULL                            THEN 'unknown'
+            WHEN cw.treReference   IS NOT NULL                            THEN 'FailedIngestion'
+            ELSE pt.TrackerStatus
+        END AS status
+    FROM (
+        SELECT *, ROW_NUMBER() OVER (
+            PARTITION BY SourceUuid ORDER BY TrackerLineLastUpdated DESC
+        ) AS rn
+        FROM '${PARSER_CSV}'
+    ) pt
+    LEFT JOIN '${CLOUDWATCH_CSV}' cw
+           ON pt.TreReference = cw.treReference
+          AND pt.TreReference != ''
+    LEFT JOIN '${MARKLOGIC_CSV}' ml
+           ON cw.\"@requestId\" = ml.AWS_request_id
+    WHERE rn = 1
+) TO '${OUTPUT_CSV}' (HEADER, DELIMITER ',');
+"
+
+echo ""
+duckdb -c "
+SELECT status, COUNT(*) AS count FROM '${OUTPUT_CSV}' GROUP BY status ORDER BY count DESC;
+SELECT COUNT(*) AS total FROM '${OUTPUT_CSV}';
+"
+
+show_if_any "Ingested" \
+    "SELECT status, SourceUuid, TreReference, Ncn, document_URI, AWS_request_id, lambdaReport, published
+     FROM '${OUTPUT_CSV}' WHERE status = 'Ingested';"
+
+show_if_any "FailedIngestion" \
+    "SELECT status, SourceUuid, TreReference, Ncn, document_URI, AWS_request_id, lastErrorMessage, lastWarningMessage
+     FROM '${OUTPUT_CSV}' WHERE status = 'FailedIngestion';"
+
+show_if_any "unknown" \
+    "SELECT * FROM '${OUTPUT_CSV}' WHERE status = 'unknown';"
+
+echo ""
+echo "Output written to: ${OUTPUT_CSV}"
+echo ""
+echo "To explore the output interactively:"
+echo "  duckdb -cmd \"CREATE VIEW output AS SELECT * FROM '${OUTPUT_CSV}';\""
+echo ""

--- a/backlog/docs/marklogic-ingested-parser-run.xquery
+++ b/backlog/docs/marklogic-ingested-parser-run.xquery
@@ -1,0 +1,38 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+(: 
+   Creates a csv file with details of documents ingested by a specific backlog parser run.
+   See bulk-upload-process.md for full details.
+:)
+
+(: CHANGE ME to the specific parser run ID you want to look for :)
+let $target-run-id := "PUT_PARSER_RUN_ID_HERE"
+
+(: Search for documents last updated by given parser run ID :)
+let $results := cts:search(
+  collection("http://marklogic.com/collections/dls/latest-version"),
+    cts:properties-fragment-query(
+    cts:element-value-query(xs:QName("parser-run-id"), $target-run-id)
+  )
+)
+
+(: Create CSV output :)
+let $csv-header := "document_URI,fake_TRE_UUID,published,AWS_request_id"
+
+let $rows :=
+  for $doc in $results
+    let $uri := xdmp:node-uri($doc)
+
+    let $props := xdmp:document-properties($uri)
+    let $published := string($props//published)
+    
+    let $annotation := xdmp:unquote(string($props//dls:annotation), (), ("format-json"))/node()
+    let $fake-tre-uuid := string($annotation/payload/tre_raw_metadata/parameters/TRE/reference)
+    let $aws-request-id := string($annotation/payload/aws_lambda_context/aws_request_id)
+
+    (: Construct the CSV row :)
+    return fn:concat('"', $uri, '","', $fake-tre-uuid, '","', $published, '","', $aws-request-id, '"')
+
+(: Join each row with a newline character :)
+return string-join(($csv-header, $rows), "&#10;")


### PR DESCRIPTION
The Bulk upload process is triggered by the backlog parser but runs through multiple services - this PR adds documentation on how the wider process hangs together and provides tools to analyse different logs to determine the status of any given document.

## Changes

- Adds documentation on the wider bulk upload process and how to spot problems
- Adds scripts to gather and consolidate logs from MarkLogic and CloudWatch with the Tracker csv