### PR TITLE
Backlog: Require UUID to be a GUID

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -68,18 +68,16 @@ internal class BacklogParserWorker(
         {
             var line = lines[i];
 
-            Guid? sourceUuid = null;
             try
             {
-                sourceUuid = Guid.Parse(line.Uuid);
-                if (tracker.IsAlreadySentToIngester(sourceUuid.Value))
+                if (tracker.IsAlreadySentToIngester(line.Uuid))
                 {
                     logger.LogInformation("Skipping {LineId} because it was previously processed", line.id);
                     alreadyDoneLines.Add(line);
                     continue;
                 }
 
-                await tracker.StartTrackingAsync(sourceUuid.Value, line, line.CsvProperties.Hash);
+                await tracker.StartTrackingAsync(line.Uuid, line, line.CsvProperties.Hash);
 
                 logger.LogInformation("Processing file: {FilePath}", line.FilePath);
                 var bundle = await GenerateBundleAsync(line);
@@ -91,7 +89,7 @@ internal class BacklogParserWorker(
 
                 await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
 
-                await tracker.UpdateToSentToIngesterAsync(sourceUuid.Value);
+                await tracker.UpdateToSentToIngesterAsync(line.Uuid);
                 successfulNewLines.Add(line);
 
                 logger.LogInformation("  success");
@@ -101,8 +99,7 @@ internal class BacklogParserWorker(
                 logger.LogError(ex, "Error processing line {LineId}:", line.id);
                 hasErrors = true;
                 failedToProcessLines.Add((line, ex));
-                if(sourceUuid.HasValue)
-                    await tracker.UpdateToParserFailedAsync(sourceUuid.Value, ex);
+                await tracker.UpdateToParserFailedAsync(line.Uuid, ex);
             }
             finally
             {
@@ -174,7 +171,7 @@ internal class BacklogParserWorker(
 
     private async Task<Bundle> GenerateBundleAsync(CsvLine csvLine)
     {
-        var sourceContent = backlogFiles.ReadFile(csvLine.Uuid);
+        var sourceContent = backlogFiles.ReadFile(csvLine.Uuid.ToString());
         var mimeType = MetadataTransformer.GetMimeType(csvLine.Extension);
 
         var isStub = string.Equals(mimeType, "application/pdf", StringComparison.InvariantCultureIgnoreCase);
@@ -196,7 +193,7 @@ internal class BacklogParserWorker(
         var trePipelineMetadata = metadataTransformer.CreateFullTreMetadata(bundleSourceFilename, csvLine.FileName,
             mimeType, sourceHash, images, response.Meta, externalMetadataFields, !isStub);
 
-        await tracker.UpdateToParsedAsync(Guid.Parse(csvLine.Uuid), trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash, response.Meta.Name);
+        await tracker.UpdateToParsedAsync(csvLine.Uuid, trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash, response.Meta.Name);
         
         return Bundle.Make(response, trePipelineMetadata, sourceContent, bundleSourceFilename, images);
     }

--- a/backlog/src/Csv/CsvLine.cs
+++ b/backlog/src/Csv/CsvLine.cs
@@ -75,8 +75,8 @@ internal record CsvLine
     [Optional]
     public string? WebArchiving { get; set; }
 
-    [Required(AllowEmptyStrings = false)]
-    public required string Uuid { get; set; }
+    [Required]
+    public required Guid Uuid { get; set; }
 
     [Default(false)]
     [TypeConverter(typeof(BooleanSkipConverter))]

--- a/test/backlog/CsvMetadataLineHelper.cs
+++ b/test/backlog/CsvMetadataLineHelper.cs
@@ -24,7 +24,7 @@ public static class CsvMetadataLineHelper
         DecisionDateTime = DateTime.MinValue,
         CaseNo = ["ABC/2023/001"],
         Respondent = "The respondent",
-        Uuid = "00000000-0000-0000-0000-000000000007"
+        Uuid = Guid.Parse("00000000-0000-0000-0000-000000000007")
     };
 
     internal static readonly CsvLine DummyLineWithClaimants = DummyLine with { Claimants = "The claimants" };

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -19,7 +19,7 @@ namespace test.backlog.EndToEndTests;
 public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTests(testOutputHelper)
 {
     private const int DocIdWithJurisdiction = 70;
-    private const string Uuid = "c2d8f30f-7b43-4fdc-a54f-ac4a526fedda";
+    private readonly Guid uuid = Guid.NewGuid();
     private string? courtMetadataPath;
     private string? tempDataDir;
 
@@ -47,7 +47,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
 
         // Create files
         var contents = testJudgmentNumber is not null ? DocumentHelpers.ReadDocx(testJudgmentNumber.Value) : [1,2,3,4];
-        File.WriteAllBytes(Path.Combine(courtDocumentsDir, Uuid), contents);
+        File.WriteAllBytes(Path.Combine(courtDocumentsDir, uuid.ToString()), contents);
 
         // Set environment variables
         courtMetadataPath = Path.Combine(tempDataDir, "court_metadata.csv");
@@ -105,7 +105,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
             Jurisdictions = ["new jurisdiction"],
             WebArchiving = "my web archiving link",
             Ncn = "[1989] UKUT 001234 (LC)",
-            Uuid = Uuid
+            Uuid = uuid
         };
         WriteCourtMetadataCsv(metadataLine);
 
@@ -159,7 +159,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
             Respondent = "new respondent",
             Jurisdictions = ["new jurisdiction"],
             WebArchiving = "my web archiving link",
-            Uuid = Uuid
+            Uuid = uuid
         };
         WriteCourtMetadataCsv(metadataLine);
 
@@ -209,7 +209,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
             Appellants = "new appellants",
             Respondent = "new respondent",
             Jurisdictions = ["A jurisdiction which is not in the original document"],
-            Uuid = Uuid
+            Uuid = uuid
         };
         WriteCourtMetadataCsv(metadataLine);
 
@@ -240,7 +240,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
             Appellants = "NIGEL RAWLINS",
             Respondent = "THE INFORMATION COMMISSIONER",
             Jurisdictions = ["InformationRights", "new jurisdiction"],
-            Uuid = Uuid
+            Uuid = uuid
         };
         WriteCourtMetadataCsv(metadataLine);
 
@@ -320,7 +320,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
             Appellants = "NIGEL RAWLINS",
             Respondent = "THE INFORMATION COMMISSIONER",
             Jurisdictions = ["InformationRights"],
-            Uuid = Uuid
+            Uuid = uuid
         };
         WriteCourtMetadataCsv(metadataLine);
 

--- a/test/backlog/MetadataTests/TestMakeMetadata.cs
+++ b/test/backlog/MetadataTests/TestMakeMetadata.cs
@@ -18,7 +18,7 @@ public class TestMakeMetadata
     public void MakeMetadata_WithBasicLine_CreatesCorrectMetadata()
     {
         // Arrange
-        var line = new CsvLine
+        var line = CsvMetadataLineHelper.DummyLine with
         {
             id = "123",
             Court = "UKFTT-GRC",
@@ -32,8 +32,7 @@ public class TestMakeMetadata
             SecCategory = "Human Rights",
             SecSubcategory = "Article 8",
             FilePath = "/path/to/test-document.pdf",
-            Extension = ".pdf",
-            Uuid = "00000000-0000-0000-0000-000000000123"
+            Extension = ".pdf"
         };
 
         // Act
@@ -65,7 +64,7 @@ public class TestMakeMetadata
     public void MakeMetadata_WithAppellants_CreatesCorrectMetadata()
     {
         // Arrange
-        var line = new CsvLine
+        var line = CsvMetadataLineHelper.DummyLine with
         {
             id = "124",
             FilePath = "/test/data/test.pdf",
@@ -76,8 +75,7 @@ public class TestMakeMetadata
             Respondent = "Home Office",
             MainCategory = "Immigration",
             MainSubcategory = "Asylum",
-            Extension = ".pdf",
-            Uuid = "00000000-0000-0000-0000-000000000124"
+            Extension = ".pdf"
         };
 
         // Act

--- a/test/backlog/MetadataTests/TestRead.cs
+++ b/test/backlog/MetadataTests/TestRead.cs
@@ -144,6 +144,28 @@ public sealed class TestRead : IDisposable
         mockTracker.VerifySet(t => t.NumAllLinesInCsv = 4);
     }
 
+    [Theory]
+    [InlineData("not a guid")]
+    [InlineData("1234")]
+    [InlineData("")]
+    public void Read_WithBadUuid_OutputsValidationError(string badUuid)
+    {
+        var csvLine =
+            $"123,{badUuid}, /test/data/test-case.pdf , .pdf , 2025-01-15 09:00:00 ,UKUT-IAC , Smith , Secretary of State for the Home Department,";
+        using var csvStream = new StringReader(
+            $"""
+            id,UUID,FilePath,Extension,decision_datetime,court,claimants,respondent,skip
+            {csvLine}
+            """
+        );
+
+        var result = csvMetadataReader.Read(csvStream);
+
+        Assert.Empty(result);
+        var expectedErrorMessage = $"Line 2: Could not convert field `Uuid` with value \"{badUuid}\" to type `Guid` [{csvLine}]";
+       mockTracker.Verify(t => t.TrackCsvParseError(expectedErrorMessage), Times.Once);
+    }
+    
     [Fact]
     public void Read_WithDodgySkippedLines_DoesNotOutputValidationErrors()
     {
@@ -379,7 +401,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "This is a test headnote summary",
-                Uuid = "aaa00000-0000-0000-0000-000000000123",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000123"),
                 Skip = false
             },
             new CsvLine
@@ -401,7 +423,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "Another test case",
-                Uuid = "aaa00000-0000-0000-0000-000000000124",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000124"),
                 Skip = false
             },
             new CsvLine
@@ -423,7 +445,7 @@ public sealed class TestRead : IDisposable
                 Ncn = "[2023] EWCA Civ 123 & 124",
                 WebArchiving = null,
                 HeadnoteSummary = "Benefits case",
-                Uuid = "aaa00000-0000-0000-0000-000000000125",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000125"),
                 Skip = false
             },
             new CsvLine
@@ -445,7 +467,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "Duplicate ID case",
-                Uuid = "aaa00000-0000-0000-0000-000000000126",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000126"),
                 Skip = false
             },
             new CsvLine
