### PR TITLE
Backlog fixup env config

### DIFF
--- a/backlog/README.md
+++ b/backlog/README.md
@@ -176,8 +176,7 @@ and can be set as follows:
 
 Configuration can be set by either:
 
-- Using [.NET user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?&tabs=linux%2Cpowershell#use-the-secret-manager-tool)
-for local development configuration
+- Using [.NET user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?&tabs=linux%2Cpowershell#use-the-secret-manager-tool) for local development configuration
     - Use `Section:Key` format for user secrets cli
       ```bash 
       dotnet user-secrets set "Section:Key" "value"
@@ -202,9 +201,7 @@ for local development configuration
     - Use `Section__Key` format for environment variables
     - Set by:
         - Exporting environment variables in the shell - `export Section__Key=value`
-        - Adding environment variables to a `.env` file in the assembly folder - `Section__Key="value"`
-        - Adding environment variables to the build/run configuration in your IDE (
-          e.g. [Run configs in Rider](https://www.jetbrains.com/help/rider/Run_Debug_Configuration.html#envvars-progargs))
+        - Adding environment variables to the build/run configuration in your IDE (e.g. [Run configs in Rider](https://www.jetbrains.com/help/rider/Run_Debug_Configuration.html#envvars-progargs))
 
 #### AWS Configuration
 

--- a/backlog/appsettings.json
+++ b/backlog/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Warning"
+    }
+  },
+  "AWS_REGION": "eu-west-2"
+}

--- a/backlog/backlog.csproj
+++ b/backlog/backlog.csproj
@@ -28,10 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="3.2.0" />
-    <None Update=".env">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/backlog/backlog.csproj
+++ b/backlog/backlog.csproj
@@ -32,6 +32,9 @@
     <None Update=".env">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -14,8 +14,6 @@ using Backlog.Src;
 using Backlog.Tracking;
 using Backlog.Utilities;
 
-using DotNetEnv.Configuration;
-
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -170,7 +168,6 @@ public class Program
     private static IHost CreateAppHost(bool isDryRun, uint? id, bool autoPublish)
     {
         var builder = Host.CreateApplicationBuilder();
-        builder.Configuration.AddDotNetEnv();
 
         // Explicitly add user secrets configuration provider so the Production dotnet environment can access it
         // because we always run this application from local machines. Then re-add the environment variables config

--- a/backlog/src/Program.cs
+++ b/backlog/src/Program.cs
@@ -172,8 +172,11 @@ public class Program
         var builder = Host.CreateApplicationBuilder();
         builder.Configuration.AddDotNetEnv();
 
-        // explicitly add user secrets configuration provider so the Production dotnet environment can access it because we always run this application from local machines
+        // Explicitly add user secrets configuration provider so the Production dotnet environment can access it
+        // because we always run this application from local machines. Then re-add the environment variables config
+        // provider, so the default precedence is unchanged and tests can override it
         builder.Configuration.AddUserSecrets<Program>();
+        builder.Configuration.AddEnvironmentVariables();
 
         // bind configuration to the options pattern
         builder.Services.AddOptions<BacklogParserOptions>()


### PR DESCRIPTION
Tests were failing locally because the user secrets were overriding the environment variables set by the e2e tests. This PR fixes that by reinstating the original order of configuration precedence. It also adds in appsettings for quality of life logging defaults and removes the old third party .env file config as it's been replaced by user secrets

## Changes

- fix broken local tests suffering from env vs user secrets conflict
- remove dotenv file support
- add appsettings