### PR TITLE
Backlog - fix pdf ncn tracker

### DIFF
--- a/backlog/src/BacklogParserWorker.cs
+++ b/backlog/src/BacklogParserWorker.cs
@@ -14,7 +14,10 @@ using Backlog.Tracking;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using UK.Gov.Legislation.Judgments.AkomaNtoso;
+
 using Api = UK.Gov.NationalArchives.Judgments.Api;
+using Bundle = Backlog.Src.Bundle;
 
 namespace Backlog;
 
@@ -105,64 +108,62 @@ internal class BacklogParserWorker(
         return hasErrors ? 1 : 0;
     }
 
-    private Api.Response CreateResponse(CsvLine csvLine, string mimeType, byte[] sourceContent, bool isStub)
+    private Api.Response SendToParser(CsvLine csvLine, string mimeType, byte[] sourceContent)
     {
-        Api.Response response;
-        if (isStub)
+        var decisionDateAsString = csvLine.DecisionDateTime.ToString("yyyy-MM-dd");
+        var request = new Api.Request
         {
-            var stubMetadata = MetadataTransformer.MakeMetadata(csvLine);
-            var stub = Stub.Make(stubMetadata);
-
-            response = new Api.Response
+            Meta = new Api.Meta
             {
-                Xml = stub.Serialize(),
-                Meta = new Api.Meta
+                DocumentType = "decision",
+                Cite = csvLine.CleanedNcn,
+                Court = csvLine.Court,
+                Date = decisionDateAsString == Metadata.DummyDate
+                    ? null
+                    : decisionDateAsString,
+                Name = csvLine.FirstPartyName + " v " + csvLine.Respondent,
+                JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
+                Extensions = new Api.Extensions
                 {
-                    DocumentType = "decision",
-                    Court = stubMetadata.Court?.Code,
-                    Date = stubMetadata.Date?.Date,
-                    Name = stubMetadata.Name
+                    SourceFormat = mimeType,
+                    CaseNumbers = csvLine.CaseNo.ToList(),
+                    Parties = csvLine.Parties.ToList(),
+                    Categories = csvLine.Categories.ToList(),
+                    WebArchivingLink = csvLine.WebArchiving
                 }
-            };
-        }
-        else
+            },
+            Hint = Api.Hint.UKUT,
+            Content = sourceContent
+        };
+
+        var response = parser.Parse(request);
+
+        if (response.Xml.Contains("<header />"))
         {
-            var decisionDateAsString = csvLine.DecisionDateTime.ToString("yyyy-MM-dd");
-            var request = new Api.Request
-            {
-                Meta = new Api.Meta
-                {
-                    DocumentType = "decision",
-                    Cite = csvLine.CleanedNcn,
-                    Court = csvLine.Court,
-                    Date = decisionDateAsString == UK.Gov.Legislation.Judgments.AkomaNtoso.Metadata.DummyDate
-                        ? null
-                        : decisionDateAsString,
-                    Name = csvLine.FirstPartyName + " v " + csvLine.Respondent,
-                    JurisdictionShortNames = csvLine.Jurisdictions.ToList(),
-                    Extensions = new Api.Extensions
-                    {
-                        SourceFormat = mimeType,
-                        CaseNumbers = csvLine.CaseNo.ToList(),
-                        Parties = csvLine.Parties.ToList(),
-                        Categories = csvLine.Categories.ToList(),
-                        WebArchivingLink = csvLine.WebArchiving
-                    }
-                },
-                Hint = Api.Hint.UKUT,
-                Content = sourceContent
-            };
-
-            response = parser.Parse(request);
-
-            if (response.Xml.Contains("<header />"))
-            {
-                throw new NotSupportedException(
-                    "Couldn't parse header - try updating titles used to identify the end of header in OptimizedUKUTParser.titles");
-            }
+            throw new NotSupportedException(
+                "Couldn't parse header - try updating titles used to identify the end of header in OptimizedUKUTParser.titles");
         }
 
         return response;