@@ -467,7 +489,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "Multiple Jurisdictions",
-                Uuid = "aaa00000-0000-0000-0000-000000000127",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000127"),
                 Skip = false
             },
             new CsvLine
@@ -489,7 +511,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "Multiple Jurisdictions with spaces",
-                Uuid = "aaa00000-0000-0000-0000-000000000128",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000128"),
                 Skip = false
             },
             new CsvLine
@@ -511,7 +533,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "One Jurisdiction",
-                Uuid = "aaa00000-0000-0000-0000-000000000129"
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000129")
             },
             new CsvLine
             {
@@ -532,7 +554,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = "http://webarchivinglink",
                 HeadnoteSummary = "With web archiving link",
-                Uuid = "aaa00000-0000-0000-0000-000000000130",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000130"),
                 Skip = false
             },
             new CsvLine
@@ -554,7 +576,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "With UUID",
-                Uuid = "ba2c15ca-6d3d-4550-8975-b516e3c0ed2d",
+                Uuid = Guid.Parse("ba2c15ca-6d3d-4550-8975-b516e3c0ed2d"),
                 Skip = false
             }
         );
@@ -644,7 +666,7 @@ public sealed class TestRead : IDisposable
                 Ncn = null,
                 WebArchiving = null,
                 HeadnoteSummary = "This is a test headnote summary",
-                Uuid = "aaa00000-0000-0000-0000-000000000123",
+                Uuid = Guid.Parse("aaa00000-0000-0000-0000-000000000123"),
                 Skip = false
             }
         );


### PR DESCRIPTION
UUID should always be a GUID so making it a CSV parse failure for it not to be one - this simplifies the requirements on the Tracker which uses the UUID as a way to uniquely identify each document it expects to send to the ingester