### PR TITLE
Backlog move final stats logging to tracker

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -109,7 +109,7 @@ internal class BacklogParserWorker(
             }
         }
 
-        LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
+        tracker.LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
             skippedCsvLineIdentifiers, numAllLinesInCsv);
 
         if (failedToProcessLines.Count > 0 || csvParseErrors.Count > 0)
@@ -118,89 +118,6 @@ internal class BacklogParserWorker(
         }
 
         return 0;
-    }
-
-    private void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
-        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
-        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
-    {
-        var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
-        var markedAsSkipIds = numSkippedCsvLines > 0
-            ? StringJoinFirstFive(skippedCsvLineIdentifiers, ", ")
-            : string.Empty;
-        var successfulFileExtensionBreakdown = string.Join(", ", successfulNewLines.GroupBy(l => l.Extension).Select(g => $"{g.Count()} {g.Key}"));
-        
-        logger.LogInformation("""
-                              ---------------------------
-                              Successfully processed {SuccessfulLinesCount} of {CsvLinesCount} csv lines, of which:
-                                - {NewLinesCount} lines were new ({SuccessfulFileExtensionBreakdown})
-                                - {MarkedToSkipLineCount} lines were marked in the csv to skip ({MarkedToSkipIds})
-                                - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
-                              """,
-            numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
-            numAllLinesInCsv,
-            successfulNewLines.Count,
-            successfulFileExtensionBreakdown,
-            numSkippedCsvLines, markedAsSkipIds,
-            alreadyDoneLines.Count
-        );
-
-        if (csvParseErrors.Count > 0)
-        {
-            logger.LogError("""
-                            ---------------------------
-                            Failed to read {FailedLineCount} lines from the csv:
-                            {FailedLineDetails}
-                            """,
-                csvParseErrors.Count,
-                string.Join(Environment.NewLine, csvParseErrors.Select(error => $"  - {error}"))
-            );
-        }
-
-        if (failedToProcessLines.Count > 0)
-        {
-            var failedIdsGroupedByErrorMessage = failedToProcessLines
-                .GroupBy(f =>
-                    {
-                        return f.exception.Message switch
-                        {
-                            _ when f.exception.Message.StartsWith("Could not find file") => "Could not find file",
-                            _ when f.exception.Message.StartsWith("Couldn't find file with UUID") =>
-                                "Couldn't find file with UUID",
-                            _ when f.exception.Message.EndsWith("was not recognized as a valid DateTime.") =>
-                                "String was not recognized as a valid DateTime",
-                            _ => f.exception.Message
-                        };
-                    },
-                    f => f.line.id);
-
-            var groupedErrorDescriptions = failedIdsGroupedByErrorMessage.Select(groupOfErrors =>
-                $"  - {groupOfErrors.Count()} lines failed with exception message \"{groupOfErrors.Key}\". Ids affected were: ({StringJoinFirstFive(groupOfErrors, ", ")})");
-            var failedFileExtensionBreakdown = string.Join(", ", failedToProcessLines.GroupBy(l => l.line.Extension).Select(g => $"{g.Count()} {g.Key}"));
-
-            logger.LogError("""
-                            ---------------------------
-                            Failed to process {FailedLineCount} lines ({FailedFileExtensionBreakdown}), of which:
-                            {GroupedErrorDescriptions}
-                            """,
-                failedToProcessLines.Count,
-                failedFileExtensionBreakdown,
-                StringJoinFirstFive(groupedErrorDescriptions, Environment.NewLine)
-            );
-        }
-
-        if (failedToProcessLines.Count == 0 && csvParseErrors.Count == 0)
-        {
-            logger.LogInformation("No failed lines");
-        }
-    }
-
-    private static string StringJoinFirstFive(IEnumerable<string> unenumeratedCollection, string separator)
-    {
-        var array = unenumeratedCollection as string[] ?? unenumeratedCollection.ToArray();
-        return array.Length <= 5
-            ? string.Join(separator, array)
-            : string.Join(separator, array.Take(5)) + "...";
     }
 
     private Api.Response CreateResponse(CsvLine csvLine, string mimeType, byte[] sourceContent, bool isStub)

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -40,8 +40,7 @@ internal class BacklogParserWorker(
     public async Task<int> RunAsync()
     {
         logger.LogInformation("Starting parser run {ParserRunId}", tracker.CurrentParserRunId);
-        var lines = csvMetadataReader.Read(out var skippedCsvLineIdentifiers, out var csvParseErrors,
-            out var numAllLinesInCsv);
+        var lines = csvMetadataReader.Read();
         if (lines.Count == 0)
         {
             logger.LogCritical("No valid records found in the metadata file");
@@ -63,6 +62,7 @@ internal class BacklogParserWorker(
         var alreadyDoneLines = new List<CsvLine>();
         var successfulNewLines = new List<CsvLine>();
         var failedToProcessLines = new List<(CsvLine line, Exception exception)>();
+        var hasErrors = tracker.HasCsvParseErrors;
 
         for (var i = 0; i < lines.Count; i++)
         {
@@ -99,6 +99,7 @@ internal class BacklogParserWorker(
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error processing line {LineId}:", line.id);
+                hasErrors = true;
                 failedToProcessLines.Add((line, ex));
                 if(sourceUuid.HasValue)
                     await tracker.UpdateToParserFailedAsync(sourceUuid.Value, ex);
@@ -109,15 +110,9 @@ internal class BacklogParserWorker(
             }
         }
 
-        tracker.LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines, csvParseErrors,
-            skippedCsvLineIdentifiers, numAllLinesInCsv);
+        tracker.LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines);
 
-        if (failedToProcessLines.Count > 0 || csvParseErrors.Count > 0)
-        {
-            return 1;
-        }
-
-        return 0;
+        return hasErrors ? 1 : 0;
     }
 
     private Api.Response CreateResponse(CsvLine csvLine, string mimeType, byte[] sourceContent, bool isStub)

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 
 using Backlog.Options;
+using Backlog.Tracking;
 
 using CsvHelper;
 using CsvHelper.Configuration;
@@ -21,32 +22,29 @@ namespace Backlog.Csv;
 
 internal interface ICsvMetadataReader
 {
-    List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
-        out int numAllLinesInCsv);
+    List<CsvLine> Read();
 
-    List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
-        out List<string> csvParseErrors, out int numAllLinesInCsv);
+    List<CsvLine> Read(TextReader textReader);
 }
 
-internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<BacklogParserOptions> backlogParserOptions)
+internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<BacklogParserOptions> backlogParserOptions,
+    ITracker tracker)
     : ICsvMetadataReader
 {
     private string csvName = "unknown.csv";
     private string csvHash = "unknown";
 
-    public List<CsvLine> Read(out List<string> skippedCsvLineIdentifiers, out List<string> csvParseErrors,
-        out int numAllLinesInCsv)
+    public List<CsvLine> Read()
     {
         var csvPath = backlogParserOptions.Value.CourtMetadataFilePath;
         csvName = Path.GetFileName(csvPath);
         csvHash = BacklogParserWorker.Hash(File.ReadAllBytes(csvPath));
 
         using var streamReader = new StreamReader(csvPath);
-        return Read(streamReader, out skippedCsvLineIdentifiers, out csvParseErrors, out numAllLinesInCsv);
+        return Read(streamReader);
     }
 
-    public List<CsvLine> Read(TextReader textReader, out List<string> skippedCsvLineIdentifiers,
-        out List<string> csvParseErrors, out int numAllLinesInCsv)
+    public List<CsvLine> Read(TextReader textReader)
     {
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)
         {
@@ -62,9 +60,7 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
         var booleanSkipConverter = csv.Context.TypeConverterCache.GetConverter(typeof(CsvLine).GetMember(nameof(CsvLine.Skip)).Single());
 
         var records = new List<CsvLine>();
-        skippedCsvLineIdentifiers = [];
-        csvParseErrors = [];
-        numAllLinesInCsv = 0;
+        var numAllLinesInCsv = 0;
 
         // Read the header first
         csv.Read();
@@ -84,7 +80,7 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
 
             if (successfullyRetrievedSkipField && skipFieldValue)
             {
-                skippedCsvLineIdentifiers.Add($"Line {currentLineNumber}");
+                tracker.TrackSkipped($"Line {currentLineNumber}");
                 logger.LogInformation("Skipping line {LineNumber} because it was marked to skip in the csv",
                     currentLineNumber);
                 continue;
@@ -95,7 +91,8 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
             switch (processCsvRecordResult)
             {
                 case { ErrorMessage: { } errorMessage, Record: null }:
-                    csvParseErrors.Add($"Line {currentLineNumber}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
+                    tracker.TrackCsvParseError(
+                        $"Line {currentLineNumber}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
                     break;
                 case { Record: { } record, ErrorMessage: null }:
                     records.Add(record);
@@ -105,6 +102,7 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
             }
         }
 
+        tracker.NumAllLinesInCsv = numAllLinesInCsv;
         return records;
     }
 

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -13,6 +13,7 @@ using Backlog.Options;
 
 using CsvHelper;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Backlog.Tracking;
@@ -27,18 +28,24 @@ internal interface ITracker
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
     Guid CurrentParserRunId { get; }
+
+    void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
+        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
+        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv);
 }
 
 internal class Tracker : ITracker
 {
     private readonly IFileSystem fileSystem;
     private readonly TimeProvider timeProvider;
+    private readonly ILogger<Tracker> logger;
 
     public Tracker(IOptions<BacklogParserOptions> backlogParserOptions, IFileSystem fileSystem,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider, ILogger<Tracker> logger)
     {
         this.fileSystem = fileSystem;
         this.timeProvider = timeProvider;
+        this.logger = logger;
         trackerFilePath = backlogParserOptions.Value.TrackerFilePath;
 
         if (fileSystem.File.Exists(trackerFilePath) &&
@@ -134,5 +141,90 @@ internal class Tracker : ITracker
         await using var csv = new CsvWriter(streamWriter, CultureInfo.InvariantCulture);
 
         await csv.WriteRecordsAsync(newFileContents);
+    }
+
+    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
+        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
+        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
+    {
+        var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
+        var markedAsSkipIds = numSkippedCsvLines > 0
+            ? StringJoinFirstFive(skippedCsvLineIdentifiers, ", ")
+            : string.Empty;
+        var successfulFileExtensionBreakdown = string.Join(", ",
+            successfulNewLines.GroupBy(l => l.Extension).Select(g => $"{g.Count()} {g.Key}"));
+
+        logger.LogInformation("""
+                              ---------------------------
+                              Successfully processed {SuccessfulLinesCount} of {CsvLinesCount} csv lines, of which:
+                                - {NewLinesCount} lines were new ({SuccessfulFileExtensionBreakdown})
+                                - {MarkedToSkipLineCount} lines were marked in the csv to skip ({MarkedToSkipIds})
+                                - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
+                              """,
+            numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
+            numAllLinesInCsv,
+            successfulNewLines.Count,
+            successfulFileExtensionBreakdown,
+            numSkippedCsvLines, markedAsSkipIds,
+            alreadyDoneLines.Count
+        );
+
+        if (csvParseErrors.Count > 0)
+        {
+            logger.LogError("""
+                            ---------------------------
+                            Failed to read {FailedLineCount} lines from the csv:
+                            {FailedLineDetails}
+                            """,
+                csvParseErrors.Count,
+                string.Join(Environment.NewLine, csvParseErrors.Select(error => $"  - {error}"))
+            );
+        }
+
+        if (failedToProcessLines.Count > 0)
+        {
+            var failedIdsGroupedByErrorMessage = failedToProcessLines
+                .GroupBy(f =>
+                    {
+                        return f.exception.Message switch
+                        {
+                            _ when f.exception.Message.StartsWith("Could not find file") => "Could not find file",
+                            _ when f.exception.Message.StartsWith("Couldn't find file with UUID") =>
+                                "Couldn't find file with UUID",
+                            _ when f.exception.Message.EndsWith("was not recognized as a valid DateTime.") =>
+                                "String was not recognized as a valid DateTime",
+                            _ => f.exception.Message
+                        };
+                    },
+                    f => f.line.id);
+
+            var groupedErrorDescriptions = failedIdsGroupedByErrorMessage.Select(groupOfErrors =>
+                $"  - {groupOfErrors.Count()} lines failed with exception message \"{groupOfErrors.Key}\". Ids affected were: ({StringJoinFirstFive(groupOfErrors, ", ")})");
+            var failedFileExtensionBreakdown = string.Join(", ",
+                failedToProcessLines.GroupBy(l => l.line.Extension).Select(g => $"{g.Count()} {g.Key}"));
+
+            logger.LogError("""
+                            ---------------------------
+                            Failed to process {FailedLineCount} lines ({FailedFileExtensionBreakdown}), of which:
+                            {GroupedErrorDescriptions}
+                            """,
+                failedToProcessLines.Count,
+                failedFileExtensionBreakdown,
+                StringJoinFirstFive(groupedErrorDescriptions, Environment.NewLine)
+            );
+        }
+
+        if (failedToProcessLines.Count == 0 && csvParseErrors.Count == 0)
+        {
+            logger.LogInformation("No failed lines");
+        }
+    }
+
+    private static string StringJoinFirstFive(IEnumerable<string> unenumeratedCollection, string separator)
+    {
+        var array = unenumeratedCollection as string[] ?? unenumeratedCollection.ToArray();
+        return array.Length <= 5
+            ? string.Join(separator, array)
+            : string.Join(separator, array.Take(5)) + "...";
     }
 }

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -135,12 +135,19 @@ internal class Tracker : ITracker
     {
         var newFileContents = previousRunTrackerLines.Concat(currentRunTrackerLines.Values).ToArray();
 
-        // We update by overwriting the file
-        await using var fileSystemStream = fileSystem.File.OpenWrite(trackerFilePath);
-        await using var streamWriter = new StreamWriter(fileSystemStream);
-        await using var csv = new CsvWriter(streamWriter, CultureInfo.InvariantCulture);
+        // We update by overwriting the file.
+        // First write to a temp file (so we don't lose data if the operation fails)
+        var tempLogFile = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), fileSystem.Path.GetRandomFileName());
+        await using (var fileSystemStream = fileSystem.File.OpenWrite(tempLogFile))
+        {
+            await using var streamWriter = new StreamWriter(fileSystemStream);
+            await using var csv = new CsvWriter(streamWriter, CultureInfo.InvariantCulture);
 
-        await csv.WriteRecordsAsync(newFileContents);
+            await csv.WriteRecordsAsync(newFileContents);
+        }
+
+        //Then overwrite the old log with the new temp log
+        fileSystem.File.Copy(tempLogFile, trackerFilePath, true);
     }
 
     public void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -87,6 +87,7 @@ internal class Tracker : ITracker
 
         };
         currentRunTrackerLines.Add(trackerLine.SourceUuid, trackerLine);
