### PR TITLE
Backlog misc changes

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -80,7 +80,7 @@ internal class BacklogParserWorker(
                 var bundleFileName = bundle.Uuid + ".tar.gz";
                 var output = Path.Combine(backlogParserOptions.Value.OutputFolderPath, bundleFileName);
                 logger.LogInformation("  Writing to output: {Output}", output);
-                File.WriteAllBytes(output, bundle.TarGz);
+                await File.WriteAllBytesAsync(output, bundle.TarGz);
 
                 await bucket.UploadBundleAsync(bundleFileName, bundle.TarGz);
 

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -18,7 +18,6 @@ using DotNetEnv.Configuration;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -141,7 +140,7 @@ public class Program
 
     private static int RunBacklogParser(bool isDryRun, uint? id, bool autoPublish)
     {
-        var appHost = CreateAppHost(isDryRun, id, autoPublish);
+        using var appHost = CreateAppHost(isDryRun, id, autoPublish);
 
         using var scope = appHost.Services.CreateScope();
         var backlogParserOptions = scope.ServiceProvider.GetRequiredService<IOptions<BacklogParserOptions>>().Value;
@@ -204,12 +203,12 @@ public class Program
         return builder.Build();
     }
 
-    private static List<(Type serviceType, object instance, bool replace)> _dependencyInjectionOverrides = [];
+    private static readonly List<Action<IServiceCollection>> _dependencyInjectionOverrides = [];
 
     /// <summary>
     ///     Allow services like S3 to be mocked, but only during tests
     /// </summary>
-    internal static List<(Type serviceType, object instance, bool replace)> DependencyInjectionOverrides =>
+    internal static List<Action<IServiceCollection>> DependencyInjectionOverrides =>
         IsTest()
             ? _dependencyInjectionOverrides
             : throw new InvalidOperationException("Cannot use dependency injection overrides in production");
@@ -246,14 +245,9 @@ public class Program
 
     private static void OverrideDependencyInjection(IServiceCollection services)
     {
-        foreach (var (serviceType, instance, replace) in DependencyInjectionOverrides)
+        foreach (var dependencyOverrideAction in DependencyInjectionOverrides)
         {
-            if (replace)
-            {
-                services.RemoveAll(serviceType);
-            }
-
-            services.AddSingleton(serviceType, instance);
+            dependencyOverrideAction(services);
         }
     }
 

--- a/backlog/src/Tracking/Tracker.cs
+++ b/backlog/src/Tracking/Tracker.cs
@@ -90,7 +90,6 @@ internal class Tracker : ITracker
         var trackerLine = new TrackerLine
         {
             SourceUuid = sourceUuid,
-            CsvLine = csvLine,
             ParserRunId = CurrentParserRunId,
             TrackerStatus = TrackerStatus.Started,
             TrackerLineLastUpdated = timeProvider.GetUtcNow(),

--- a/backlog/src/Tracking/TrackerLine.cs
+++ b/backlog/src/Tracking/TrackerLine.cs
@@ -2,23 +2,15 @@
 
 using System;
 
-using Backlog.Csv;
-
 using CsvHelper.Configuration.Attributes;
 
 namespace Backlog.Tracking;
 
 internal class TrackerLine
 {
-    public string? Court { get; set;}
-    public string? FileExtension {get; set; }
-    
-    
+    public string? Court { get; set; }
+    public string? FileExtension { get; set; }
     public Guid SourceUuid { get; init; }
-
-    [Ignore]
-    public CsvLine? CsvLine { get; init; }
-
     public Guid ParserRunId { get; set; }
     public TrackerStatus TrackerStatus { get; set; }
     public string? TreReference { get; set; }
@@ -31,6 +23,4 @@ internal class TrackerLine
 
     [Format("yyyy-MM-dd HH:mm:ss.fff")]
     public DateTimeOffset TrackerLineLastUpdated { get; set; }
-
-    
 }

--- a/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
+++ b/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
@@ -6,6 +6,8 @@ using System.IO;
 
 using Amazon.S3;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 
@@ -35,20 +37,30 @@ public abstract class BaseEndToEndTests : IDisposable
         // Clear lingering overrides from previous tests (overrides are in a static context)
         Environment.SetEnvironmentVariable("IS_TEST", "true");
         Backlog.Program.DependencyInjectionOverrides.Clear();
-        
+
         // Configure S3 client
         Environment.SetEnvironmentVariable("AWS_REGION", "eu-west-2");
-        Backlog.Program.DependencyInjectionOverrides.Add((typeof(IAmazonS3), mockS3Client.Object, true));
+        Backlog.Program.DependencyInjectionOverrides.Add(service =>
+        {
+            service.RemoveAll<IAmazonS3>();
+            service.AddScoped<IAmazonS3>(_ => mockS3Client.Object);
+        });
 
         // Control time
-        Backlog.Program.DependencyInjectionOverrides.Add((typeof(TimeProvider), fakeTimeProvider, true));
+        Backlog.Program.DependencyInjectionOverrides.Add(service =>
+        {
+            service.RemoveAll<TimeProvider>();
+            service.AddScoped<TimeProvider>(_ => fakeTimeProvider);
+        });
 
         // Mock logger
         var mockLoggerProvider = new Mock<ILoggerProvider>();
         mockLoggerProvider.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(() => ConsolidatedLogger.Object);
 
-        Backlog.Program.DependencyInjectionOverrides.Add(
-            (typeof(ILoggerProvider), mockLoggerProvider.Object, false));
+        Backlog.Program.DependencyInjectionOverrides.Add(service =>
+        {
+            service.AddSingleton<ILoggerProvider>(_ => mockLoggerProvider.Object);
+        });
     }
 
     public void Dispose()

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
A few small changes split out from larger overhaul of tracker

## Changes

- Add [Shouldly](https://docs.shouldly.org/), a small assertion framework with nicer error messages than default xunit
- Allow DI to have custom scopes
- Fix missing async warning in BacklogParserWorker by using the async version of `WriteAllBytes`
- Remove unused csvline property from TrackerLine