### PR TITLE
Rename ContentHash to not collide with SHA256 primitive

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -287,6 +287,7 @@ internal class BacklogParserWorker(
 
     public static string Hash(byte[] content)
     {
+        // This is the hash of the source document
         var hash = SHA256.HashData(content);
         return BitConverter.ToString(hash).Replace("-", string.Empty).ToLower();
     }

--- a/src/akn/Builder.cs
+++ b/src/akn/Builder.cs
@@ -815,7 +815,7 @@ abstract class Builder {
     }
 
     protected static void AddHash(XmlDocument akn, string ns) {
-        string value = SHA256.Hash(akn);
+        string value = ContentHash.CalculateContentHash(akn);
         XmlNamespaceManager nsmgr = new XmlNamespaceManager(akn.NameTable);
         nsmgr.AddNamespace("akn", Builder.ns);
         XmlElement proprietary = (XmlElement) akn.SelectSingleNode("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary", nsmgr);

--- a/src/akn/ContentHash.cs
+++ b/src/akn/ContentHash.cs
@@ -1,6 +1,6 @@
 
 using System.IO;
-using Crypto = System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -8,7 +8,7 @@ using System.Xml.Xsl;
 
 namespace UK.Gov.Legislation.Judgments.AkomaNtoso {
 
-public class SHA256 {
+public class ContentHash {
 
     private static string xslt = @"<?xml version='1.0'?>
     <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' xmlns:akn='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' version='1.0'>
@@ -28,10 +28,10 @@ public class SHA256 {
         return textWriter.ToString();
     }
 
-    internal static string Hash(XmlDocument akn) {
+    internal static string CalculateContentHash(XmlDocument akn) {
         string text = RemoveMetadata(akn);
         text = Regex.Replace(text, @"\s", "").Normalize();
-        byte[] hash = Crypto.SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(text));
         return System.BitConverter.ToString(hash).Replace("-", string.Empty).ToLower();
     }
 


### PR DESCRIPTION
The content hash function (which takes the substantive body of the XML/HTML/Word Document and hashes the non-whitespace characters) was named `SHA256` which was deeply misleading.