### PR TITLE
refactor(backlog): move `parserRunId` into Tracker

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -39,8 +39,7 @@ internal class BacklogParserWorker(
 {
     public async Task<int> RunAsync()
     {
-        var parserRunId = Guid.NewGuid();
-        logger.LogInformation("Starting parser run {ParserRunId}", parserRunId);
+        logger.LogInformation("Starting parser run {ParserRunId}", tracker.CurrentParserRunId);
         var lines = csvMetadataReader.Read(out var skippedCsvLineIdentifiers, out var csvParseErrors,
             out var numAllLinesInCsv);
         if (lines.Count == 0)
@@ -80,10 +79,10 @@ internal class BacklogParserWorker(
                     continue;
                 }
 
-                await tracker.StartTrackingAsync(sourceUuid.Value, line, parserRunId, line.CsvProperties.Hash);
+                await tracker.StartTrackingAsync(sourceUuid.Value, line, line.CsvProperties.Hash);
 
                 logger.LogInformation("Processing file: {FilePath}", line.FilePath);
-                var bundle = await GenerateBundleAsync(line, parserRunId);
+                var bundle = await GenerateBundleAsync(line);
 
                 var bundleFileName = bundle.Uuid + ".tar.gz";
                 var output = Path.Combine(backlogParserOptions.Value.OutputFolderPath, bundleFileName);
@@ -261,7 +260,7 @@ internal class BacklogParserWorker(
         return response;
     }
 
-    private async Task<Bundle> GenerateBundleAsync(CsvLine csvLine, Guid parserRunId)
+    private async Task<Bundle> GenerateBundleAsync(CsvLine csvLine)
     {
         var sourceContent = backlogFiles.ReadFile(csvLine.Uuid);
         var mimeType = MetadataTransformer.GetMimeType(csvLine.Extension);
@@ -282,8 +281,8 @@ internal class BacklogParserWorker(
             bundleSourceFilename = csvLine.FileName + ".docx";
         }
 
-        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(parserRunId, bundleSourceFilename, csvLine.FileName, mimeType, sourceHash,
-            images, response.Meta, externalMetadataFields, !isStub);
+        var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(bundleSourceFilename, csvLine.FileName,
+            mimeType, sourceHash, images, response.Meta, externalMetadataFields, !isStub);
 
         await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash, response.Meta.Name);
         

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 using Backlog.Csv;
 using Backlog.Options;
+using Backlog.Tracking;
 using Backlog.TreMetadata;
 
 using Microsoft.Extensions.Options;
@@ -22,17 +23,20 @@ namespace Backlog.Src;
 
 internal interface IMetadataTransformer
 {
-    FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
-        string primarySourceFilename, string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
+    FullTreMetadata CreateFullTreMetadata(string bundleSourceFilename, string primarySourceFilename,
+        string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
         List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText);
 
     List<IMetadataField> CsvLineToMetadataFields(CsvLine csvLine);
 }
 
-internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserOptions, TimeProvider timeProvider)
+internal class MetadataTransformer(
+    IOptions<BacklogParserOptions> backlogParserOptions,
+    TimeProvider timeProvider,
+    ITracker tracker)
     : IMetadataTransformer
 {
-    public FullTreMetadata CreateFullTreMetadata(Guid parserRunId, string bundleSourceFilename,
+    public FullTreMetadata CreateFullTreMetadata(string bundleSourceFilename,
         string primarySourceFilename, string sourceMimeType, string sourceHash, Image[] images, Meta responseMeta,
         List<IMetadataField> externalMetadataFields, bool xmlContainsDocumentText)
     {
@@ -59,7 +63,7 @@ internal class MetadataTransformer(IOptions<BacklogParserOptions> backlogParserO
                     Extensions = responseMeta.Extensions,
                     Attachments = responseMeta.Attachments ?? [],
                     DocumentType = Enum.Parse<DocumentType>(responseMeta.DocumentType, true),
-                    ParserRunId = parserRunId,
+                    ParserRunId = tracker.CurrentParserRunId,
                     ErrorMessages = [],
                     MetadataFields = externalMetadataFields,
                     PrimarySource = new PrimarySourceFile

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -20,12 +20,13 @@ namespace Backlog.Tracking;
 internal interface ITracker
 {
     bool IsAlreadySentToIngester(Guid sourceUuid);
-    Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, Guid parserRunId, string csvMetadataHash);
+    Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, string csvMetadataHash);
 
     Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash, string? caseName);
 
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
+    Guid CurrentParserRunId { get; }
 }
 
 internal class Tracker : ITracker
@@ -50,6 +51,8 @@ internal class Tracker : ITracker
     private readonly TrackerLine[] previousRunTrackerLines = [];
     private readonly Dictionary<Guid, TrackerLine> currentRunTrackerLines = new();
     private readonly string trackerFilePath;
+    
+    public Guid CurrentParserRunId { get; } = Guid.NewGuid();
 
     public bool IsAlreadySentToIngester(Guid sourceUuid)
     {
@@ -61,13 +64,13 @@ internal class Tracker : ITracker
         return alreadySentToIngester;
     }
 
-    public async Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, Guid parserRunId, string csvMetadataHash)
+    public async Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, string csvMetadataHash)
     {
         var trackerLine = new TrackerLine
         {
             SourceUuid = sourceUuid,
             CsvLine = csvLine,
-            ParserRunId = parserRunId,
+            ParserRunId = CurrentParserRunId,
             TrackerStatus = TrackerStatus.Started,
             TrackerLineLastUpdated = timeProvider.GetUtcNow(),
             CsvMetadataHash = csvMetadataHash,

--- a/test/backlog/MetadataTests/TestMetadataTransformer.cs
+++ b/test/backlog/MetadataTests/TestMetadataTransformer.cs
@@ -6,9 +6,12 @@ using System.Linq;
 
 using Backlog.Options;
 using Backlog.Src;
+using Backlog.Tracking;
 
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+
+using Moq;
 
 using TRE.Metadata;
 using TRE.Metadata.Enums;
@@ -28,11 +31,12 @@ public class TestMetadataTransformer
     private readonly FakeTimeProvider fakeTimeProvider = new();
     private readonly MetadataTransformer metadataTransformer;
     private readonly IOptions<BacklogParserOptions> options;
+    private readonly Mock<ITracker> mockTracker = new();
 
     public TestMetadataTransformer()
     {
         options = BacklogParserOptionsHelper.Create(autoPublish: true);
-        metadataTransformer = new MetadataTransformer(options, fakeTimeProvider);
+        metadataTransformer = new MetadataTransformer(options, fakeTimeProvider, mockTracker.Object);
     }
 
     [Theory]
@@ -46,9 +50,7 @@ public class TestMetadataTransformer
         var responseMeta = new Api.Meta { DocumentType = "decision" };
 
         // Act
-        var result = metadataTransformer.CreateFullTreMetadata(
-            Guid.NewGuid(),
-            "test.pdf",
+        var result = metadataTransformer.CreateFullTreMetadata("test.pdf",
             "test.pdf",
             sourceMimeType,
             contentHash,
@@ -77,6 +79,7 @@ public class TestMetadataTransformer
         fakeTimeProvider.AdjustTime(expectedDate);
 
         var parserRunId = Guid.NewGuid();
+        mockTracker.SetupGet(t => t.CurrentParserRunId).Returns(parserRunId);
 
         var extensions = new Api.Extensions
         {
@@ -103,7 +106,6 @@ public class TestMetadataTransformer
 
         // Act
         var result = metadataTransformer.CreateFullTreMetadata(
-            parserRunId,
             "test.doc.docx",
             "test.doc",
             "application/pdf",
@@ -149,7 +151,6 @@ public class TestMetadataTransformer
 
         // Act
         var result = metadataTransformer.CreateFullTreMetadata(
-            Guid.NewGuid(),
             sourceFilename,
             sourceFilename,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -169,11 +170,7 @@ public class TestMetadataTransformer
     [Fact]
     public void CreateFullTreMetadata_Generates_UniqueTreReference()
     {
-        var parserRunId = Guid.NewGuid();
-
-        var firstFullTreMetadata = metadataTransformer.CreateFullTreMetadata(
-            parserRunId,
-            "test-file.doc.docx",
+        var firstFullTreMetadata = metadataTransformer.CreateFullTreMetadata("test-file.doc.docx",
             "test-file.doc",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "sha256:abc",
@@ -182,9 +179,7 @@ public class TestMetadataTransformer
             [],
             false
         );
-        var secondFullTreMetadata = metadataTransformer.CreateFullTreMetadata(
-            parserRunId,
-            "test-file.doc.docx",
+        var secondFullTreMetadata = metadataTransformer.CreateFullTreMetadata("test-file.doc.docx",
             "test-file.doc",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "sha256:abc",

--- a/test/backlog/TestTracker.cs
+++ b/test/backlog/TestTracker.cs
@@ -37,6 +37,16 @@ public class TestTracker
     }
 
     [Fact]
+    public void CurrentParserRunId_IsDifferentForEveryRun()
+    {
+        // Simulate new runs by creating a new tracker instance
+        var tracker = CreateTracker();
+        var tracker2 = CreateTracker();
+        
+        Assert.NotEqual(tracker.CurrentParserRunId, tracker2.CurrentParserRunId);
+    }
+
+    [Fact]
     public void IsAlreadySentToIngester_WhenNoTrackerFileExists_ReturnsFalse()
     {
         mockFileSystem.RemoveFile(TrackerFilePath);
@@ -93,18 +103,16 @@ public class TestTracker
     public async Task StartTrackingAsync_WritesStartedStatusWithUuidAndRunIdToFile()
     {
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
-        const string parserRunId = "00000000-0000-0000-0000-000000000099";
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
         var tracker = CreateTracker();
 
-        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
-            Guid.Parse(parserRunId), "my-metadata-hash");
+        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, "my-metadata-hash");
 
         var trackerLines =
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
             TrackerCsvHeader,
-            $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},Started,,,,/some/long/path/example.pdf,,my-metadata-hash,,2025-06-15 10:30:00.000"
+            $"UKFTT-GRC,.pdf,{sourceUuid},{tracker.CurrentParserRunId},Started,,,,/some/long/path/example.pdf,,my-metadata-hash,,2025-06-15 10:30:00.000"
         ], trackerLines);
     }
 
@@ -116,7 +124,6 @@ public class TestTracker
         // Arrange
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
         const string treReference = "00000000-0000-0000-0000-00000000002";
-        const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
         const string caseName = "Case Name";
@@ -124,8 +131,7 @@ public class TestTracker
         var tracker = CreateTracker();
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
-        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
-            Guid.Parse(parserRunId), csvMetadataHash);
+        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
 
         // Arrange - advance time by a minute to ensure the timestamp is updated
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 31, 0, TimeSpan.Zero));
@@ -138,7 +144,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},Parsed,{treReference},{ncn ?? ""},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{tracker.CurrentParserRunId},Parsed,{treReference},{ncn ?? ""},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:31:00.000"
             ],
             trackerLines);
     }
