### PR TITLE
FCL-2007: Update tracker db to support cloudwatch and marklogic logs

### DIFF
--- a/backlog/Migrations/20260616100119_AddCloudWatchAndMarklogic.Designer.cs
+++ b/backlog/Migrations/20260616100119_AddCloudWatchAndMarklogic.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backlog.Tracking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Backlog.Migrations
 {
     [DbContext(typeof(TrackerDbContext))]
-    partial class TrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616100119_AddCloudWatchAndMarklogic")]
+    partial class AddCloudWatchAndMarklogic
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.27");

--- a/backlog/Migrations/20260616100119_AddCloudWatchAndMarklogic.cs
+++ b/backlog/Migrations/20260616100119_AddCloudWatchAndMarklogic.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backlog.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCloudWatchAndMarklogic : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CloudwatchIngesterRunSummaries",
+                columns: table => new
+                {
+                    RequestId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    MarkLogicUri = table.Column<string>(type: "TEXT", nullable: true),
+                    TreReference = table.Column<Guid>(type: "TEXT", nullable: true),
+                    NcnReference = table.Column<string>(type: "TEXT", nullable: true),
+                    LastInfoMessage = table.Column<string>(type: "TEXT", nullable: true),
+                    LastWarningMessage = table.Column<string>(type: "TEXT", nullable: true),
+                    LastErrorMessage = table.Column<string>(type: "TEXT", nullable: true),
+                    LambdaReport = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CloudwatchIngesterRunSummaries", x => x.RequestId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarkLogicDocumentStatuses",
+                columns: table => new
+                {
+                    FakeTreUuid = table.Column<Guid>(type: "TEXT", nullable: false),
+                    DocumentUri = table.Column<string>(type: "TEXT", nullable: false),
+                    Published = table.Column<bool>(type: "INTEGER", nullable: false),
+                    AwsRequestId = table.Column<Guid>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarkLogicDocumentStatuses", x => x.FakeTreUuid);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CloudwatchIngesterRunSummaries_NcnReference",
+                table: "CloudwatchIngesterRunSummaries",
+                column: "NcnReference");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CloudwatchIngesterRunSummaries_TreReference",
+                table: "CloudwatchIngesterRunSummaries",
+                column: "TreReference");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarkLogicDocumentStatuses_AwsRequestId",
+                table: "MarkLogicDocumentStatuses",
+                column: "AwsRequestId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CloudwatchIngesterRunSummaries");
+
+            migrationBuilder.DropTable(
+                name: "MarkLogicDocumentStatuses");
+        }
+    }
+}

