### PR TITLE
FCLC 2007: Move tracking state to tracker

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -60,7 +60,6 @@ internal class BacklogParserWorker(
         }
 
         var alreadyDoneLines = new List<CsvLine>();
-        var successfulNewLines = new List<CsvLine>();
         var failedToProcessLines = new List<(CsvLine line, Exception exception)>();
         var hasErrors = tracker.HasCsvParseErrors;
 
@@ -90,7 +89,6 @@ internal class BacklogParserWorker(
                 await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
 
                 await tracker.UpdateToSentToIngesterAsync(line.Uuid);
-                successfulNewLines.Add(line);
 
                 logger.LogInformation("  success");
             }
@@ -107,7 +105,7 @@ internal class BacklogParserWorker(
             }
         }
 
-        tracker.LogFinalStatistics(alreadyDoneLines, successfulNewLines, failedToProcessLines);
+        tracker.LogFinalStatistics(alreadyDoneLines, failedToProcessLines);
 
         return hasErrors ? 1 : 0;
     }

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -60,7 +60,6 @@ internal class BacklogParserWorker(
         }
 
         var alreadyDoneLines = new List<CsvLine>();
-        var failedToProcessLines = new List<(CsvLine line, Exception exception)>();
         var hasErrors = tracker.HasCsvParseErrors;
 
         for (var i = 0; i < lines.Count; i++)
@@ -96,7 +95,6 @@ internal class BacklogParserWorker(
             {
                 logger.LogError(ex, "Error processing line {LineId}:", line.id);
                 hasErrors = true;
-                failedToProcessLines.Add((line, ex));
                 await tracker.UpdateToParserFailedAsync(line.Uuid, ex);
             }
             finally
@@ -105,7 +103,7 @@ internal class BacklogParserWorker(
             }
         }
 
-        tracker.LogFinalStatistics(alreadyDoneLines, failedToProcessLines);
+        tracker.LogFinalStatistics(alreadyDoneLines);
 
         return hasErrors ? 1 : 0;
     }

--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -59,7 +58,6 @@ internal class BacklogParserWorker(
             }
         }
 
-        var alreadyDoneLines = new List<CsvLine>();
         var hasErrors = tracker.HasCsvParseErrors;
 
         for (var i = 0; i < lines.Count; i++)
@@ -71,7 +69,6 @@ internal class BacklogParserWorker(
                 if (tracker.IsAlreadySentToIngester(line.Uuid))
                 {
                     logger.LogInformation("Skipping {LineId} because it was previously processed", line.id);
-                    alreadyDoneLines.Add(line);
                     continue;
                 }
 
@@ -103,7 +100,7 @@ internal class BacklogParserWorker(
             }
         }
 
-        tracker.LogFinalStatistics(alreadyDoneLines);
+        tracker.LogFinalStatistics();
 
         return hasErrors ? 1 : 0;
     }

--- a/backlog/src/Csv/CsvMetadataReader.cs
+++ b/backlog/src/Csv/CsvMetadataReader.cs
@@ -91,8 +91,9 @@ internal class CsvMetadataReader(ILogger<CsvMetadataReader> logger, IOptions<Bac
             switch (processCsvRecordResult)
             {
                 case { ErrorMessage: { } errorMessage, Record: null }:
-                    tracker.TrackCsvParseError(
-                        $"Line {currentLineNumber}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]");
+                    var csvParseError = $"Line {currentLineNumber}: {errorMessage} [{csv.Context.Parser!.RawRecord.ReplaceLineEndings(string.Empty)}]";
+                    tracker.TrackCsvParseError(csvParseError);
+                    logger.LogError(csvParseError, currentLineNumber);
                     break;
                 case { Record: { } record, ErrorMessage: null }:
                     records.Add(record);

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -31,8 +31,7 @@ internal interface ITracker
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
 
-    void LogFinalStatistics(List<CsvLine> alreadyDoneLines,
-        List<(CsvLine line, Exception exception)> failedToProcessLines);
+    void LogFinalStatistics(List<CsvLine> alreadyDoneLines);
 }
 
 internal class Tracker : ITracker
@@ -173,8 +172,7 @@ internal class Tracker : ITracker
         fileSystem.File.Copy(tempLogFile, trackerFilePath, true);
     }
 
-    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines,
-        List<(CsvLine line, Exception exception)> failedToProcessLines)
+    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines)
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
@@ -211,40 +209,42 @@ internal class Tracker : ITracker
             );
         }
 
-        if (failedToProcessLines.Count > 0)
+        var failedToProcessLines = currentRunTrackerLines.Values.Where(t => t.TrackerStatus == TrackerStatus.ParserFailed).ToArray();
+        
+        if (failedToProcessLines.Length > 0)
         {
             var failedIdsGroupedByErrorMessage = failedToProcessLines
-                .GroupBy(f =>
+                .GroupBy(t =>
                     {
-                        return f.exception.Message switch
+                        return t.ErrorMessage switch
                         {
-                            _ when f.exception.Message.StartsWith("Could not find file") => "Could not find file",
-                            _ when f.exception.Message.StartsWith("Couldn't find file with UUID") =>
+                            _ when t.ErrorMessage?.StartsWith("Could not find file") ?? false => "Could not find file",
+                            _ when t.ErrorMessage?.StartsWith("Couldn't find file with UUID") ?? false =>
                                 "Couldn't find file with UUID",
-                            _ when f.exception.Message.EndsWith("was not recognized as a valid DateTime.") =>
+                            _ when t.ErrorMessage?.EndsWith("was not recognized as a valid DateTime.") ?? false =>
                                 "String was not recognized as a valid DateTime",
-                            _ => f.exception.Message
+                            _ => t.ErrorMessage
                         };
                     },
-                    f => f.line.id);
+                    t => t.SourceUuid.ToString());
 
             var groupedErrorDescriptions = failedIdsGroupedByErrorMessage.Select(groupOfErrors =>
                 $"  - {groupOfErrors.Count()} lines failed with exception message \"{groupOfErrors.Key}\". Ids affected were: ({StringJoinFirstFive(groupOfErrors, ", ")})");
             var failedFileExtensionBreakdown = string.Join(", ",
-                failedToProcessLines.GroupBy(l => l.line.Extension).Select(g => $"{g.Count()} {g.Key}"));
+                failedToProcessLines.GroupBy(t => t.FileExtension).Select(g => $"{g.Count()} {g.Key}"));
 
             logger.LogError("""
                             ---------------------------
                             Failed to process {FailedLineCount} lines ({FailedFileExtensionBreakdown}), of which:
                             {GroupedErrorDescriptions}
                             """,
-                failedToProcessLines.Count,
+                failedToProcessLines.Length,
                 failedFileExtensionBreakdown,
                 StringJoinFirstFive(groupedErrorDescriptions, Environment.NewLine)
             );
         }
 