@@ -148,14 +154,12 @@ public class TestTracker
     {
         // Arrange
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
-        const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         var tracker = CreateTracker();
 
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
-        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
-            Guid.Parse(parserRunId), csvMetadataHash);
+        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
 
         // Arrange - advance time by a minute to ensure the timestamp is updated
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 31, 0, TimeSpan.Zero));
@@ -169,7 +173,7 @@ public class TestTracker
             await mockFileSystem.File.ReadAllLinesAsync(TrackerFilePath, TestContext.Current.CancellationToken);
         Assert.Equal([
                 TrackerCsvHeader,
-                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},ParserFailed,,,,/some/long/path/example.pdf,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{tracker.CurrentParserRunId},ParserFailed,,,,/some/long/path/example.pdf,,{csvMetadataHash},Something went wrong,2025-06-15 10:31:00.000"
             ],
             trackerLines);
     }
@@ -180,7 +184,6 @@ public class TestTracker
         // Arrange
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
         const string treReference = "00000000-0000-0000-0000-00000000002";
-        const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
         const string ncn = "[2023] ABCD 123";
@@ -190,8 +193,7 @@ public class TestTracker
 
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
-        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
-            Guid.Parse(parserRunId), csvMetadataHash);
+        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
         await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash, caseName);
 
         // Arrange - advance time by a couple of minutes to ensure the timestamp is updated