+
         await UpdateTrackerFileAsync();
     }
 
@@ -100,21 +101,28 @@ internal class Tracker : ITracker
         trackerLine.DocumentContentHash = documentContentHash;
         trackerLine.TrackerLineLastUpdated = timeProvider.GetUtcNow();
         trackerLine.CaseName = caseName;
+
         await UpdateTrackerFileAsync();
     }
 
     public async Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception)
     {
-        currentRunTrackerLines[sourceUuid].TrackerStatus = TrackerStatus.ParserFailed;
-        currentRunTrackerLines[sourceUuid].ErrorMessage = exception.Message;
-        currentRunTrackerLines[sourceUuid].TrackerLineLastUpdated = timeProvider.GetUtcNow();
+        var trackerLine = currentRunTrackerLines[sourceUuid];
+        
+        trackerLine.TrackerStatus = TrackerStatus.ParserFailed;
+        trackerLine.ErrorMessage = exception.Message;
+        trackerLine.TrackerLineLastUpdated = timeProvider.GetUtcNow();
+
         await UpdateTrackerFileAsync();
     }
 
     public async Task UpdateToSentToIngesterAsync(Guid sourceUuid)
     {
-        currentRunTrackerLines[sourceUuid].TrackerStatus = TrackerStatus.SentToIngester;
-        currentRunTrackerLines[sourceUuid].TrackerLineLastUpdated = timeProvider.GetUtcNow();
+        var trackerLine = currentRunTrackerLines[sourceUuid];
+        
+        trackerLine.TrackerStatus = TrackerStatus.SentToIngester;
+        trackerLine.TrackerLineLastUpdated = timeProvider.GetUtcNow();
+
         await UpdateTrackerFileAsync();
     }
 

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -20,18 +20,19 @@ namespace Backlog.Tracking;
 
 internal interface ITracker
 {
+    Guid CurrentParserRunId { get; }
+    bool HasCsvParseErrors { get; }
+    int NumAllLinesInCsv { get; set; }
+    void TrackCsvParseError(string errorMessage);
+    void TrackSkipped(string identifier);
     bool IsAlreadySentToIngester(Guid sourceUuid);
     Task StartTrackingAsync(Guid sourceUuid, CsvLine csvLine, string csvMetadataHash);
-
     Task UpdateToParsedAsync(Guid sourceUuid, string treReference, string? ncn, string documentContentHash, string? caseName);
-
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
-    Guid CurrentParserRunId { get; }
 
     void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
-        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
-        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv);
+        List<(CsvLine line, Exception exception)> failedToProcessLines);
 }
 
 internal class Tracker : ITracker