-        if (failedToProcessLines.Count == 0 && csvParseErrors.Count == 0)
+        if (failedToProcessLines.Length == 0 && csvParseErrors.Count == 0)
         {
             logger.LogInformation("No failed lines");
         }

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -31,7 +31,7 @@ internal interface ITracker
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
 
-    void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
+    void LogFinalStatistics(List<CsvLine> alreadyDoneLines,
         List<(CsvLine line, Exception exception)> failedToProcessLines);
 }
 
@@ -173,15 +173,16 @@ internal class Tracker : ITracker
         fileSystem.File.Copy(tempLogFile, trackerFilePath, true);
     }
 
-    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines, List<CsvLine> successfulNewLines,
+    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines,
         List<(CsvLine line, Exception exception)> failedToProcessLines)
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
             ? StringJoinFirstFive(skippedCsvLineIdentifiers, ", ")
             : string.Empty;
+        var sentToIngester = currentRunTrackerLines.Values.Where(t => t.TrackerStatus == TrackerStatus.SentToIngester).ToArray();
         var successfulFileExtensionBreakdown = string.Join(", ",
-            successfulNewLines.GroupBy(l => l.Extension).Select(g => $"{g.Count()} {g.Key}"));
+            sentToIngester.GroupBy(l => l.FileExtension).Select(g => $"{g.Count()} {g.Key}"));
 
         logger.LogInformation("""
                               ---------------------------
@@ -190,9 +191,9 @@ internal class Tracker : ITracker
                                 - {MarkedToSkipLineCount} lines were marked in the csv to skip ({MarkedToSkipIds})
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
-            numSkippedCsvLines + alreadyDoneLines.Count + successfulNewLines.Count,
+            numSkippedCsvLines + alreadyDoneLines.Count + sentToIngester.Length,
             NumAllLinesInCsv,
-            successfulNewLines.Count,
+            sentToIngester.Length,
             successfulFileExtensionBreakdown,
             numSkippedCsvLines, markedAsSkipIds,
             alreadyDoneLines.Count

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -31,7 +31,7 @@ internal interface ITracker
     Task UpdateToParserFailedAsync(Guid sourceUuid, Exception exception);
     Task UpdateToSentToIngesterAsync(Guid sourceUuid);
 
-    void LogFinalStatistics(List<CsvLine> alreadyDoneLines);
+    void LogFinalStatistics();
 }
 
 internal class Tracker : ITracker
@@ -172,13 +172,14 @@ internal class Tracker : ITracker
         fileSystem.File.Copy(tempLogFile, trackerFilePath, true);
     }
 
-    public void LogFinalStatistics(List<CsvLine> alreadyDoneLines)
+    public void LogFinalStatistics()
     {
         var numSkippedCsvLines = skippedCsvLineIdentifiers.Count;
         var markedAsSkipIds = numSkippedCsvLines > 0
             ? StringJoinFirstFive(skippedCsvLineIdentifiers, ", ")
             : string.Empty;
         var sentToIngester = currentRunTrackerLines.Values.Where(t => t.TrackerStatus == TrackerStatus.SentToIngester).ToArray();
+        var alreadyDoneLines = previousRunTrackerLines.Where(t => t.TrackerStatus == TrackerStatus.SentToIngester).ToArray();
         var successfulFileExtensionBreakdown = string.Join(", ",
             sentToIngester.GroupBy(l => l.FileExtension).Select(g => $"{g.Count()} {g.Key}"));
 
@@ -189,12 +190,12 @@ internal class Tracker : ITracker
                                 - {MarkedToSkipLineCount} lines were marked in the csv to skip ({MarkedToSkipIds})
                                 - {AlreadyDoneLineCount} lines were skipped because they had been processed in a previous run
                               """,
-            numSkippedCsvLines + alreadyDoneLines.Count + sentToIngester.Length,
+            numSkippedCsvLines + alreadyDoneLines.Length + sentToIngester.Length,
             NumAllLinesInCsv,
             sentToIngester.Length,
             successfulFileExtensionBreakdown,
             numSkippedCsvLines, markedAsSkipIds,
-            alreadyDoneLines.Count
+            alreadyDoneLines.Length
         );
 
         if (csvParseErrors.Count > 0)


### PR DESCRIPTION
Moves the rest of the responsibility for "which lines are in which state" into the tracker.

## Changes

- Backlog parser worker no longer holds state about which lines succeeded/failed/were already done
- Log final statistics uses current and previous tracker line collections to determine end state
- Fixes a small issue where full csv parse errors were no longer being logged