+    }
+
+    internal static Api.Response MakeStubResponse(CsvLine csvLine)
+    {
+        var stubMetadata = MetadataTransformer.MakeMetadata(csvLine);
+        var stub = Stub.Make(stubMetadata);
+
+        return new Api.Response
+        {
+            Xml = stub.Serialize(),
+            Meta = new Api.Meta
+            {
+                DocumentType = "decision",
+                Court = stubMetadata.Court?.Code,
+                Date = stubMetadata.Date?.Date,
+                Name = stubMetadata.Name,
+                Cite = stubMetadata.Cite
+            }
+        };
     }
 
     private async Task<Bundle> GenerateBundleAsync(CsvLine csvLine)
@@ -171,7 +172,7 @@ internal class BacklogParserWorker(
         var mimeType = MetadataTransformer.GetMimeType(csvLine.Extension);
 
         var isStub = string.Equals(mimeType, "application/pdf", StringComparison.InvariantCultureIgnoreCase);
-        var response = CreateResponse(csvLine, mimeType, sourceContent, isStub);
+        var response = isStub ? MakeStubResponse(csvLine) : SendToParser(csvLine, mimeType, sourceContent);
 
         var sourceHash = Hash(sourceContent);
         var images = response.Images?.ToArray() ?? [];
@@ -190,7 +191,7 @@ internal class BacklogParserWorker(
             mimeType, sourceHash, images, response.Meta, externalMetadataFields, !isStub);
 
         await tracker.UpdateToParsedAsync(csvLine.Uuid, trePipelineMetadata.Parameters.TRE.Reference, response.Meta.Cite, sourceHash, response.Meta.Name);
-        
+
         return Bundle.Make(response, trePipelineMetadata, sourceContent, bundleSourceFilename, images);
     }
 

--- a/test/Mocks/MockLogger.cs
+++ b/test/Mocks/MockLogger.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 
 using Microsoft.Extensions.Logging;
 