@@ -39,6 +40,8 @@ internal class Tracker : ITracker
     private readonly IFileSystem fileSystem;
     private readonly TimeProvider timeProvider;
     private readonly ILogger<Tracker> logger;
+    private readonly List<string> skippedCsvLineIdentifiers = [];
+    private readonly List<string> csvParseErrors = [];
 
     public Tracker(IOptions<BacklogParserOptions> backlogParserOptions, IFileSystem fileSystem,
         TimeProvider timeProvider, ILogger<Tracker> logger)
@@ -58,8 +61,20 @@ internal class Tracker : ITracker
     private readonly TrackerLine[] previousRunTrackerLines = [];
     private readonly Dictionary<Guid, TrackerLine> currentRunTrackerLines = new();
     private readonly string trackerFilePath;
-    
+
     public Guid CurrentParserRunId { get; } = Guid.NewGuid();
+    public bool HasCsvParseErrors => csvParseErrors.Any();
+    public int NumAllLinesInCsv { get; set; }
+
+    public void TrackCsvParseError(string errorMessage)
+    {
+        csvParseErrors.Add(errorMessage);
+    }
+
+    public void TrackSkipped(string identifier)
+    {
+        skippedCsvLineIdentifiers.Add(identifier);
+    }
 
     public bool IsAlreadySentToIngester(Guid sourceUuid)
     {
@@ -159,8 +174,7 @@ internal class Tracker : ITracker
     }
 
     public void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
-        List<(CsvLine line, Exception exception)> failedToProcessLines, List<string> csvParseErrors,
-        List<string> skippedCsvLineIdentifiers, int numAllLinesInCsv)
+        List<(CsvLine line, Exception exception)> failedToProcessLines)
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
@@ -177,7 +191,7 @@ internal class Tracker : ITracker
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
             numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
-            numAllLinesInCsv,
+            NumAllLinesInCsv,
             successfulNewLines.Count,
             successfulFileExtensionBreakdown,
             numSkippedCsvLines, markedAsSkipIds,

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -8,8 +8,11 @@ using System.Linq;
 using Backlog;
 using Backlog.Csv;
 using Backlog.Options;
