### PR TITLE
FCLC-1980: Save dummy dates from backlog spreadsheet

### DIFF
--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -75,7 +75,10 @@ namespace Backlog.Src
             uri.SetAttribute("value", Data.WorkURI);
             XmlElement date = CreateAndAppend("FRBRdate", work);
             date.SetAttribute("date", Data.Date?.Date);
-            date.SetAttribute("name", Data.Date?.Name);
+            if (Data.Date?.Date == "1000-01-01")
+                date.SetAttribute("name", "dummy");
+            else
+                date.SetAttribute("name", Data.Date?.Name);
             XmlElement author = CreateAndAppend("FRBRauthor", work);
             author.SetAttribute("href", "#" + UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.MakeCourtId(Data.Court));
             XmlElement country = CreateAndAppend("FRBRcountry", work);

--- a/test/XmlAssertions.cs
+++ b/test/XmlAssertions.cs
@@ -20,6 +20,14 @@ public static class XmlAssertions
         return nodeMatches[0]!;
     }
 
+    public static XmlNode HasAttribute(this XmlNode node, string attributeName, string expectedValue)
+    {
+        var attribute = node.Attributes?[attributeName];
+        Assert.NotNull(attribute);
+        Assert.Equal(expectedValue, attribute!.InnerText);
+        return node;
+    }
+
     public static void DoesNotHaveNodeWithName(this XmlDocument doc, string name)
     {
         var nodeMatches = doc.GetElementsByTagName(name);
@@ -135,7 +143,18 @@ public static class XmlAssertions
 
         return node;
     }
-    
+
+    public static XmlNode HasChildWithName(this XmlNode node, string name)
+{
+    var child = node.Cast<XmlNode>()
+        .FirstOrDefault(child =>
+            string.Equals(child.Name, name, StringComparison.InvariantCultureIgnoreCase));
+
+    if (child == null)
+        Assert.Fail($"Did not find a child of {node.Name} with name {name}");
+
+    return child;
+}
     public static XmlNode DoesNotHaveChildWithName(this XmlNode node, string name)
     {
         var childNodes = node.Cast<XmlNode>();

--- a/test/backlog/MetadataTests/TestStub.cs
+++ b/test/backlog/MetadataTests/TestStub.cs
@@ -1,5 +1,5 @@
 using System.Xml;
-
+using System;
 using Backlog.Src;
 
 using Xunit;
@@ -204,5 +204,45 @@ public class TestStub
         var doc = new XmlDocument();
         doc.LoadXml(xml);
         doc.DoesNotHaveNodeWithName("uk:webarchiving");
+    }
+
+    [Fact]
+    public void Stub_WithDummyDate_AppearsInXmlAsDummyDate()
+    {
+        // Arrange
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = DateTime.Parse("1000-01-01")
+        };
+        var metadata = MetadataTransformer.MakeMetadata(line);
+
+        // Act
+        var stub = Stub.Make(metadata);
+        var xml = stub.Serialize();
+
+        // Assert
+        var doc = new XmlDocument();
+        doc.LoadXml(xml);
+        doc.HasSingleNodeWithName("FRBRWork").Which().HasChildWithName("FRBRdate").Which().HasAttribute("name", "dummy").And().HasAttribute("date", "1000-01-01");
+    }
+
+    [Fact]
+    public void Stub_WithNormalDate_AppearsInXmlAsNonDummyDate()
+    {
+        // Arrange
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = DateTime.Parse("2025-01-01")
+        };
+        var metadata = MetadataTransformer.MakeMetadata(line);
+
+        // Act
+        var stub = Stub.Make(metadata);
+        var xml = stub.Serialize();
+
+        // Assert
+        var doc = new XmlDocument();
+        doc.LoadXml(xml);
+        doc.HasSingleNodeWithName("FRBRWork").Which().HasChildWithName("FRBRdate").Which().HasAttribute("name", "decision").And().HasAttribute("date", "2025-01-01");
     }
 }


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-1980

Ensure that we can enter dates of 1000-01-01 into the spreadsheet and they'll be recognised as dummy dates in the system.

See also #509 which I hadn't noticed at the time