### PR TITLE
FCLC-1987 add more fields to backlog tracker output

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -280,7 +280,7 @@ internal class BacklogParserWorker(
         var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, bundleSourceFilename, csvLine.FileName, mimeType, sourceHash,
             images, response.Meta, externalMetadataFields, !isStub);
 
-        await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash);
+        await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash, response.Meta.Name);
         
         return Bundle.Make(response, trePipelineMetadata, sourceContent, bundleSourceFilename, images);
     }

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -22,7 +22,7 @@ internal interface ITracker
     bool IsAlreadySentToIngester(Guid sourceUuid);
     Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, Guid parserRunId, string csvMetadataHash);
 
-    Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash);
+    Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash, string? caseName);
 
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
@@ -70,13 +70,17 @@ internal class Tracker : ITracker
             ParserRunId = parserRunId,
             TrackerStatus = TrackerStatus.Started,
             TrackerLineLastUpdated = timeProvider.GetUtcNow(),
-            CsvMetadataHash = csvMetadataHash
+            CsvMetadataHash = csvMetadataHash,
+            FileExtension = csvLine.Extension,
+            OriginalFileName = csvLine.FilePath,
+            Court = csvLine.Court
+
         };
         currentRunTrackerLines.Add(trackerLine.SourceUuid, trackerLine);
         await UpdateTrackerFileAsync();
     }
 
-    public async Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash)
+    public async Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash, string? caseName)
     {
         var trackerLine = currentRunTrackerLines[sourceUuid];
 
@@ -85,6 +89,7 @@ internal class Tracker : ITracker
         trackerLine.Ncn = ncn;
         trackerLine.DocumentContentHash = documentContentHash;
         trackerLine.TrackerLineLastUpdated = timeProvider.GetUtcNow();
+        trackerLine.CaseName = caseName;
         await UpdateTrackerFileAsync();
     }
 

--- a/backlog/src/Tracking/TrackerLine.cs
+++ b/backlog/src/Tracking/TrackerLine.cs
@@ -10,6 +10,10 @@ namespace Backlog.Tracking;
 
 internal class TrackerLine
 {
+    public string? Court { get; set;}
+    public string? FileExtension {get; set; }
+    
+    
     public Guid SourceUuid { get; init; }
 
     [Ignore]
@@ -19,14 +23,14 @@ internal class TrackerLine
     public TrackerStatus TrackerStatus { get; set; }
     public string? TreReference { get; set; }
     public string? Ncn { get; set; }
+    public string? CaseName { get; set; }
+    public string? OriginalFileName { get; set; }
     public string? DocumentContentHash { get; set; }
     public string? CsvMetadataHash { get; set; }
     public string? ErrorMessage { get; set; }
 
     [Format("yyyy-MM-dd HH:mm:ss.fff")]
     public DateTimeOffset TrackerLineLastUpdated { get; set; }
-    public string? FileExtension {get; set; }
-    public string? OriginalFileName { get; set; }
-    public string? Court { get; set;}
-    public string? CaseName { get; set; }
+
+    
 }

--- a/backlog/src/Tracking/TrackerLine.cs
+++ b/backlog/src/Tracking/TrackerLine.cs
@@ -25,4 +25,8 @@ internal class TrackerLine
 
     [Format("yyyy-MM-dd HH:mm:ss.fff")]
     public DateTimeOffset TrackerLineLastUpdated { get; set; }
+    public string? FileExtension {get; set; }
+    public string? OriginalFileName { get; set; }
+    public string? Court { get; set;}
+    public string? CaseName { get; set; }
 }