@@ -208,7 +210,7 @@ public class TestTracker
 
         Assert.Equal([
                 TrackerCsvHeader,
-                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{tracker.CurrentParserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
             ],
             trackerLines);
     }
@@ -220,7 +222,6 @@ public class TestTracker
         // Arrange
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
         const string treReference = "00000000-0000-0000-0000-00000000002";
-        const string parserRunId = "00000000-0000-0000-0000-000000000099";
         const string csvMetadataHash = "my-metadata-hash";
         const string documentContentHash = "my-document-hash";
         const string caseName = "Case Name";
@@ -238,8 +239,7 @@ public class TestTracker
 
         // Act - trigger all tracker operations
         _ = tracker.IsAlreadySentToIngester(Guid.Parse(sourceUuid));
-        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine,
-            Guid.Parse(parserRunId), csvMetadataHash);
+        await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
         await tracker.UpdateToParsedAsync(Guid.Parse(sourceUuid), treReference, ncn, documentContentHash, caseName);
 
         await tracker.UpdateToSentToIngesterAsync(Guid.Parse(sourceUuid));
@@ -249,7 +249,7 @@ public class TestTracker
         Assert.Equal([
                 TrackerCsvHeader,
                 .. oldTrackerLines,
-                $"UKFTT-GRC,.pdf,{sourceUuid},{parserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
+                $"UKFTT-GRC,.pdf,{sourceUuid},{tracker.CurrentParserRunId},SentToIngester,{treReference},{ncn},{caseName},/some/long/path/example.pdf,{documentContentHash},{csvMetadataHash},,2025-06-15 10:32:00.000"
             ],
             trackerLines);
     }


### PR DESCRIPTION
This gives it a proper home so we don't have to pass it around everywhere