### PR TITLE
FCLC-2120: Backlog: Fix dummy date stub outputs

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -127,6 +127,7 @@ internal class BacklogParserWorker(
         }
         else
         {
+            var decisionDateAsString = csvLine.DecisionDateTime.ToString("yyyy-MM-dd");
             var request = new Api.Request
             {
                 Meta = new Api.Meta
@@ -134,7 +135,9 @@ internal class BacklogParserWorker(
                     DocumentType = "decision",
                     Cite = csvLine.CleanedNcn,
                     Court = csvLine.Court,
-                    Date = csvLine.DecisionDateTime.ToString("yyyy-MM-dd"),
+                    Date = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
+                        ? null
+                        : decisionDateAsString,
                     Name = csvLine.FirstPartyName + " v " + csvLine.Respondent,
                     JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
                     Extensions = new Api.Extensions

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -89,12 +89,18 @@ internal class MetadataTransformer(
 
     internal static StubMetadata MakeMetadata(CsvLine line)
     {
+        var decisionDateAsString = line.DecisionDateTime.ToString("yyyy-MM-dd");
+
+        var wNamedDate = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
+            ? new WNamedDate { Date = UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate, Name = "dummy" }
+            : new WNamedDate { Date = decisionDateAsString, Name = "decision" };
+        
         StubMetadata meta = new()
         {
             Type = JudgmentType.Decision,
             Court = Courts.GetByCode(line.Court),
             Jurisdictions = line.Jurisdictions.Select(jurisdiction => new OutsideJurisdiction { ShortName = jurisdiction }),
-            Date = new WNamedDate { Date = line.DecisionDateTime.ToString("yyyy-MM-dd"), Name = "decision" },
+            Date = wNamedDate,
             Name = line.FirstPartyName + " v " + line.Respondent,
             CaseNumbers = line.CaseNo.ToList(),
             Parties = line.Parties.ToList(),

--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -77,14 +77,7 @@ internal class Stub
 
         var date = CreateAndAppend("FRBRdate", work);
         date.SetAttribute("date", stubMetadata.Date?.Date);
-        if (stubMetadata.Date?.Date == "1000-01-01")
-        {
-            date.SetAttribute("name", "dummy");
-        }
-        else
-        {
-            date.SetAttribute("name", stubMetadata.Date?.Name);
-        }
+        date.SetAttribute("name", stubMetadata.Date?.Name);
 
         var author = CreateAndAppend("FRBRauthor", work);
         author.SetAttribute("href", "#" + Metadata.MakeCourtId(stubMetadata.Court));
@@ -143,11 +136,16 @@ internal class Stub
 
     private void Lifecycle(XmlElement meta)
     {
+        if (stubMetadata.Date?.Date == Metadata.DummyDate)
+        {
+            return;
+        }
+        
         var lifecycle = CreateAndAppend("lifecycle", meta);
         lifecycle.SetAttribute("source", "#");
 
         var eventRef = CreateAndAppend("eventRef", lifecycle);
-        eventRef.SetAttribute("date", stubMetadata.Date.Date);
+        eventRef.SetAttribute("date", stubMetadata.Date!.Date);
         eventRef.SetAttribute("refersTo", "#" + Metadata.MakeDateId(stubMetadata.Date));
         eventRef.SetAttribute("source", "#");
     }

--- a/test/XmlAssertions.cs
+++ b/test/XmlAssertions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Xml;
 
@@ -128,20 +129,39 @@ public static class XmlAssertions
                 }
             }
 
-            Assert.True(hasPassedInspection, $"""Found unexpected child node <{child.Name}> with value "{child.InnerText}" in <{node.Name}>""");
+            Assert.True(hasPassedInspection,
+                $"Found unexpected child node in <{node.Name}>: {XmlNodeAsFormattedString(child)}");
         }
 
         Assert.True(unpassedInspectors.Count == 0, $"{unpassedInspectors.Count} inspectors were not satisfied for <{node.Name}>");
     }
-    
-    public static XmlNode HasChildMatching(this XmlNode node, string expectedName, string expectedValue)
+
+    public static XmlNode HasChildMatching(this XmlNode node, string expectedName, string expectedValue,
+        params (string key, string value)[] expectedAttributes)
     {
         var childNodes = node.Cast<XmlNode>();
-        
-        if (!childNodes.Any(child => child.IsMatch(expectedName, expectedValue).isMatch))
-            Assert.Fail($"Could not find a child of {node.Name} with name {expectedName} and value \"{expectedValue}\"");
+
+        if (!childNodes.Any(child => child.IsMatch(expectedName, expectedValue, expectedAttributes).isMatch))
+        {
+            Assert.Fail(
+                $"""
+                 Could not find a child with name {expectedName}, value "{expectedValue}" and attributes [{string.Join(", ", expectedAttributes.Select(x => x.key + ":" + x.value))}] in:
+                 {XmlNodeAsFormattedString(node)}
+                 """);
+        }
 
         return node;
+    }
+
+    private static string XmlNodeAsFormattedString(XmlNode node)
+    {
+        using var stringWriter = new StringWriter();
+        using var xmlTextWriter = new XmlTextWriter(stringWriter);
+        xmlTextWriter.Formatting = Formatting.Indented;
+
+        node.WriteTo(xmlTextWriter);
+
+        return stringWriter.ToString();
     }
 
     public static XmlNode HasChildWithName(this XmlNode node, string name)

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -140,6 +140,58 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
     }
 
     [Fact]
+    public void ProcessBacklogTribunal_DocxWithDummyDecisionDate_UsesDateFromDocument()
+    {
+        const int docWithDecisionDate = 13;
+        var originalFileName = $"test{docWithDecisionDate}.docx";
+
+        ConfigureTestEnvironment(docWithDecisionDate);
+
+        var metadataLine = new CsvLine
+        {
+            id = docWithDecisionDate.ToString(),
+            FilePath = originalFileName,
+            Extension = ".docx",
+            DecisionDateTime = new DateTime(1000, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            Court = "UKUT-IA",
+            Claimants = "a claimant",
+            Respondent = "a respondent",
+            Uuid = uuid
+        };
+        WriteCourtMetadataCsv(metadataLine);
+
+        // Act
+        var exitCode = Backlog.Program.Main();
+
+        //Assert
+        AssertProgramExitedSuccessfully(exitCode);
+
+        var doc = GetXmlDocumentFromS3();
+
+        // Assert xml is as expected
+        doc.HasSingleNodeWithName("FRBRWork")
+           .Which().HasChildMatching("FRBRdate", "", ("name", "decision"), ("date", "2021-04-12"));
+
+        doc.HasSingleNodeWithName("FRBRExpression")
+           .Which().HasChildMatching("FRBRdate", "", ("name", "decision"), ("date", "2021-04-12"));
+
+        doc.HasSingleNodeWithName("lifecycle")
+           .Which().HasChildrenMatching(
+               child => child.Should().Match(
+                   "eventRef",
+                   "",
+                   ("refersTo", "#hearing"), ("date", "2021-03-24"), ("source", "#")),
+               child => child.Should().Match(
+                   "eventRef",
+                   "",
+                   ("refersTo", "#decision"), ("date", "2021-04-12"), ("source", "#"))
+           );
+
+        doc.HasSingleNodeWithName("proprietary")
+           .Which().HasChildMatching("uk:year", "2021");
+    }
+
+    [Fact]
     public void ProcessBacklogTribunal_PdfWithExternalMetaData_AddsMetadata()
     {
         var originalFileName = "test.pdf";
@@ -188,6 +240,45 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
 
         doc.HasSingleNodeWithName("references")
            .Which().DoesNotHaveChildWithName("docJurisdiction");
+    }
+
+    [Fact]
+    public void ProcessBacklogTribunal_PdfWithDummyDecisionDate_OutputsDummyDate()
+    {
+        var originalFileName = "test.pdf";
+
+        ConfigureTestEnvironment(null);
+
+        var metadataLine = new CsvLine
+        {
+            id = "42",
+            FilePath = originalFileName,
+            Extension = ".pdf",
+            DecisionDateTime = new DateTime(1000, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            Court = "UKUT-LC",
+            Ncn = "[1989] UKUT 001234 (LC)",
+            Claimants = "new claimants",
+            Respondent = "new respondent",
+            Uuid = uuid
+        };
+        WriteCourtMetadataCsv(metadataLine);
+
+        // Act
+        var exitCode = Backlog.Program.Main();
+
+        //Assert
+        AssertProgramExitedSuccessfully(exitCode);
+
+        var doc = GetXmlDocumentFromS3();
+
+        // Assert - dummy date is in FRBR Work and Expression
+        doc.HasSingleNodeWithName("FRBRWork")
+           .Which().HasChildMatching("FRBRdate", "", ("name", "dummy"), ("date", "1000-01-01"));
+        doc.HasSingleNodeWithName("FRBRExpression")
+           .Which().HasChildMatching("FRBRdate", "", ("name", "dummy"), ("date", "1000-01-01"));
+
+        // Assert - lifecycle is not present because we have no real date
+        doc.DoesNotHaveNodeWithName("lifecycle");
     }
 
     [Fact]

--- a/test/backlog/MetadataTests/TestMakeMetadata.cs
+++ b/test/backlog/MetadataTests/TestMakeMetadata.cs
@@ -2,9 +2,9 @@
 
 using System;
 
-using Backlog.Csv;
-
 using Backlog.Src;
+
+using Shouldly;
 
 using UK.Gov.Legislation.Judgments;
 
@@ -14,6 +14,8 @@ namespace test.backlog.MetadataTests;
 
 public class TestMakeMetadata
 {
+    private readonly DateTime dummyDate = new(1000, 01, 01, 00, 00, 00, 00, DateTimeKind.Utc);
+
     [Fact]
     public void MakeMetadata_WithBasicLine_CreatesCorrectMetadata()
     {
@@ -280,5 +282,30 @@ public class TestMakeMetadata
 
         // Assert
         Assert.Empty(result.Jurisdictions);
+    }
+
+    [Fact]
+    public void MakeMetadata_WithDummyDate_SetsNamedDateToDummy()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { DecisionDateTime = dummyDate };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Date.Date.ShouldBe("1000-01-01");
+        result.Date.Name.ShouldBe("dummy");
+    }
+
+    [Fact]
+    public void MakeMetadata_WithRealDate_SetsNamedDateToDecision()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = new DateTime(2020, 11, 05, 01, 00, 00, DateTimeKind.Utc)
+        };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Date.Date.ShouldBe("2020-11-05");
+        result.Date.Name.ShouldBe("decision");
     }
 }