--- a/test/backlog/CsvMetadataLineHelper.cs
+++ b/test/backlog/CsvMetadataLineHelper.cs
@@ -19,7 +19,7 @@ public static class CsvMetadataLineHelper
     {
         id = "007",
         Court = "UKFTT-GRC",
-        FilePath = "",
+        FilePath = "/some/long/path/example.pdf",
         Extension = ".pdf",
         DecisionDateTime = DateTime.MinValue,
         CaseNo = ["ABC/2023/001"],

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -227,9 +227,9 @@ namespace test.backlog.EndToEndTests
 
             // Pre-populate tracker to mark first item as already processed
             await File.WriteAllTextAsync(trackerPath, """
-                                                      SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated
-                                                      11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000
-                                                      22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000
+                                                      SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName
+                                                      11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file.docx,UKSC,V v V
+                                                      22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file2.docx,UKSC,V v V
                                                       """,
                 TestContext.Current.CancellationToken);
 
@@ -245,9 +245,9 @@ namespace test.backlog.EndToEndTests
 
             // Should have the header plus original entry plus new successful entries
             Assert.Collection(trackerLines, 
-                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated", "First line should be the header"),
-                line => Assert.True(line == "11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000", "This line from an old run should stay"),
-                line => Assert.True(line == "22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000", "This line from an old run should stay"),
+                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName", $"First line should be the header but was {line}"),
+                line => Assert.True(line == "11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file.docx,UKSC,V v V", "This line from an old run should stay"),
+                line => Assert.True(line == "22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file2.docx,UKSC,V v V", "This line from an old run should stay"),
                 line => Assert.True(line.StartsWith("22222222-2222-2222-2222-222222222222") && line.Contains("SentToIngester"), "This line should have been retried"),
                 line => Assert.True(line.StartsWith("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
                 );
@@ -278,7 +278,7 @@ namespace test.backlog.EndToEndTests
 
             var trackerLines = await File.ReadAllLinesAsync(trackerPath, TestContext.Current.CancellationToken);
             Assert.Collection(trackerLines, 
-                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated", "First line should be the header"),
+                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName", "First line should be the header"),
                 line => Assert.True(line.StartsWith("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
             );
         }

--- a/test/backlog/EndToEndTests/EndToEndTests.cs
+++ b/test/backlog/EndToEndTests/EndToEndTests.cs
@@ -227,9 +227,9 @@ namespace test.backlog.EndToEndTests
 
             // Pre-populate tracker to mark first item as already processed
             await File.WriteAllTextAsync(trackerPath, """
-                                                      SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName
-                                                      11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file.docx,UKSC,V v V
-                                                      22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file2.docx,UKSC,V v V
+                                                      Court,FileExtension,SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,CaseName,OriginalFileName,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated
+                                                      UKSC,docx,11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,V v V,old_file.docx,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000
+                                                      UKSC,docx,22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,V v V,old_file2.docx,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000
                                                       """,
                 TestContext.Current.CancellationToken);
 
@@ -245,11 +245,11 @@ namespace test.backlog.EndToEndTests
 
             // Should have the header plus original entry plus new successful entries
             Assert.Collection(trackerLines, 
-                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName", $"First line should be the header but was {line}"),
-                line => Assert.True(line == "11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file.docx,UKSC,V v V", "This line from an old run should stay"),
-                line => Assert.True(line == "22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000,docx,old_file2.docx,UKSC,V v V", "This line from an old run should stay"),
-                line => Assert.True(line.StartsWith("22222222-2222-2222-2222-222222222222") && line.Contains("SentToIngester"), "This line should have been retried"),
-                line => Assert.True(line.StartsWith("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
+                line => Assert.True(line == "Court,FileExtension,SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,CaseName,OriginalFileName,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated", $"First line should be the header but was {line}"),
+                line => Assert.True(line == "UKSC,docx,11111111-1111-1111-1111-111111111111,6ee2ae0f-9b8a-4d9f-99f0-f66d7234bd2e,SentToIngester,7d24775f-406f-4aa1-b0cc-09361f549a65,,V v V,old_file.docx,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000", "This line from an old run should stay"),
+                line => Assert.True(line == "UKSC,docx,22222222-2222-2222-2222-222222222222,8342b8f3-4e7e-40e1-a330-a06657bd67f2,ParserFailed,3167bcc6-3133-47d2-ab6e-b16afba8d7df,,V v V,old_file2.docx,f8ee4467a300c87045d1eda8cd22b88763cce7ed225b77204ae2a9e80de243ac,46f78fce3cd21a3fd0099ecb4d8c43cff2b1003411911675f1b51aa5c74a5c91,,2000-01-01 00:00:00.000", "This line from an old run should stay"),
+                line => Assert.True(line.Contains("22222222-2222-2222-2222-222222222222") && line.Contains("SentToIngester"), "This line should have been retried"),
+                line => Assert.True(line.Contains("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
                 );
 
             // Log file should mention skips
@@ -278,8 +278,8 @@ namespace test.backlog.EndToEndTests
 
             var trackerLines = await File.ReadAllLinesAsync(trackerPath, TestContext.Current.CancellationToken);
             Assert.Collection(trackerLines, 
-                line => Assert.True(line == "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName", "First line should be the header"),
-                line => Assert.True(line.StartsWith("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
+                line => Assert.True(line == "Court,FileExtension,SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,CaseName,OriginalFileName,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated", "First line should be the header"),
+                line => Assert.True(line.Contains("33333333-3333-3333-3333-333333333333") && line.Contains("SentToIngester"), "This line should have been newly processed")
             );
         }
 

--- a/test/backlog/TestTracker.cs
+++ b/test/backlog/TestTracker.cs
@@ -20,7 +20,7 @@ public class TestTracker
     private const string TrackerFilePath = "/tracker.csv";
 
     private const string TrackerCsvHeader =
-        "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated";
+        "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName";
 
     private readonly FakeTimeProvider fakeTimeProvider = new();
     private readonly MockFileSystem mockFileSystem = new();
@@ -63,7 +63,7 @@ public class TestTracker
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
         var tracker = CreateTracker(
-            $"{sourceUuid},00000000-0000-0000-0000-000000000099,{previousTrackerStatus},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000");
+            $"{sourceUuid},00000000-0000-0000-0000-000000000099,{previousTrackerStatus},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,V v V");
 
         Assert.Equal(expectedResult, tracker.IsAlreadySentToIngester(sourceUuid));
     }
@@ -73,8 +73,8 @@ public class TestTracker
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
         var tracker = CreateTracker(
-            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000",
-            $"{sourceUuid},20000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000"
+            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000,docx,word.docx,UKSC,V v V",
+            $"{sourceUuid},20000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,V v V"
         );
 
         Assert.True(tracker.IsAlreadySentToIngester(sourceUuid));
@@ -84,7 +84,7 @@ public class TestTracker
     public void IsAlreadySentToIngester_WhenDifferentUuidWasSent_ReturnsFalse()
     {
         var tracker = CreateTracker(
-            $"99999999-9999-9999-9999-999999999999,00000000-0000-0000-0000-000000000099,{TrackerStatus.SentToIngester},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000");
+            $"99999999-9999-9999-9999-999999999999,00000000-0000-0000-0000-000000000099,{TrackerStatus.SentToIngester},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,");
 
         Assert.False(tracker.IsAlreadySentToIngester(Guid.Parse("00000000-0000-0000-0000-000000000001")));
     }
@@ -104,7 +104,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
             TrackerCsvHeader,
-            $"{sourceUuid},{parserRunId},Started,,,,my-metadata-hash,,2025-06-15 10:30:00.000"
+            $"{sourceUuid},{parserRunId},Started,,,,my-metadata-hash,,2025-06-15 10:30:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,"
         ], trackerLines);
     }
 
@@ -119,6 +119,8 @@ public class TestTracker
         const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
+        const string caseName = "Case Name";
+
         var tracker = CreateTracker();
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
@@ -129,14 +131,14 @@ public class TestTracker
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 31, 0, TimeSpan.Zero));
 
         // Act - update tracker
-        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash);
+        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash, caseName);
 
         // Assert
         var trackerLines =
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},Parsed,{treReference},{ncn ?? ""},{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000"
+                $"{sourceUuid},{parserRunId},Parsed,{treReference},{ncn ?? ""},{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
             ],
             trackerLines);
     }