--- a/backlog/README.md
+++ b/backlog/README.md
@@ -16,7 +16,7 @@ This module provides a specialized entry point to the parser specifically design
       * [Required Columns](#required-columns)
       * [Optional Columns](#optional-columns)
       * [CSV Line Example](#csv-line-example)
-    * [Tracker CSV](#tracker-csv)
+    * [Tracker database](#tracker-database)
     * [Configuration variables](#configuration-variables)
       * [AWS Configuration](#aws-configuration)
   * [Development](#development)
@@ -150,13 +150,18 @@ id,court,FilePath,Extension,decision_datetime,CaseNo,claimants,respondent,main_c
 - Line 2 = ID 124 (Jones vs HMRC)
 - Line 3 = ID 125 (Williams vs Home Office)
 
-### Tracker CSV
+### Tracker database
 
-This is created and populated by the Backlog Parser. It tracks which judgments have been uploaded to production, preventing duplicate processing. This is particularly important for batch processing where:
+The tracker is a SQLite database created and populated by the Backlog Parser. It tracks the status of each document in a batch (e.g. whether it failed parsing or got sent to the ingester) and is also used to exclude previously published documents from being processed again.
 
-- Multiple runs might be needed to process all files
-- Some files might fail and need reprocessing
-- Source files might be updated and need reprocessing
+Use the [dotnet ef tool to create new migrations](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/managing?tabs=dotnet-core-cli) when the model changes:
+
+```bash
+cd backlog   # first ensure that you are in the backlog directory
+dotnet ef migrations add <migration name>
+```
+
+On startup, the parser applies any pending EF Core migrations automatically.
 
 ### Configuration variables
 
@@ -168,7 +173,7 @@ and can be set as follows:
 |---------------|-------------------------|----------------------------------------------------------------------------------|
 | BacklogParser | `CourtMetadataFilePath` | Path to the CSV file containing court metadata                                   |
 | BacklogParser | `DataFolderPath`        | Path to the folder containing judgment data files                                |
-| BacklogParser | `TrackerFilePath`       | Path to the CSV file tracking uploaded judgments                                 |
+| BacklogParser | `TrackerFilePath`       | Path to the SQLite db file which tracks uploaded judgments                       |
 | BacklogParser | `OutputFolderPath`      | Path to where generated bundle files will be saved                               |
 | BacklogParser | `BucketName`            | AWS bucket to upload processed files and xml to - optional if using dry run mode |
 | -             | `AWS_REGION`            | AWS region for S3 bucket operations - optional if using dry run mode             |

--- a/backlog/docs/bulk-upload-process.md
+++ b/backlog/docs/bulk-upload-process.md
@@ -5,8 +5,8 @@
   * [Bulk ingestion events](#bulk-ingestion-events-)
   * [Running a bulk upload](#running-a-bulk-upload)
   * [Verifying document status after a bulk upload](#verifying-document-status-after-a-bulk-upload)
-    * [Get logs as csv](#get-logs-as-csv)
-      * [Backlog tracker csv](#backlog-tracker-csv)
+    * [Get logs](#get-logs)
+      * [Backlog tracker db](#backlog-tracker-db)
       * [AWS Ingester logs](#aws-ingester-logs)
       * [MarkLogic logs](#marklogic-logs)
     * [Consolidating log CSVs with DuckDB](#consolidating-log-csvs-with-duckdb)
@@ -31,7 +31,7 @@ When bulk uploading a batch we need to:
 
     subgraph Log locations
       direction LR  
-      tracker[Parser tracker csv]
+      tracker[Parser tracker db]
       cloudwatch[AWS Cloudwatch logs]
       marklogic[Marklogic query]
     end
@@ -80,11 +80,11 @@ See [configure and run backlog parser](../README.md#backlog-parser) for details 
 
 ## Verifying document status after a bulk upload
 
-### Get logs as csv
+### Get logs
 
-#### Backlog tracker csv
+#### Backlog tracker db
 
-Found in [backlog parser outputs](../README.md#tracker-csv)
+This is a SQLite db created by the backlog parser run - see [backlog parser outputs](../README.md#tracker-database)
 
 #### AWS Ingester logs
 

--- a/backlog/src/Tracking/CloudwatchIngesterRunSummary.cs
+++ b/backlog/src/Tracking/CloudwatchIngesterRunSummary.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Backlog.Tracking;
+
+[Index(nameof(NcnReference))]
+[Index(nameof(TreReference))]
+public class CloudwatchIngesterRunSummary
+{
+    [Key]
+    public Guid RequestId { get; set; }
+
+    public string? MarkLogicUri { get; set; }
+    public Guid? TreReference { get; set; }
+    public string? NcnReference { get; set; }
+    public string? LastInfoMessage { get; set; }
+    public string? LastWarningMessage { get; set; }
+    public string? LastErrorMessage { get; set; }
+    public string LambdaReport { get; set; }
+}

--- a/backlog/src/Tracking/MarkLogicDocumentStatus.cs
+++ b/backlog/src/Tracking/MarkLogicDocumentStatus.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Backlog.Tracking;
+
+[Index(nameof(AwsRequestId))]
+public class MarkLogicDocumentStatus
+{
+    public string DocumentUri { get; set; }
+
+    [Key]
+    public Guid FakeTreUuid { get; set; }
+
+    public bool Published { get; set; }
+    public Guid AwsRequestId { get; set; }
+}

--- a/backlog/src/Tracking/TrackerDbContext.cs
+++ b/backlog/src/Tracking/TrackerDbContext.cs
@@ -8,6 +8,8 @@ namespace Backlog.Tracking;
 internal class TrackerDbContext(DbContextOptions<TrackerDbContext> options) : DbContext(options)
 {
     public DbSet<TrackerLine> ParserEvents { get; set; }
+    public DbSet<CloudwatchIngesterRunSummary> CloudwatchIngesterRunSummaries { get; set; }
+    public DbSet<MarkLogicDocumentStatus> MarkLogicDocumentStatuses { get; set; }
     
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {


### PR DESCRIPTION
This PR expands the backlog tracker database so it can support wider bulk-upload document status verification, including parser, CloudWatch ingester, and MarkLogic status data.

## Changes

- Updated backlog documentation to describe the tracker as a SQLite database rather than a CSV file, including migration guidance.
- Added a tracker table/entity for CloudWatch ingester run summaries, indexed by NCN and TRE reference for easier cross-service lookup.
- Added a tracker table/entity for MarkLogic document statuses, including document URI, published status, and AWS request ID.
