### PR TITLE
SixLabors v4 upgrade (requires licensing)

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -1,4 +1,5 @@
 name: Run Integrations Tests
+permissions: {}
 
 on:
   pull_request:
@@ -19,6 +20,8 @@ jobs:
       # Checkout the code
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up .NET environment (assuming C# is the primary language)
       - name: Setup .NET
@@ -32,6 +35,8 @@ jobs:
 
       # Build
       - name: Build
+        env: 
+          SIXLABORSLICENSEKEY: ${{ secrets.SIXLABORSLICENSEKEY }}
         run: dotnet build tna-judgments-parser.sln --no-restore --configuration release
 
       # Run tests

--- a/.github/workflows/tre-docker-smoke.yml
+++ b/.github/workflows/tre-docker-smoke.yml
@@ -1,4 +1,5 @@
 name: TRE Docker Smoke Test
+permissions: {}
 
 on:
   pull_request:
@@ -16,10 +17,21 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build Docker image
-        run: |
-          docker build -f TRE/DockerfileV2 -t tre-lambda-test .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          load: true
+          secrets: |
+            "SIXLABORS_LICENSE_KEY=${{ secrets.SIXLABORSLICENSEKEY }}"
+          context: .
+          file: ./TRE/DockerfileV2
+          tags: tre-lambda-test
 
       - name: Run Docker container
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Secrets.cs
 
 ## Files downloaded from other repos
 NationalArchives.FindCaseLaw.Utils/courts.json
+
+## Six Labors Licence Key File
+sixlabors.lic

--- a/README.md
+++ b/README.md
@@ -128,3 +128,10 @@ You can run this code in a Dev Container in VSCode or [other IDES](https://conta
 You can now run tests in debug mode from the Flask (Testing) icon on the left.
 
 Configuration lives in `devcontainer.json`.
+
+## Six Labors Licence Key
+
+If running locally, put the licence at sixlabors.lic in the root directory of this repo, or ensure that the $SIX_LABORS_LIC docker variable is populated
+(potentially via [/vars in the terraform enviroment](https://github.com/nationalarchives/da-tre-terraform-environments/tree/main/vars))
+
+Additionally it is stored in the github actions secrets as SIXLABORSLICENSEKEY.

--- a/TRE/DockerfileV2
+++ b/TRE/DockerfileV2
@@ -11,12 +11,13 @@ COPY ["judgments.csproj", "judgments.csproj"]
 RUN dotnet restore judgments.csproj
 COPY ["TRE/TRE.csproj", "TRE/TRE.csproj"]
 RUN dotnet restore TRE/TRE.csproj
+
+RUN --mount=type=secret,id=SIXLABORS_LICENSE_KEY,env=SIXLABORS_LICENSE_KEY echo "$SIXLABORS_LICENSE_KEY" > ./sixlabors.lic
 # Copy the rest of the repo over
 COPY . ./
 
 FROM build-env AS publish
-
-RUN dotnet publish TRE/TRE.csproj -c Release -o /app/publish --no-restore
+RUN --mount=type=secret,id=SIXLABORS_LICENSE_KEY,env=SIXLABORS_LICENSE_KEY dotnet publish TRE/TRE.csproj -c Release -o /app/publish --no-restore
 
 FROM base AS final
 

--- a/judgments.csproj
+++ b/judgments.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Actually merging this will require that the TRE build pipeline also supports the environment variable / secrets