@@ -167,7 +169,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},ParserFailed,,,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000"
+                $"{sourceUuid},{parserRunId},ParserFailed,,,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,"
             ],
             trackerLines);
     }
@@ -182,6 +184,7 @@ public class TestTracker
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
         const string ncn = "[2023] ABCD 123";
+        const string caseName = "Case Name";
 
         var tracker = CreateTracker();
 
@@ -189,7 +192,7 @@ public class TestTracker
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
         await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
             Guid.Parse(parserRunId), csvMetadataHash);
-        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash);
+        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash, caseName);
 
         // Arrange - advance time by a couple of minutes to ensure the timestamp is updated
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 32, 0, TimeSpan.Zero));
@@ -205,7 +208,7 @@ public class TestTracker
 
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
+                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
             ],
             trackerLines);
     }
@@ -220,14 +223,15 @@ public class TestTracker
         const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
+        const string caseName = "Case Name";
         const string ncn = "[2023] ABCD 123";
 
         // Arrange
         string[] oldTrackerLines =
         [
-            "e169cd7c-6fe0-446d-91d2-9e4de2829b38,10000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-14 09:30:00.000",
-            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000",
-            $"{sourceUuid},20000000-0000-0000-0000-000000000099,Parsed,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000"
+            "e169cd7c-6fe0-446d-91d2-9e4de2829b38,10000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-14 09:30:00.000,docx,word.docx,UKSC,Case Name",
+            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000,docx,word.docx,UKSC,Case Name",
+            $"{sourceUuid},20000000-0000-0000-0000-000000000099,Parsed,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,Case Name"
         ];
         var tracker = CreateTracker(oldTrackerLines);
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 32, 0, TimeSpan.Zero));
@@ -236,7 +240,7 @@ public class TestTracker
         _ = tracker.IsAlreadySentToIngester(Guid.Parse(sourceUuid));
         await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
             Guid.Parse(parserRunId), csvMetadataHash);
