### PR TITLE
refactor(backlog): rename contentHash to sourceHash

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -264,7 +264,7 @@ internal class BacklogParserWorker(
         var isStub = string.Equals(mimeType, "application/pdf", StringComparison.InvariantCultureIgnoreCase);
         var response = CreateResponse(csvLine, mimeType, sourceContent, isStub);
 
-        var contentHash = Hash(sourceContent);
+        var sourceHash = Hash(sourceContent);
         var images = response.Images?.ToArray() ?? [];
 
         var externalMetadataFields = metadataTransformer.CsvLineToMetadataFields(csvLine);
@@ -277,10 +277,10 @@ internal class BacklogParserWorker(
             bundleSourceFilename = csvLine.FileName + ".docx";
         }
 
-        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, bundleSourceFilename, csvLine.FileName, mimeType, contentHash,
+        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, bundleSourceFilename, csvLine.FileName, mimeType, sourceHash,
             images, response.Meta, externalMetadataFields, !isStub);
 
-        await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, contentHash);
+        await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash);
         
         return Bundle.Make(response, trePipelineMetadata, sourceContent, bundleSourceFilename, images);
     }

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -23,7 +23,7 @@ namespace Backlog.Src;
 internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserOptions, TimeProvider timeProvider)
 {
     internal FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
-        string primarySourceFilename, string sourceMimeType, string contentHash, Image[] images, Meta responseMeta,
+        string primarySourceFilename, string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
         List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText)
     {
         var metadata = new FullTreMetadata
@@ -57,7 +57,7 @@ internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserO
                         Filename = primarySourceFilename,
                         Mimetype = sourceMimeType,
                         Route = Route.Bulk,
-                        Sha256 = contentHash,
+                        Sha256 = sourceHash,
                         RouteDateTime = timeProvider.GetUtcNow().UtcDateTime
                     },
                     XmlContainsDocumentText = xmlContainsDocumentText
@@ -66,7 +66,7 @@ internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserO
                 {
                     AutoPublish = backlogParserOptions.Value.AutoPublish,
                     ErrorOnExistingDocument = true,
-                    Source = new SourceDocument { Format = sourceMimeType, Hash = contentHash }
+                    Source = new SourceDocument { Format = sourceMimeType, Hash = sourceHash }
                 }
             }
         };


### PR DESCRIPTION
This is to disambiguate it from the akn builder content hash which strips whitespace and hashes the xml