### PR TITLE
chore: bump caselaw utils courts.json to v4.7.0

### DIFF
--- a/NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj
+++ b/NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <CourtsJson>https://raw.githubusercontent.com/nationalarchives/ds-caselaw-utils/refs/tags/v4.1.0/src/autogen/courts.json</CourtsJson>
+        <CourtsJson>https://raw.githubusercontent.com/nationalarchives/ds-caselaw-utils/refs/tags/v4.7.0/src/autogen/courts.json</CourtsJson>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Bump caselaw utils courts.json to v4.7.0 for UKIT court.