-        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash);
+        await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash, caseName);
 
         await tracker.UpdateToSentToIngesterAsync(Guid.Parse(sourceUuid));
 
@@ -245,7 +249,7 @@ public class TestTracker
         Assert.Equal([
                 TrackerCsvHeader,
                 .. oldTrackerLines,
-                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
+                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
             ],
             trackerLines);
     }

--- a/test/backlog/TestTracker.cs
+++ b/test/backlog/TestTracker.cs
@@ -20,7 +20,7 @@ public class TestTracker
     private const string TrackerFilePath = "/tracker.csv";
 
     private const string TrackerCsvHeader =
-        "SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated,FileExtension,OriginalFileName,Court,CaseName";
+        "Court,FileExtension,SourceUuid,ParserRunId,TrackerStatus,TreReference,Ncn,CaseName,OriginalFileName,DocumentContentHash,CsvMetadataHash,ErrorMessage,TrackerLineLastUpdated";
 
     private readonly FakeTimeProvider fakeTimeProvider = new();
     private readonly MockFileSystem mockFileSystem = new();
@@ -63,7 +63,7 @@ public class TestTracker
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
         var tracker = CreateTracker(
-            $"{sourceUuid},00000000-0000-0000-0000-000000000099,{previousTrackerStatus},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,V v V");
+            $"UKSC,docx,{sourceUuid},00000000-0000-0000-0000-000000000099,{previousTrackerStatus},ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000");
 
         Assert.Equal(expectedResult, tracker.IsAlreadySentToIngester(sourceUuid));
     }