+using Backlog.Tracking;
 
 using Microsoft.Extensions.Options;
+
+using Moq;
 
 using test.Mocks;
 
@@ -17,21 +20,23 @@ using Xunit;
 
 namespace test.backlog.MetadataTests;
 
-public class TestRead : IDisposable
+public sealed class TestRead : IDisposable
 {
     private readonly CsvMetadataReader csvMetadataReader;
     private readonly IOptions<BacklogParserOptions> backlogParserOptions;
     private readonly string testDataDirectory;
+    private readonly Mock<ITracker> mockTracker = new();
 
     public TestRead()
     {
         // Create a unique temporary directory for test files (used by some tests accessing the real file system)
         testDataDirectory = Path.Combine(Path.GetTempPath(), nameof(TestRead), Guid.NewGuid().ToString());
         Directory.CreateDirectory(testDataDirectory);
-        
+
         var courtMetadataFilePath = Path.Combine(testDataDirectory, "metadata.csv");
         backlogParserOptions = BacklogParserOptionsHelper.Create(courtMetadataFilePath: courtMetadataFilePath);
-        csvMetadataReader = new(new MockLogger<CsvMetadataReader>().Object, backlogParserOptions);
+        csvMetadataReader = new CsvMetadataReader(new MockLogger<CsvMetadataReader>().Object, backlogParserOptions,
+            mockTracker.Object);
     }
 
     public void Dispose()
@@ -54,15 +59,14 @@ public class TestRead : IDisposable
             """
         );
 
-        var result =
-            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
-        Assert.Empty(csvParseErrors);
+        var result = csvMetadataReader.Read(csvStream);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Never);
 
         var parsedLine = Assert.Single(result);
         Assert.Equal("123", parsedLine.id);
         Assert.False(parsedLine.Skip);
 
-        Assert.Equal(["Line 3"], skippedCsvLineIdentifiers);
+        mockTracker.Verify(t => t.TrackSkipped("Line 3"), Times.Once);
     }
 
     [Theory]
@@ -88,11 +92,10 @@ public class TestRead : IDisposable
              """
         );
 
-        var result =
-            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
-        Assert.Empty(csvParseErrors);
-        Assert.Empty(skippedCsvLineIdentifiers);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Never);
+        mockTracker.Verify(t => t.TrackSkipped(It.IsAny<string>()), Times.Never);
 
         var line = Assert.Single(result);
         Assert.False(line.Skip);
@@ -116,16 +119,15 @@ public class TestRead : IDisposable
              """
         );
 
-        var result =
-            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
-        Assert.Empty(csvParseErrors);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Never);
         Assert.Empty(result);
-        Assert.Single(skippedCsvLineIdentifiers);
+        mockTracker.Verify(t => t.TrackSkipped(It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public void Read_WithVarietyOfRows_OutputsFullRowCount()
+    public void Read_WithVarietyOfRows_SetsFullRowCountInTracker()
     {
         using var csvStream = new StringReader(
             """
@@ -136,12 +138,12 @@ public class TestRead : IDisposable
             126, missing_extension_unskipped_line.docx  ,  ,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,
             """
         );
-        
-        _ = csvMetadataReader.Read(csvStream, out _, out _, out var fullRowCount);
 
-        Assert.Equal(4, fullRowCount);
+        _ = csvMetadataReader.Read(csvStream);
+
+        mockTracker.VerifySet(t => t.NumAllLinesInCsv = 4);
     }
-    
+
     [Fact]
     public void Read_WithDodgySkippedLines_DoesNotOutputValidationErrors()
     {
@@ -157,18 +159,17 @@ public class TestRead : IDisposable
             """
         );
 
-        var result =
-            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         // Assert that the good line is returned
         var parsedLine = Assert.Single(result);
         Assert.Equal("123", parsedLine.id);
 
-        // Assert all skipped lines are returned despite validation errors        
-        Assert.Equal(5, skippedCsvLineIdentifiers.Count);
+        // Assert all skipped lines are tracked despite validation errors        
+        mockTracker.Verify(t => t.TrackSkipped(It.IsAny<string>()), Times.Exactly(5));
 
-        // Assert that there are no validation errors returned
-        Assert.Empty(csvParseErrors);
+        // Assert that there are no validation errors tracked
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Never);
     }
 
     [Theory]
@@ -196,10 +197,10 @@ public class TestRead : IDisposable
             csvWithMissingColumn
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         Assert.Empty(result);
-        Assert.All(csvParseErrors, csvParseError => Assert.Contains(missingColumn, csvParseError));
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains(missingColumn))), Times.AtLeastOnce);
     }
 
     [Theory]
@@ -224,7 +225,7 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         var line = Assert.Single(result);
         Assert.Equal(expectedJurisdictions, line.Jurisdictions);
