### PR TITLE
FCLC-2120: Backlog: Use cite for stub uk:year and add uk:number

### DIFF
--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -91,10 +91,21 @@ internal class MetadataTransformer(
     {
         var decisionDateAsString = line.DecisionDateTime.ToString("yyyy-MM-dd");
 
-        var wNamedDate = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
+        var isDummyDate = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate;
+        var wNamedDate = isDummyDate
             ? new WNamedDate { Date = UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate, Name = "dummy" }
             : new WNamedDate { Date = decisionDateAsString, Name = "decision" };
-        
+
+        var hasNcn = line.CleanedNcn is not null;
+        var shortUriComponent = hasNcn ? Citations.MakeUriComponent(line.CleanedNcn) : null;
+
+        var year = (hasNcn, isDummyDate) switch
+        {
+            (hasNcn: true, _) => Citations.YearFromUriComponent(shortUriComponent),
+            (hasNcn: false, isDummyDate: false) => line.DecisionDateTime.Year,
+            (hasNcn: false, isDummyDate: true) => null
+        };
+
         StubMetadata meta = new()
         {
             Type = JudgmentType.Decision,
@@ -107,6 +118,8 @@ internal class MetadataTransformer(
             Categories = line.Categories.ToList(),
             SourceFormat = GetMimeType(line.Extension),
             Cite = line.CleanedNcn,
+            Year = year,
+            ShortUriComponent = shortUriComponent,
             WebArchivingLink = line.WebArchiving
         };
         return meta;

--- a/backlog/src/MetadataTransformer.cs
+++ b/backlog/src/MetadataTransformer.cs
@@ -119,6 +119,7 @@ internal class MetadataTransformer(
             SourceFormat = GetMimeType(line.Extension),
             Cite = line.CleanedNcn,
             Year = year,
+            Number = Citations.NumberFromUriComponent(shortUriComponent),
             ShortUriComponent = shortUriComponent,
             WebArchivingLink = line.WebArchiving
         };

--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -195,6 +195,11 @@ internal class Stub
             CreateAndAppendUk(proprietary, "year", stubMetadata.Year.Value.ToString());
         }
 
+        if (stubMetadata.Number.HasValue)
+        {
+            CreateAndAppendUk(proprietary, "number", stubMetadata.Number.Value.ToString());
+        }
+
         foreach (var caseNo in stubMetadata.CaseNumbers)
         {
             CreateAndAppendUk(proprietary, "caseNumber", caseNo);

--- a/backlog/src/Stub.cs
+++ b/backlog/src/Stub.cs
@@ -190,7 +190,10 @@ internal class Stub
             CreateAndAppendUk(proprietary, "jurisdiction", jurisdiction.ShortName);
         }
 
-        CreateAndAppendUk(proprietary, "year", stubMetadata.Date.Date[..4]);
+        if (stubMetadata.Year.HasValue)
+        {
+            CreateAndAppendUk(proprietary, "year", stubMetadata.Year.Value.ToString());
+        }
 
         foreach (var caseNo in stubMetadata.CaseNumbers)
         {

--- a/src/model/Citations.cs
+++ b/src/model/Citations.cs
@@ -173,7 +173,12 @@ public class Citations {
         return int.Parse(year);
     }
 
-    internal static int NumberFromUriComponent(string uri) {
+    public static int? NumberFromUriComponent(string uri)
+    {
+        if (uri is null)
+        {
+            return null;
+        }
         string num = Regex.Match(uri, @"^[a-z]+(/[a-z]+[1-3]?)?/\d{4}/(\d+)").Groups[2].Value;
         return int.Parse(num);
     }

--- a/src/model/Citations.cs
+++ b/src/model/Citations.cs
@@ -163,7 +163,12 @@ public class Citations {
         return Regex.IsMatch(uri, @"^[a-z]+(/[a-z]+[1-3]?)?/\d{4}/\d+(/press-summary/\d+)?$");
     }
 
-    internal static int YearFromUriComponent(string uri) {
+    public static int? YearFromUriComponent(string uri)
+    {
+        if (uri is null)
+        {
+            return null;
+        }
         string year = Regex.Match(uri, @"^[a-z]+(/[a-z]+[1-3]?)?/(\d{4})/\d+").Groups[2].Value;
         return int.Parse(year);
     }

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -234,7 +234,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
                child => child.Should().Match("uk:jurisdiction", "new jurisdiction"),
                child => child.Should().Match("uk:sourceFormat", "application/pdf"),
                child => child.Should().HaveName("uk:parser"),
-               child => child.Should().Match("uk:year", "2099"),
+               child => child.Should().Match("uk:year", "1989"),
                child => child.Should().Match("uk:webarchiving", "my web archiving link")
            );
 
@@ -279,6 +279,10 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
 
         // Assert - lifecycle is not present because we have no real date
         doc.DoesNotHaveNodeWithName("lifecycle");
+
+        // Assert proprietary node uses year from cite not dummy date
+        doc.HasSingleNodeWithName("proprietary")
+           .Which().HasChildMatching("uk:year", "1989");
     }
 
     [Fact]

--- a/test/backlog/EndToEndTests/MetadataTests.cs
+++ b/test/backlog/EndToEndTests/MetadataTests.cs
@@ -235,6 +235,7 @@ public class MetadataTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTes
                child => child.Should().Match("uk:sourceFormat", "application/pdf"),
                child => child.Should().HaveName("uk:parser"),
                child => child.Should().Match("uk:year", "1989"),
+               child => child.Should().Match("uk:number", "1234"),
                child => child.Should().Match("uk:webarchiving", "my web archiving link")
            );
 

--- a/test/backlog/MetadataTests/TestMakeMetadata.cs
+++ b/test/backlog/MetadataTests/TestMakeMetadata.cs
@@ -308,4 +308,37 @@ public class TestMakeMetadata
         result.Date.Date.ShouldBe("2020-11-05");
         result.Date.Name.ShouldBe("decision");
     }
+
+    [Fact]
+    public void MakeMetadata_WithNcn_SetsYearFromNcn()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = "[2024] UKFTT 2345 (GRC)" };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Year.ShouldBe(2024);
+    }
+
+    [Fact]
+    public void MakeMetadata_WithoutNcn_UsesDateAsYear()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            Ncn = null, DecisionDateTime = new DateTime(2019, 03, 21, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Year.ShouldBe(2019);
+    }
+
+    [Fact]
+    public void MakeMetadata_WithDummyDateAndWithoutNcn_SetsYearToNull()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { DecisionDateTime = dummyDate };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Year.ShouldBe(null);
+    }
 }

