### PR TITLE
backlog: Update marklogic query

### DIFF
--- a/backlog/docs/marklogic-ingested-parser-run.xquery
+++ b/backlog/docs/marklogic-ingested-parser-run.xquery
@@ -9,27 +9,30 @@ import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls
 (: CHANGE ME to the specific parser run ID you want to look for :)
 let $target-run-id := "PUT_PARSER_RUN_ID_HERE"
 
-(: Search for documents last updated by given parser run ID :)
-let $results := cts:search(
-  collection("http://marklogic.com/collections/dls/latest-version"),
-    cts:properties-fragment-query(
-    cts:element-value-query(xs:QName("parser-run-id"), $target-run-id)
-  )
-)
-
 (: Create CSV output :)
 let $csv-header := "document_URI,fake_TRE_UUID,published,AWS_request_id"
 
 let $rows :=
-  for $doc in $results
-    let $uri := xdmp:node-uri($doc)
+  for $uri in cts:uris("", (), cts:and-query(
+    (
+      cts:collection-query("http://marklogic.com/collections/dls/latest-version"),
+      cts:collection-query("judgment"),
+      cts:properties-fragment-query(cts:element-value-query(xs:QName("parser-run-id"), $target-run-id))
+    )))
 
+    (: Get published data from latest version :)
     let $props := xdmp:document-properties($uri)
     let $published := string($props//published)
-    
-    let $annotation := xdmp:unquote(string($props//dls:annotation), (), ("format-json"))/node()
-    let $fake-tre-uuid := string($annotation/payload/tre_raw_metadata/parameters/TRE/reference)
-    let $aws-request-id := string($annotation/payload/aws_lambda_context/aws_request_id)
+
+    (: Get annotation data from the version which has this parserrun id in annotation too - it won't be in the latest version for enriched documents and won't be in the first version for re-run documents :)
+    let $versioned-uris := fn:replace($uri, "^/(d-[^/]+)\.xml$", "/$1_xml_versions/*.xml")
+    let $version-with-annotation := cts:uri-match($versioned-uris, (), cts:properties-fragment-query(cts:element-query(xs:QName("dls:annotation"), $target-run-id)))
+
+    let $annotation-str := xdmp:document-properties($version-with-annotation)//dls:annotation/string()
+    let $annotation := xdmp:unquote($annotation-str, (), "format-json")/node()
+
+    let $fake-tre-uuid := $annotation/payload/tre_raw_metadata/parameters/TRE/reference/string()
+    let $aws-request-id := $annotation/payload/aws_lambda_context/aws_request_id/string()
 
     (: Construct the CSV row :)
     return fn:concat('"', $uri, '","', $fake-tre-uuid, '","', $published, '","', $aws-request-id, '"')


### PR DESCRIPTION
The old query wasn't returning information for documents that have been through the enrichment engine which was causing missing data for batch 16