@@ -252,7 +253,7 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         var line = Assert.Single(result);
         Assert.Equal(expectedCaseNos, line.CaseNo);
@@ -270,7 +271,7 @@ public class TestRead : IDisposable
             """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         Assert.Collection(result,
             line => Assert.Equivalent(new Dictionary<string, string>
@@ -355,7 +356,7 @@ public class TestRead : IDisposable
         using var csvStream = new StringReader(csvContent);
 
         // Act
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         // Assert - results
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
@@ -559,8 +560,7 @@ public class TestRead : IDisposable
         );
 
         // Assert - marked as skip lines
-        var skippedLine = Assert.Single(skippedCsvLineIdentifiers);
-        Assert.Equal("Line 11", skippedLine);
+        mockTracker.Verify(t => t.TrackSkipped("Line 11"), Times.Once);
     }
 
     [Fact]
@@ -580,23 +580,18 @@ public class TestRead : IDisposable
             """
         );
 
-        var validLines = csvMetadataReader.Read(csvStream, out _, out var failedToParseLines, out _);
+        var validLines = csvMetadataReader.Read(csvStream);
 
         Assert.Equal(3, validLines.Count);
-        Assert.Equal(5, failedToParseLines.Count);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Exactly(5));
 
-        Assert.Equivalent(
-            new List<string>
-            {
-                "Line 4: Id 123 - Must have either claimants or appellants. At least one is required. [123,00000000-0000-0000-0000-000000000123,NoClaimants.pdf,.pdf,2025-01-15 09:00:00,IA/2025/001,UKUT-IAC,,Secretary of State for the Home Department,,,,,]",
-                "Line 5: Field at index '6' does not exist. You can ignore missing fields by setting MissingFieldFound to null. [completely invalid line]",
-                "Line 6: Field at index '13' does not exist. You can ignore missing fields by setting MissingFieldFound to null. [124,00000000-0000-0000-0000-000000000124,MissingAComma.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,Bad subcategory,,]",
-                "Line 7: Id 125 - main_subcategory 'Bad main subcategory' cannot exist without main_category being defined [125,00000000-0000-0000-0000-000000000125,MissingMainCategory.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,Bad main subcategory,,,]",
-                "Line 8: Id 126 - sec_subcategory 'Bad secondary subcategory' cannot exist without sec_category being defined [126,00000000-0000-0000-0000-000000000126,MissingSecondaryCategory.docx,.docx,2025-01-16 10:00:00,IA/2025/002,UKFTT-TC,Jones,HMRC,,,,Bad secondary subcategory,]"
-            },
-            failedToParseLines);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains("Must have either claimants or appellants"))), Times.Once);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains("Field at index '6' does not exist"))), Times.Once);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains("Field at index '13' does not exist"))), Times.Once);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains("main_subcategory 'Bad main subcategory' cannot exist without main_category"))), Times.Once);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.Is<string>(msg => msg.Contains("sec_subcategory 'Bad secondary subcategory' cannot exist without sec_category"))), Times.Once);
     }
-    
+
     [Fact]
     public void Read_WithNcn_DoesNotTrimOriginalNcnInFullCsvLineContents()
     {
@@ -606,8 +601,8 @@ public class TestRead : IDisposable
                                   124,[2024] EAT 001,00000000-0000-0000-0000-000000000124,/test/data/test-case2.docx,.docx,2025-01-16 10:00:00,UKFTT-TC,Jones,HMRC,
                                   """;
         using var csvStream = new StringReader(csvContent);
-        
-        var result = csvMetadataReader.Read(csvStream, out _, out _, out _);
+
+        var result = csvMetadataReader.Read(csvStream);
 
         var fullCsvLineContentNcns = result.Select(l => l.FullCsvLineContents["ncn"]);
         Assert.Equal(["[2025] UKUT 0027 (LC)", "[2024] EAT 001"], fullCsvLineContentNcns);
@@ -627,7 +622,7 @@ public class TestRead : IDisposable
         using var csvStream = new StringReader(csvContent);
 
         //Act
-        var result = csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out _, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         CsvMetadataLineHelper.AssertCsvLinesMatch(result,
             new CsvLine
@@ -654,7 +649,7 @@ public class TestRead : IDisposable
             }
         );
 
-        Assert.Equal(["Line 3"], skippedCsvLineIdentifiers);
+        mockTracker.Verify(t => t.TrackSkipped("Line 3"), Times.Once);
     }
 
     [Theory]
@@ -678,10 +673,9 @@ public class TestRead : IDisposable
              """
         );
 
-        var result =
-            csvMetadataReader.Read(csvStream, out var skippedCsvLineIdentifiers, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
-        Assert.Empty(csvParseErrors);
+        mockTracker.Verify(t => t.TrackCsvParseError(It.IsAny<string>()), Times.Never);
         var line = Assert.Single(result);
         Assert.Equal(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc), line.DecisionDateTime);
     }