@@ -73,8 +73,8 @@ public class TestTracker
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
         var tracker = CreateTracker(
-            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000,docx,word.docx,UKSC,V v V",
-            $"{sourceUuid},20000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,V v V"
+            $"UKSC,docx,{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-14 10:30:00.000",
+            $"UKSC,docx,{sourceUuid},20000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000"
         );
 
         Assert.True(tracker.IsAlreadySentToIngester(sourceUuid));
@@ -84,7 +84,7 @@ public class TestTracker
     public void IsAlreadySentToIngester_WhenDifferentUuidWasSent_ReturnsFalse()
     {
         var tracker = CreateTracker(
-            $"99999999-9999-9999-9999-999999999999,00000000-0000-0000-0000-000000000099,{TrackerStatus.SentToIngester},ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,");
+            $"UKSC,docx,99999999-9999-9999-9999-999999999999,00000000-0000-0000-0000-000000000099,{TrackerStatus.SentToIngester},ref1,ncn1,,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000");
 
         Assert.False(tracker.IsAlreadySentToIngester(Guid.Parse("00000000-0000-0000-0000-000000000001")));
     }
@@ -104,7 +104,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
             TrackerCsvHeader,
-            $"{sourceUuid},{parserRunId},Started,,,,my-metadata-hash,,2025-06-15 10:30:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,"
+            $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},Started,,,,/some/long/path/example.pdf,,my-metadata-hash,,2025-06-15 10:30:00.000"
         ], trackerLines);
     }
 
@@ -138,7 +138,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},Parsed,{treReference},{ncn ?? ""},{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},Parsed,{treReference},{ncn ?? ""},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000"
             ],
             trackerLines);
     }
@@ -169,7 +169,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},ParserFailed,,,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},ParserFailed,,,,/some/long/path/example.pdf,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000"
             ],
             trackerLines);
     }
@@ -208,7 +208,7 @@ public class TestTracker
 
         Assert.Equal([
                 TrackerCsvHeader,
-                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
             ],
             trackerLines);
     }
@@ -229,9 +229,9 @@ public class TestTracker
         // Arrange
         string[] oldTrackerLines =
         [
-            "e169cd7c-6fe0-446d-91d2-9e4de2829b38,10000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,hash1,metahash1,,2025-06-14 09:30:00.000,docx,word.docx,UKSC,Case Name",
-            $"{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,hash1,metahash1,,2025-06-14 10:30:00.000,docx,word.docx,UKSC,Case Name",
-            $"{sourceUuid},20000000-0000-0000-0000-000000000099,Parsed,ref1,ncn1,hash1,metahash1,,2025-06-15 10:30:00.000,docx,word.docx,UKSC,Case Name"
+            "UKSC,docx,e169cd7c-6fe0-446d-91d2-9e4de2829b38,10000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,Case Name,word.docx,hash1,metahash1,,2025-06-14 09:30:00.000",
+            $"UKSC,docx,{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,Case Name,word.docx,hash1,metahash1,,2025-06-14 10:30:00.000",
+            $"UKSC,docx,{sourceUuid},20000000-0000-0000-0000-000000000099,Parsed,ref1,ncn1,Case Name,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000"
         ];
         var tracker = CreateTracker(oldTrackerLines);
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 32, 0, TimeSpan.Zero));
@@ -249,7 +249,7 @@ public class TestTracker
         Assert.Equal([
                 TrackerCsvHeader,
                 .. oldTrackerLines,
-                $"{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000,.pdf,/some/long/path/example.pdf,UKFTT-GRC,Case Name"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
             ],
             trackerLines);
     }


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-1987

### User story

As an FCL team member publishing Historic Tribunal decisions
I want to easily find a decision in EUI/PUI that I think should have been ingested or published
So that I can quickly confirm whether or not the process has been successful

### Acceptance criteria

Given the Backlog Parser is processing a batch

When the tracker records that a new file is about to be parsed
Then the line written to the tracker csv includes this information from the external metadata csv: file extension (e.g. doc, docx, pdf), original file name and court

When the tracker records that a file has been parsed
Then the line written to the tracker csv includes the decision name from the parsed response 
