### PR TITLE
Backlog - Move to interfaces

### DIFF
--- a/backlog/Properties/AssemblyInfo.cs
+++ b/backlog/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Runtime.CompilerServices;
 
 // Allows tests to see internal classes and methods. DynamicProxyGenAssembly2 is used by Moq to fake dependencies like ILogger
 [assembly: InternalsVisibleTo("test")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/backlog/src/BacklogFiles.cs
+++ b/backlog/src/BacklogFiles.cs
@@ -10,10 +10,21 @@ using Microsoft.Extensions.Options;
 
 namespace Backlog;
 
+internal interface IBacklogFiles
+{
+    /// <summary>
+    ///     Returns the contents of a file using its metadata information by resolving the UUID
+    ///     and locating the corresponding document in the court documents directory.
+    /// </summary>
+    /// <param name="uuid">TDR UUID used to locate file</param>
+    /// <returns>File contents as a byte array</returns>
+    byte[] ReadFile(string uuid);
+}
+
 /// <summary>
 ///     Provides file operations for processing backlog documents.
 /// </summary>
-internal class BacklogFiles
+internal class BacklogFiles : IBacklogFiles
 {
     private readonly IFileSystem fileSystem;
     private readonly IDirectoryInfo courtDocumentsDirectory;
@@ -31,14 +42,7 @@ internal class BacklogFiles
         }
     }
 
-    /// <summary>
-    ///     Reads the contents of a file using its metadata information by resolving the UUID
-    ///     and locating the corresponding document in the court documents directory.
-    ///     Handles special case for .doc files which are stored as .docx files.
-    /// </summary>
-    /// <param name="uuid"></param>
-    /// <returns>File contents as a byte array</returns>
-    internal byte[] ReadFile(string uuid)
+    public byte[] ReadFile(string uuid)
     {
         var filesWithUuid = courtDocumentsDirectory.GetFiles($"{uuid}*", SearchOption.AllDirectories);
         if (filesWithUuid.Length == 0)

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -19,18 +19,23 @@ using Api = UK.Gov.NationalArchives.Judgments.Api;
 
 namespace Backlog;
 
+internal interface IBacklogParserWorker
+{
+    Task<int> RunAsync();
+}
+
 /// <summary>
 ///     This is the main entry point to the bulk backlog parsing process
 /// </summary>
 internal class BacklogParserWorker(
     ILogger<BacklogParserWorker> logger,
-    Api.Parser parser,
-    BacklogFiles backlogFiles,
-    CsvMetadataReader csvMetadataReader,
+    Api.IParser parser,
+    IBacklogFiles backlogFiles,
+    ICsvMetadataReader csvMetadataReader,
     ITracker tracker,
     IBucket bucket,
-    MetadataTransformer metadataTransformer,
-    IOptions<BacklogParserOptions> backlogParserOptions)
+    IMetadataTransformer metadataTransformer,
+    IOptions<BacklogParserOptions> backlogParserOptions) : IBacklogParserWorker
 {
     public async Task<int> RunAsync()
     {

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 
 using Backlog.Options;
-using Backlog.Src;
 
 using CsvHelper;
 using CsvHelper.Configuration;
@@ -20,12 +19,22 @@ using Microsoft.Extensions.Options;
 
 namespace Backlog.Csv;
 
+internal interface ICsvMetadataReader
+{
+    List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
+        out int numAllLinesInCsv);
+
+    List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
+        out List<string> csvParseErrors, out int numAllLinesInCsv);
+}
+
 internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<BacklogParserOptions> backlogParserOptions)
+    : ICsvMetadataReader
 {
     private string csvName = "unknown.csv";
     private string csvHash = "unknown";
 
-    internal List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
+    public List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
         out int numAllLinesInCsv)
     {
         var csvPath = backlogParserOptions.Value.CourtMetadataFilePath;
@@ -36,7 +45,7 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
         return Read(streamReader, out skippedCsvLineIdentifiers, out csvParseErrors, out numAllLinesInCsv);
     }
 
-    internal List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
+    public List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
         out List<string> csvParseErrors, out int numAllLinesInCsv)
     {
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -20,9 +20,19 @@ using UK.Gov.NationalArchives.Judgments.Api;
 
 namespace Backlog.Src;
 
-internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserOptions, TimeProvider timeProvider)
+internal interface IMetadataTransformer
 {
-    internal FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
+    FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
+        string primarySourceFilename, string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
+        List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText);
+
+    List<IMetadataField> CsvLineToMetadataFields(CsvLine csvLine);
+}
+
+internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserOptions, TimeProvider timeProvider)
+    : IMetadataTransformer
+{
+    public FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
         string primarySourceFilename, string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
         List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText)
     {

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -155,7 +155,7 @@ public class Program
             logger.LogInformation("Using court metadata from: {PathToCourtMetadataFile}",
                 backlogParserOptions.CourtMetadataFilePath);
 
-            var backlogParserWorker = scope.ServiceProvider.GetRequiredService<BacklogParserWorker>();
+            var backlogParserWorker = scope.ServiceProvider.GetRequiredService<IBacklogParserWorker>();
             Directory.CreateDirectory(backlogParserOptions.OutputFolderPath);
 
             return backlogParserWorker.RunAsync().Result;
@@ -212,11 +212,13 @@ public class Program
 
     internal static void ConfigureDependencyInjection(IServiceCollection services, bool isDryRun = false)
     {
-        services.AddScoped<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator, UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
-        services.AddScoped<Parser>();
-        services.AddScoped<BacklogParserWorker>();
-        services.AddScoped<CsvMetadataReader>();
-        services.AddScoped<BacklogFiles>();
+        services
+            .AddScoped<UK.Gov.Legislation.Judgments.AkomaNtoso.IValidator,
+                UK.Gov.Legislation.Judgments.AkomaNtoso.Validator>();
+        services.AddScoped<IParser, Parser>();
+        services.AddScoped<IBacklogParserWorker, BacklogParserWorker>();
+        services.AddScoped<ICsvMetadataReader, CsvMetadataReader>();
+        services.AddScoped<IBacklogFiles, BacklogFiles>();
         services.AddScoped<ITracker, Tracker>();
         if (isDryRun)
         {
@@ -228,7 +230,7 @@ public class Program
             services.AddScoped<IBucket, Bucket>();
         }
 
-        services.AddScoped<MetadataTransformer>();
+        services.AddScoped<IMetadataTransformer, MetadataTransformer>();
         services.AddScoped<TimeProvider>(_ => TimeProvider.System);
         services.AddSingleton<IFileSystem, FileSystem>();
 

--- a/src/api/Parser.cs
+++ b/src/api/Parser.cs
@@ -31,7 +31,12 @@ public class InvalidAkNException : Exception {
     public InvalidAkNException(ValidationEventArgs cause) : base(cause.Message, cause.Exception) { }
 }
 
-public class Parser(ILogger<Parser> logger, AkN.IValidator validator)
+public interface IParser
+{
+    Response Parse(Request request);
+}
+
+public class Parser(ILogger<Parser> logger, AkN.IValidator validator) : IParser
 {
     /// <exception cref="InvalidAkNException"></exception>
     public Response Parse(Request request) {


### PR DESCRIPTION
Make things easier to test and refactor. Also removes strong naming from `InternalsVisibleTo:DynamicProxyGenAssembly2` so Moq can actually access internal interfaces (this is only applicable if you're signing your assemblies which we're not because we don't need to).
Some methods have become public - this is required in C# when a method implements an interface. As the interface and class are both internal, the public methods are still only accessible in an internal context