@@ -711,11 +705,10 @@ public class TestRead : IDisposable
              """
         );
 
-        var result = csvMetadataReader.Read(csvStream, out _, out var csvParseErrors, out _);
+        var result = csvMetadataReader.Read(csvStream);
 
         Assert.Empty(result);
-        var error = Assert.Single(csvParseErrors);
-        Assert.Equal(expectedErrorMessage, error);
+        mockTracker.Verify(t => t.TrackCsvParseError(expectedErrorMessage), Times.Once);
     }
 
     [Fact]
@@ -727,7 +720,7 @@ public class TestRead : IDisposable
         // Act & Assert
         Assert.Throws<FileNotFoundException>(() =>
         {
-            _ = csvMetadataReader.Read(out _, out _, out _);
+            _ = csvMetadataReader.Read();
         });
     }
 
@@ -739,7 +732,7 @@ public class TestRead : IDisposable
             "id,FilePath,Extension,decision_datetime,CaseNo,court,claimants,respondent,main_category,main_subcategory,sec_category,sec_subcategory,headnote_summary");
 
         // Act
-        var lines = csvMetadataReader.Read(out _, out _, out _);
+        var lines = csvMetadataReader.Read();
 
         // Assert
         Assert.Empty(lines);
@@ -757,7 +750,7 @@ public class TestRead : IDisposable
         var expectedHash = BacklogParserWorker.Hash(File.ReadAllBytes(backlogParserOptions.Value.CourtMetadataFilePath));
 
         // Act
-        var result = csvMetadataReader.Read(out _, out _, out _);
+        var result = csvMetadataReader.Read();
 
         // Assert
         var line = Assert.Single(result);
@@ -774,7 +767,7 @@ public class TestRead : IDisposable
         using var reader = new StringReader(csvContent);
 
         // Act
-        var result = csvMetadataReader.Read(reader, out _, out _, out _);
+        var result = csvMetadataReader.Read(reader);
 
         // Assert
         var line = Assert.Single(result);

--- a/test/backlog/TestTracker.cs
+++ b/test/backlog/TestTracker.cs
@@ -31,29 +31,36 @@ public class TestTracker
     private readonly IOptions<BacklogParserOptions> options =
         BacklogParserOptionsHelper.Create(trackerFilePath: TrackerFilePath);
 
-    private Tracker CreateTracker(params string[] trackerDataLines)
+    private Tracker tracker;
+
+    public TestTracker()
+    {
+        tracker = new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
+    }
+
+    private void SetupTrackerWithExistingData(params string[] trackerDataLines)
     {
         var fullTrackerContents = string.Join(Environment.NewLine, trackerDataLines.Prepend(TrackerCsvHeader));
-
         mockFileSystem.AddFile(TrackerFilePath, new MockFileData(fullTrackerContents));
-        return new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
+
+        // recreate tracker object because it reads the old tracker file on initialisation
+        tracker = new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
     }
 
     [Fact]
     public void CurrentParserRunId_IsDifferentForEveryRun()
     {
         // Simulate new runs by creating a new tracker instance
-        var tracker = CreateTracker();
-        var tracker2 = CreateTracker();
+        var tracker1 = new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
+        var tracker2 = new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
         
-        Assert.NotEqual(tracker.CurrentParserRunId, tracker2.CurrentParserRunId);
+        Assert.NotEqual(tracker1.CurrentParserRunId, tracker2.CurrentParserRunId);
     }
 
     [Fact]
     public void IsAlreadySentToIngester_WhenNoTrackerFileExists_ReturnsFalse()
     {
         mockFileSystem.RemoveFile(TrackerFilePath);
-        var tracker = CreateTracker();
         Assert.False(tracker.IsAlreadySentToIngester(Guid.NewGuid()));
     }
 
@@ -61,7 +68,6 @@ public class TestTracker
     public void IsAlreadySentToIngester_WhenTrackerFileIsEmpty_ReturnsFalse()
     {
         mockFileSystem.AddEmptyFile(TrackerFilePath);
-        var tracker = CreateTracker();
         Assert.False(tracker.IsAlreadySentToIngester(Guid.NewGuid()));
     }
 
@@ -75,7 +81,7 @@ public class TestTracker
         bool expectedResult)
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
-        var tracker = CreateTracker(
+        SetupTrackerWithExistingData(
             $"UKSC,docx,{sourceUuid},00000000-0000-0000-0000-000000000099,{previousTrackerStatus},ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000");
 
         Assert.Equal(expectedResult, tracker.IsAlreadySentToIngester(sourceUuid));
@@ -85,7 +91,7 @@ public class TestTracker
     public void IsAlreadySentToIngester_MultiplePreviousRunsWithOneSuccess_ReturnsTrue()
     {
         var sourceUuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
-        var tracker = CreateTracker(
+        SetupTrackerWithExistingData(
             $"UKSC,docx,{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-14 10:30:00.000",
             $"UKSC,docx,{sourceUuid},20000000-0000-0000-0000-000000000099,SentToIngester,ref1,ncn1,V v V,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000"
         );
@@ -96,7 +102,7 @@ public class TestTracker
     [Fact]
     public void IsAlreadySentToIngester_WhenDifferentUuidWasSent_ReturnsFalse()
     {
-        var tracker = CreateTracker(
+        SetupTrackerWithExistingData(
             $"UKSC,docx,99999999-9999-9999-9999-999999999999,00000000-0000-0000-0000-000000000099,{TrackerStatus.SentToIngester},ref1,ncn1,,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000");
 
         Assert.False(tracker.IsAlreadySentToIngester(Guid.Parse("00000000-0000-0000-0000-000000000001")));
@@ -107,8 +113,7 @@ public class TestTracker
     {
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
-        var tracker = CreateTracker();
-
+        
         await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, "my-metadata-hash");
 
         var trackerLines =
@@ -131,7 +136,6 @@ public class TestTracker
         const string documentContentHash = "my-document-hash";
         const string caseName = "Case Name";
 
-        var tracker = CreateTracker();
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
         await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
@@ -158,7 +162,6 @@ public class TestTracker
         // Arrange
         const string sourceUuid = "00000000-0000-0000-0000-000000000001";
         const string csvMetadataHash = "my-metadata-hash";
-        var tracker = CreateTracker();
 
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
@@ -192,8 +195,6 @@ public class TestTracker
         const string ncn = "[2023] ABCD 123";
         const string caseName = "Case Name";
 
-        var tracker = CreateTracker();
-
         // Arrange - set existing tracker lines via tracker because it holds internal state separate to the file
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero));
         await tracker.StartTrackingAsync(Guid.Parse(sourceUuid), CsvMetadataLineHelper.DummyLine, csvMetadataHash);
@@ -218,6 +219,26 @@ public class TestTracker
             trackerLines);
     }
 
+    [Fact]
+    public void TrackSkipped_NewSkippedLine_DoesNotWriteToFile()
+    {
+        tracker.TrackSkipped("Line 5");
+
+        Assert.False(mockFileSystem.File.Exists(TrackerFilePath));
+    }
+
+    [Fact]
+    public void HasCsvParseErrors_WhenNoCsvParseErrors_ReturnsFalse()
+    {
+        Assert.False(tracker.HasCsvParseErrors);
+    }
+
+    [Fact]
+    public void HasCsvParseErrors_WhenCsvParseErrorExists_ReturnsTrue()
+    {
+        tracker.TrackCsvParseError("Line 3: missing field");
+        Assert.True(tracker.HasCsvParseErrors);
+    }
 
     [Fact]
     public async Task TrackerOperations_DoNotOverwritePreviousRunLines()
@@ -237,7 +258,8 @@ public class TestTracker
             $"UKSC,docx,{sourceUuid},10000000-0000-0000-0000-000000000099,ParserFailed,ref1,ncn1,Case Name,word.docx,hash1,metahash1,,2025-06-14 10:30:00.000",
             $"UKSC,docx,{sourceUuid},20000000-0000-0000-0000-000000000099,Parsed,ref1,ncn1,Case Name,word.docx,hash1,metahash1,,2025-06-15 10:30:00.000"
         ];
-        var tracker = CreateTracker(oldTrackerLines);
+
+        SetupTrackerWithExistingData(oldTrackerLines);
         fakeTimeProvider.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 32, 0, TimeSpan.Zero));
 
         // Act - trigger all tracker operations

--- a/test/backlog/TestTracker.cs
+++ b/test/backlog/TestTracker.cs
@@ -11,6 +11,8 @@ using Backlog.Tracking;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 
+using test.Mocks;
+
 using Xunit;
 
 namespace test.backlog;
@@ -24,6 +26,7 @@ public class TestTracker
 
     private readonly FakeTimeProvider fakeTimeProvider = new();
     private readonly MockFileSystem mockFileSystem = new();
+    private readonly MockLogger<Tracker> mockLogger = new();
 
     private readonly IOptions<BacklogParserOptions> options =
         BacklogParserOptionsHelper.Create(trackerFilePath: TrackerFilePath);
@@ -33,7 +36,7 @@ public class TestTracker
         var fullTrackerContents = string.Join(Environment.NewLine, trackerDataLines.Prepend(TrackerCsvHeader));
 
         mockFileSystem.AddFile(TrackerFilePath, new MockFileData(fullTrackerContents));
-        return new Tracker(options, mockFileSystem, fakeTimeProvider);
+        return new Tracker(options, mockFileSystem, fakeTimeProvider, mockLogger.Object);
     }
 
     [Fact]


### PR DESCRIPTION
Moving the final stats logging to the tracker enables us to keep all the state required for the final stats inside the tracker, which makes it easier to add new things and refactor other areas.

## Changes

- Move final stats logging to Tracker
- Stop csv metadata reader passing back tracking info to backlog parser worker
- Improve the tracker file writing