### PR TITLE
WIP - Backlog: Enable dummy date

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -127,6 +127,7 @@ internal class BacklogParserWorker(
         }
         else
         {
+            var decisionDateAsString = csvLine.DecisionDateTime.ToString("yyyy-MM-dd");
             var request = new Api.Request
             {
                 Meta = new Api.Meta
@@ -134,7 +135,9 @@ internal class BacklogParserWorker(
                     DocumentType = "decision",
                     Cite = csvLine.CleanedNcn,
                     Court = csvLine.Court,
-                    Date = csvLine.DecisionDateTime.ToString("yyyy-MM-dd"),
+                    Date = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
+                        ? null
+                        : decisionDateAsString,
                     Name = csvLine.FirstPartyName + " v " + csvLine.Respondent,
                     JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
                     Extensions = new Api.Extensions

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -89,12 +89,19 @@ internal class MetadataTransformer(
 
     internal static StubMetadata MakeMetadata(CsvLine line)
     {
+        var decisionDateAsString = line.DecisionDateTime.ToString("yyyy-MM-dd");
+
+        var wNamedDate = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
+            ? new WNamedDate { Date = decisionDateAsString, Name = "decision" }
+            : new WNamedDate { Date = UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate, Name = "dummy" };
+        
+        
         StubMetadata meta = new()
         {
             Type = JudgmentType.Decision,
             Court = Courts.GetByCode(line.Court),
             Jurisdictions = line.Jurisdictions.Select(jurisdiction => new OutsideJurisdiction { ShortName = jurisdiction }),
-            Date = new WNamedDate { Date = line.DecisionDateTime.ToString("yyyy-MM-dd"), Name = "decision" },
+            Date = wNamedDate,
             Name = line.FirstPartyName + " v " + line.Respondent,
             CaseNumbers = line.CaseNo.ToList(),
             Parties = line.Parties.ToList(),

--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -1,15 +1,16 @@
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 
+using Backlog.Src;
+
 using UK.Gov.Legislation.Judgments;
 using UK.Gov.Legislation.Judgments.AkomaNtoso;
 using UK.Gov.NationalArchives.CaseLaw.Model;
 
-namespace Backlog.Src
+namespace Backlog
 {
 
     internal class Stub
@@ -121,6 +122,11 @@ namespace Backlog.Src
 
         private void Lifecycle(XmlElement meta)
         {
+            if (Data.Date.Date == Metadata.DummyDate)
+            {
+                return;
+            }
+
             XmlElement lifecycle = CreateAndAppend("lifecycle", meta);
             lifecycle.SetAttribute("source", "#");
             XmlElement eventRef = CreateAndAppend("eventRef", lifecycle);

--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -243,6 +243,7 @@ namespace Backlog.Src
 
         public void Serialize(Stream stream)
         {
+            Validate();
             Serializer.Serialize(Document, stream);
         }
 

--- a/test/backlog/MetadataTests/TestStub.cs
+++ b/test/backlog/MetadataTests/TestStub.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 
+using Backlog;
 using Backlog.Src;
 
 using Xunit;


### PR DESCRIPTION
This probably works to allow dummy date of 1000-1-1 to be specified in csv metadata. It's less fuss than making the field optional but that could be done instead by amending the csv metadata conversion and validation. I wouldn't recommend allowing date to be nullable across the application because that's a rabbithole.....

### Todo

- [ ] See if it works
- [ ] Add tests
- [ ] Update docs
  - [ ]  Refinement docs so people know to replace the 1000-1-1 date
  - [ ] Backlog Parser docs