@@ -10,6 +11,14 @@ namespace test.Mocks;
 
 public class MockLogger<T> : Mock<ILogger<T>>
 {
+    public string GetLogMessageContaining(string partialMessage)
+    {
+        return Invocations.Where(i => i.Method.Name == nameof(ILogger.Log))
+                          .Where(i => i.Arguments[2].ToString()!.Contains(partialMessage))
+                          .Select(i => i.Arguments[2].ToString()!)
+                          .Single();
+    }
+
     public MockLogger<T> VerifyLog(string expectedMessage, LogLevel expectedLogLevel, Times? times = null)
     {
         times ??= Times.Once();

--- a/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
+++ b/test/backlog/EndToEndTests/BaseEndtoEndTests.cs
@@ -116,6 +116,14 @@ public abstract class BaseEndToEndTests : IDisposable
         return capturedUuid;
     }
 
+    protected Guid GetParserRunIdFromLogs()
+    {
+        //Get parser run Id
+        var parserRunId = Guid.Parse(ConsolidatedLogger.GetLogMessageContaining("Starting parser run")
+                                                       .Split(' ')[^1]);
+        return parserRunId;
+    }
+
     protected void PrintToOutputWithNumberedLines(string textToPrint)
     {
         PrintToOutputWithNumberedLines(textToPrint.Split(Environment.NewLine));

--- a/test/backlog/EndToEndTests/TrackerTests.cs
+++ b/test/backlog/EndToEndTests/TrackerTests.cs
@@ -1,0 +1,245 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Backlog.Tracking;
+
+using Shouldly;
+
+using Xunit;
+
+namespace test.backlog.EndToEndTests;
+
+public class TrackerTests(ITestOutputHelper testOutputHelper) : BaseEndToEndTests(testOutputHelper)
+{
+    private string? trackerPath;
+    private string? courtDocumentsDir;
+    private string? courtMetadataPath;
+    private string? tempDataDir;
+    private const string Court = "UKUT-LC";
+
+    protected override void Dispose(bool disposing)
+    {
+        if (tempDataDir is not null && Directory.Exists(tempDataDir))
+        {
+            Directory.Delete(tempDataDir, true);
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private record TestData
+    {
+        public bool Is(Properties flag)
+        {
+            return properties.HasFlag(flag);
+        }
+
+        public TestData(int Id, Properties properties, TrackerStatus? Status = null)
+        {
+            this.Id = Id;
+            this.properties = properties;
+            this.Status = Status;
+
+            Uuid = Guid.Parse($"00000000-0000-0000-0000-{Id:000000000000}");
+
+            Appellant = $"appellant {Id}";
+            Respondent = $"respondent {Id}";
+
+            Ncn = Is(Properties.HasNcn) ? $"[2017] UKUT {Id} (LC)" : null;
+
+            if (Is(Properties.IsDocx))
+            {
+                Extension = ".docx";
+                Contents = DocumentHelpers.ReadDocx(1);
+                DocumentHash = "6a67df51a7306d58da905765c3b050faf23a2f99e1a8e5750cab732b9814cf82";
+            }
+            else if (Is(Properties.IsPdf))
+            {
+                Extension = ".pdf";
+                Contents = DocumentHelpers.GetEmbeddedResourceAsBytes(
+                    "test.backlog.test_data.Money_Worries_Ltd_v_Office_of_Fair_Trading.court_documents.ac4e30ac-416c-494d-8a76-a0dee0ca93bc");
+                DocumentHash = "a12036d81e1e533b7aa91dcfa73c96c36abca19b8c78a52aeecef89e6a3a578b";
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(properties), properties,
+                    "Must set test data document type to either docx or pdf");
+            }
+
+            OriginalFilePathForDocument = $"Data/Folder/Orig{Id}{Extension}";
+        }
+
+        public string Extension { get; }
+        public int Id { get; }
+        public string? Ncn { get; }
+        public string Appellant { get; }
+        public string Respondent { get; }
+        public string OriginalFilePathForDocument { get; }
+
+        public Guid Uuid { get; }
+
+        public byte[] Contents { get; }
+        public string DocumentHash { get; }
+
+        public TrackerStatus? Status { get; }
+
+        private readonly Properties properties;
+
+        [Flags]
+        public enum Properties
+        {
+            ShouldSkip = 1,
+            IsDocx = 2,
+            IsPdf = 4,
+            HasNcn = 8
+        }
+    }
+
+    private void ConfigureTestEnvironment(params TestData[] testData)
+    {
+        // Create directories
+        tempDataDir = Path.Combine(Path.GetTempPath(), $"FilesTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDataDir);
+
+        var outputPath = Path.Combine(tempDataDir, "output");
+        Directory.CreateDirectory(outputPath);
+
+        courtDocumentsDir = Path.Combine(tempDataDir, "court_documents");
+        Directory.CreateDirectory(courtDocumentsDir);
+
+        // Set environment variables
+        courtMetadataPath = Path.Combine(tempDataDir, "court_metadata.csv");
+        trackerPath = Path.Combine(tempDataDir, $"tracker{Guid.NewGuid()}.db");
+
+        SetPathEnvironmentVariables(tempDataDir, outputPath, courtMetadataPath, trackerPath);
+
+        // Create files
+        foreach (var document in testData)
+        {
+            File.WriteAllBytes(Path.Combine(courtDocumentsDir, document.Uuid.ToString()), document.Contents);
+        }
+
+        WriteCourtMetadataCsv(testData);
+        var existingTrackerData = testData.Where(t => t.Status is not null)
+                                          .Select(t => new TrackerLine
+                                          {
+                                              Court = Court,
+                                              FileExtension = t.Extension,
+                                              ParserRunId = Guid.NewGuid(),
+                                              SourceUuid = t.Uuid,
+                                              TrackerStatus = t.Status!.Value,
+                                              TrackerLineLastUpdated = new DateTimeOffset(2025, 1, 1, 0, 0, 0,
+                                                  TimeSpan.Zero)
+                                          })
+                                          .ToArray();
+        TrackerDbHelper.SeedFileTrackerDb(trackerPath, existingTrackerData);
+    }
+
+    private void WriteCourtMetadataCsv(TestData[] testData)
+    {
+        const string headerLine = "id,FilePath,Extension,decision_datetime,court,appellants,respondent,skip,UUID,ncn";
+        var csvMetadataLines = new List<string> { headerLine };
+
+        csvMetadataLines.AddRange(testData.Select(item =>
+            string.Join(',',
+                item.Id,
+                item.OriginalFilePathForDocument,
+                item.Extension,
+                "2001-01-01",
+                Court,
+                item.Appellant,
+                item.Respondent,
+                item.Is(TestData.Properties.ShouldSkip) ? "skip" : "",
+                item.Uuid,
+                item.Ncn
+            )));
+
+        File.WriteAllLines(courtMetadataPath!, csvMetadataLines);
+        PrintToOutputWithNumberedLines(csvMetadataLines);
+    }
+
+    [Fact]
+    public void Tracker_SuccessfulParse_AddsParserEventSentToIngester()
+    {
+        TestData[] data =
+        [
+            new(1, TestData.Properties.IsDocx | TestData.Properties.HasNcn),
+            new(2, TestData.Properties.IsDocx),
+            new(3, TestData.Properties.IsPdf | TestData.Properties.HasNcn),
+            new(4, TestData.Properties.IsPdf)
+        ];
+        ConfigureTestEnvironment(data);
+
+        var expectedTime = new DateTimeOffset(2026, 07, 08, 09, 10, 11, TimeSpan.Zero);
+        fakeTimeProvider.AdjustTime(expectedTime);
+
+        // Act
+        var exitCode = Backlog.Program.Main();
+        AssertProgramExitedSuccessfully(exitCode);
+
+        // Assert - tracker was updated for all processed items
+        using var trackerDb = TrackerDbHelper.OpenFileTrackerDb(trackerPath!);
+        var actualParserEvents = trackerDb.ParserEvents.ToArray();
+        actualParserEvents.Length.ShouldBe(4);
+
+        // Assert - ParserEvents data that is always the same
+        actualParserEvents.ShouldAllBe(t => t.TrackerStatus == TrackerStatus.SentToIngester);
+        actualParserEvents.ShouldAllBe(t => t.ErrorMessage == null);
+        actualParserEvents.ShouldAllBe(t => t.Court == Court);
+
+        // Assert - CsvMetadataHash is the same for all ParserEvents (it varies per test run because of the temporary files created during the test)
+        var expectedCsvMetadataHash = actualParserEvents[0].CsvMetadataHash;
+        expectedCsvMetadataHash.ShouldBe("627c8ca63f0331c301b82dedeb4af9a4e927bb8dedaf307c9aa9d497951cd342");
+        actualParserEvents.ShouldAllBe(t =>
+            t.CsvMetadataHash == "627c8ca63f0331c301b82dedeb4af9a4e927bb8dedaf307c9aa9d497951cd342");
+
+        // Assert - ParserEvents contains data generated during run
+        var parserRunId = GetParserRunIdFromLogs();
+        actualParserEvents.ShouldAllBe(t => t.ParserRunId == parserRunId);
+        actualParserEvents.Select(t => t.TreReference).ShouldBe(mockS3Client.TreReferencesFromCapturedKeys);
+
+        // Assert - ParserEvents contains data from test inputs
+        foreach (var expectedDocument in data)
+        {
+            var actualParserEvent = actualParserEvents
+                                    .Where(t => t.SourceUuid == expectedDocument.Uuid)
+                                    .ShouldHaveSingleItem();
+
+            actualParserEvent.FileExtension.ShouldBe(expectedDocument.Extension);
+            actualParserEvent.SourceUuid.ShouldBe(expectedDocument.Uuid);
+            actualParserEvent.Ncn.ShouldBe(expectedDocument.Ncn);
+            actualParserEvent.CaseName.ShouldBe($"{expectedDocument.Appellant} v {expectedDocument.Respondent}");
+            actualParserEvent.OriginalFileName.ShouldBe(expectedDocument.OriginalFilePathForDocument);
+            actualParserEvent.DocumentContentHash.ShouldBe(expectedDocument.DocumentHash);
+            actualParserEvent.TrackerLineLastUpdated.ShouldBe(expectedTime);
+        }
+    }
+
+    [Fact]
+    public void Tracker_SkippedDocument_DoesNotAddParserEvent()
+    {
+        var skipped1 = new TestData(1, TestData.Properties.IsDocx | TestData.Properties.ShouldSkip);
+        var skipped2 = new TestData(2, TestData.Properties.IsPdf | TestData.Properties.ShouldSkip);
+
+        ConfigureTestEnvironment(
+            new TestData(12, TestData.Properties.IsDocx),
+            skipped1,
+            new TestData(13, TestData.Properties.IsPdf),
+            skipped2);
+
+        // Act
+        var exitCode = Backlog.Program.Main();
+        AssertProgramExitedSuccessfully(exitCode);
+
+        // Assert
+        using var trackerDb = TrackerDbHelper.OpenFileTrackerDb(trackerPath!);
+
+        trackerDb.ParserEvents.Count().ShouldBe(2);
+        trackerDb.ParserEvents.ShouldNotContain(t => t.SourceUuid == skipped1.Uuid);
+        trackerDb.ParserEvents.ShouldNotContain(t => t.SourceUuid == skipped2.Uuid);
+    }
+}

--- a/test/backlog/MockS3Client.cs
+++ b/test/backlog/MockS3Client.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -44,6 +45,9 @@ public partial class MockS3Client : Mock<IAmazonS3>, IDisposable
     }
 
     public IEnumerable<string> CapturedKeys => s3Captures.Keys;
+
+    public IEnumerable<string> TreReferencesFromCapturedKeys =>
+        CapturedKeys.Select(key => key.Replace(".tar.gz", string.Empty));
 
     public void Dispose()
     {

--- a/test/backlog/TestBacklogParserWorker.cs
+++ b/test/backlog/TestBacklogParserWorker.cs
@@ -1,0 +1,81 @@
+#nullable enable
+
+using System;
+
+using Backlog;
+
+using Shouldly;
+
+using Xunit;
+
+namespace test.backlog;
+
+public class TestBacklogParserWorker
+{
+    [Fact]
+    public void MakeStubResponse_SetsDocumentTypeToDecision()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants;
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.DocumentType.ShouldBe("decision");
+    }
+
+    [Fact]
+    public void MakeStubResponse_SetsCourt()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants with { Court = "ET" };
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.Court.ShouldBe("ET");
+    }
+
+    [Fact]
+    public void MakeStubResponse_SetsDate()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            DecisionDateTime = new DateTime(2026, 07, 08, 09, 10, 11, 12, DateTimeKind.Utc)
+        };
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.Date.ShouldBe("2026-07-08");
+    }
+
+    [Fact]
+    public void MakeStubResponse_SetsName()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants with
+        {
+            Claimants = "some claimant",
+            Respondent = "some respondent"
+        };
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.Name.ShouldBe("some claimant v some respondent");
+    }
+
+    [Fact]
+    public void MakeStubResponse_WithNcn_PutsNcnIntoCite()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = "My NCN" };
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.Cite.ShouldBe("My NCN");
+    }
+
+    [Fact]
+    public void MakeStubResponse_WithoutNcn_SetsCiteToNull()
+    {
+        var csvLine = CsvMetadataLineHelper.DummyLineWithClaimants with { Ncn = null };
+
+        var result = BacklogParserWorker.MakeStubResponse(csvLine);
+
+        result.Meta.Cite.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Some new e2e tracker tests found a bug - the ncns weren't being tracked in `ParserEvents` for PDFs. This PR fixes that and adds the first batch of e2e tracker tests.

# Changes

- Add e2e tracker db tests
- Record NCNs in the ParserEvents tracker table for PDFs