--- a/test/backlog/MetadataTests/TestMakeMetadata.cs
+++ b/test/backlog/MetadataTests/TestMakeMetadata.cs
@@ -320,6 +320,16 @@ public class TestMakeMetadata
     }
 
     [Fact]
+    public void MakeMetadata_WithNcn_SetsNumberFromNcn()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = "[2024] UKFTT 2345 (GRC)" };
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Number.ShouldBe(2345);
+    }
+
+    [Fact]
     public void MakeMetadata_WithoutNcn_UsesDateAsYear()
     {
         var line = CsvMetadataLineHelper.DummyLineWithClaimants with
@@ -340,5 +350,15 @@ public class TestMakeMetadata
         var result = MetadataTransformer.MakeMetadata(line);
 
         result.Year.ShouldBe(null);
+    }
+
+    [Fact]
+    public void MakeMetadata_WithoutNcn_SetsNumberToNull()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants;
+
+        var result = MetadataTransformer.MakeMetadata(line);
+
+        result.Number.ShouldBe(null);
     }
 }

--- a/test/backlog/MetadataTests/TestStub.cs
+++ b/test/backlog/MetadataTests/TestStub.cs
@@ -181,6 +181,18 @@ public class TestStub
         resultXml.HasSingleNodeWithName("proprietary")
                  .Which().HasChildMatching("uk:year", "2024");
     }
+
+    [Fact]
+    public void Stub_WithNcn_GetsNumberFromNcn()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = "[2024] UKFTT 2345 (GRC)" };
+
+        var resultXml = Act(line);
+
+        resultXml.HasSingleNodeWithName("proprietary")
+                 .Which().HasChildMatching("uk:number", "2345");
+    }
+
     [Fact]
     public void Stub_WithoutNcn_UsesDateAsYear()
     {
@@ -203,6 +215,16 @@ public class TestStub
         var resultXml = Act(line);
 
         resultXml.DoesNotHaveNodeWithName("uk:year");
+    }
+
+    [Fact]
+    public void Stub_WithoutNcn_HasNoUkNumber()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants;
+
+        var resultXml = Act(line);
+
+        resultXml.DoesNotHaveNodeWithName("uk:number");
     }
 
     private static XmlDocument Act(CsvLine line)

--- a/test/backlog/MetadataTests/TestStub.cs
+++ b/test/backlog/MetadataTests/TestStub.cs
@@ -171,6 +171,40 @@ public class TestStub
                  .HasAttribute("name", "decision").And().HasAttribute("date", "2025-01-01");
     }
 
+    [Fact]
+    public void Stub_WithNcn_GetsYearFromNcn()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = "[2024] UKFTT 2345 (GRC)" };
+
+        var resultXml = Act(line);
+
+        resultXml.HasSingleNodeWithName("proprietary")
+                 .Which().HasChildMatching("uk:year", "2024");
+    }
+    [Fact]
+    public void Stub_WithoutNcn_UsesDateAsYear()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = new DateTime(2019, 03, 21, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var resultXml = Act(line);
+
+        resultXml.HasSingleNodeWithName("proprietary")
+                 .Which().HasChildMatching("uk:year", "2019");
+    }
+
+    [Fact]
+    public void Stub_WithDummyDateAndWithoutNcn_HasNoUkYear()
+    {
+        var line = CsvMetadataLineHelper.DummyLineWithClaimants with { DecisionDateTime = dummyDate };
+
+        var resultXml = Act(line);
+
+        resultXml.DoesNotHaveNodeWithName("uk:year");
+    }
+
     private static XmlDocument Act(CsvLine line)
     {
         var metadata = MetadataTransformer.MakeMetadata(line);


### PR DESCRIPTION
This brings the stub behaviour more inline with the real parsed xml and stops the `uk:year` being 1000 when there is no decision date

## Changes

- Gets stub uk:year from ncn when available or falls back to decision year (if not dummy) when no valid ncn specified
- Adds uk:number to stub