--- a/test/backlog/MetadataTests/TestStub.cs
+++ b/test/backlog/MetadataTests/TestStub.cs
@@ -117,8 +117,10 @@ public class TestStub
         resultXml.DoesNotHaveNodeWithName("uk:webarchiving");
     }
 
-    [Fact]
-    public void Stub_WithDummyDate_AppearsInXmlAsDummyDate()
+    [Theory]
+    [InlineData("FRBRWork")]
+    [InlineData("FRBRExpression")]
+    public void Stub_WithDummyDate_AppearsInXmlAsDummyDate(string frbrNode)
     {
         var line = CsvMetadataLineHelper.DummyLineWithClaimants with
         {
@@ -127,11 +129,36 @@ public class TestStub
 
         var resultXml = Act(line);
 
-        resultXml.HasSingleNodeWithName("FRBRWork").Which().HasChildWithName("FRBRdate").Which().HasAttribute("name", "dummy").And().HasAttribute("date", "1000-01-01");
+        resultXml.HasSingleNodeWithName(frbrNode)
+           .Which().HasChildMatching(
+               "FRBRdate",
+               "",
+               ("name", "dummy"), ("date", "1000-01-01")
+           );
     }
 
     [Fact]
-    public void Stub_WithNormalDate_AppearsInXmlAsNonDummyDate()
+    public void Stub_WithDummyDate_DoesNotHaveLifecycle()
+    {
+        // Arrange
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = DateTime.Parse("1000-01-01")
+        };
+        var metadata = MetadataTransformer.MakeMetadata(line);
+
+        // Act
+        var stub = Stub.Make(metadata);
+        var xml = stub.Serialize();
+
+        // Assert
+        var doc = new XmlDocument();
+        doc.LoadXml(xml);
+        doc.DoesNotHaveNodeWithName("lifecycle");
+    }
+
+    [Fact]
+    public void Stub_WithNormalDate_AppearsInXmlAsDecisionDate()
     {
         var line = CsvMetadataLineHelper.DummyLineWithClaimants with
         {


### PR DESCRIPTION
This fixes some issues with dummy date handling in the Backlog parser.

## Changes

- Backlog docx
  - Ensure that the dummy date isn't passed to main parser code (because otherwise it will override the date pulled from the doc)
- Stub
  - Ensure that lifecycle isn't set for dummy dates
  - Use date name "dummy" in both FRBRWork and FRBRExpression (by setting the name when we create the stub metadata)