### PR TITLE
WIP - add parser control view

### DIFF
--- a/backlog/Migrations/20260616133555_AddParserControl.Designer.cs
+++ b/backlog/Migrations/20260616133555_AddParserControl.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backlog.Tracking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Backlog.Migrations
 {
     [DbContext(typeof(TrackerDbContext))]
-    partial class TrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616133555_AddParserControl")]
+    partial class AddParserControl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.27");

--- a/backlog/Migrations/20260616133555_AddParserControl.cs
+++ b/backlog/Migrations/20260616133555_AddParserControl.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backlog.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddParserControl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                CREATE VIEW ParserControlView AS
+                WITH LatestParserEvents AS (
+                    SELECT
+                        SourceUuid,
+                        TreReference,
+                        TrackerStatus,
+                        ROW_NUMBER() OVER (PARTITION BY SourceUuid ORDER BY TrackerLineLastUpdated DESC) AS rn
+                    FROM ParserEvents
+                )
+                SELECT
+                    lpe.SourceUuid,
+                    CASE
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM CloudwatchIngesterRunSummaries cirs
+                            JOIN MarkLogicDocumentStatuses mlds ON cirs.RequestId = mlds.AwsRequestId
+                            WHERE cirs.TreReference = lpe.TreReference AND mlds.Published = 1
+                        ) THEN 'Published'
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM CloudwatchIngesterRunSummaries cirs
+                            JOIN MarkLogicDocumentStatuses mlds ON cirs.RequestId = mlds.AwsRequestId
+                            WHERE cirs.TreReference = lpe.TreReference AND mlds.Published = 0
+                        ) THEN 'PublicationFailed'
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM CloudwatchIngesterRunSummaries cirs
+                            WHERE cirs.TreReference = lpe.TreReference AND cirs.LastErrorMessage IS NOT NULL
+                        ) THEN 'IngesterFailed'
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM CloudwatchIngesterRunSummaries cirs
+                            WHERE cirs.TreReference = lpe.TreReference
+                        ) THEN 'Ingested'
+                        ELSE lpe.TrackerStatus
+                    END AS TrackerStatus
+                FROM LatestParserEvents lpe
+                WHERE lpe.rn = 1
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW IF EXISTS ParserControlView");
+        }
+    }
+}

--- a/backlog/src/Tracking/ParserControl.cs
+++ b/backlog/src/Tracking/ParserControl.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Backlog.Tracking;
+
+internal class ParserControl
+{
+    [Key]
+    public Guid SourceUuid { get; set; }
+    public TrackerStatus TrackerStatus { get; set; }
+}

--- a/backlog/src/Tracking/TrackerDbContext.cs
+++ b/backlog/src/Tracking/TrackerDbContext.cs
@@ -10,7 +10,17 @@ internal class TrackerDbContext(DbContextOptions<TrackerDbContext> options) : Db
     public DbSet<TrackerLine> ParserEvents { get; set; }
     public DbSet<CloudwatchIngesterRunSummary> CloudwatchIngesterRunSummaries { get; set; }
     public DbSet<MarkLogicDocumentStatus> MarkLogicDocumentStatuses { get; set; }
-    
+    public DbSet<ParserControl> ParserControlView { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ParserControl>(entity =>
+        {
+            entity.ToView("ParserControlView");
+            entity.HasKey(e => e.SourceUuid);
+        });
+    }
+
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder

--- a/backlog/src/Tracking/TrackerStatus.cs
+++ b/backlog/src/Tracking/TrackerStatus.cs
@@ -7,5 +7,8 @@ public enum TrackerStatus
     Parsed,
     ParserFailed,
     SentToIngester,
-    IngesterFailed
+    Ingested,
+    IngesterFailed,
+    Published,
+    PublicationFailed
 }


### PR DESCRIPTION
Adds a view which has the latest tracker state for each sourceuuid to control whether or not the parser reparses a line

## Changes

- Adds a new `ParserControl` view

## Todo

- [ ] Add tests
- [ ] Use the `ParserControl` view in `IsAlreadySentToIngesterAsync`