### PR TITLE
Marklogic delete by annotation

### DIFF
--- a/backlog/docs/bulk-upload-process.md
+++ b/backlog/docs/bulk-upload-process.md
@@ -77,6 +77,23 @@ When bulk uploading a batch we need to:
 Please refer to the [internal documentation](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1437794305/) for details on the full process including retrieving and validating inputs, performing file conversions and what to look for when doing a dry run.
 See [configure and run backlog parser](../README.md#backlog-parser) for details on commands and flags.
 
+### Clearing a previous bulk upload in MarkLogic
+
+Two staging cleanup scripts are available:
+
+- [marklogic-delete-by-parser-run-id.xqy](./marklogic-delete-by-parser-run-id.xqy)
+  finds documents using the parser run ID.
+- [marklogic-delete-by-annotation-name.xqy](./marklogic-delete-by-annotation-name.xqy)
+  finds documents using the metadata CSV filename.
+
+Both scripts print the matching document URLs by default, with the delete calls
+commented out. Run the selected script first and verify that the returned
+documents and count are expected. To check whether a document is checked out,
+uncomment the checkout-status block in the script; it prints documents which
+are checked out. If documents are checked out, uncomment and run the
+`dls:break-checkout(...)` block first. Then uncomment the delete call and rerun
+the script.
+
 ## Verifying document status after a bulk upload
 
 ### Get logs

--- a/backlog/docs/bulk-upload-process.md
+++ b/backlog/docs/bulk-upload-process.md
@@ -77,6 +77,10 @@ When bulk uploading a batch we need to:
 Please refer to the [internal documentation](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1437794305/) for details on the full process including retrieving and validating inputs, performing file conversions and what to look for when doing a dry run.
 See [configure and run backlog parser](../README.md#backlog-parser) for details on commands and flags.
 
+### Clearing a previous bulk upload in MarkLogic
+
+Run the [marklogic-delete-by-annotation-name.xqy](./marklogic-delete-by-annotation-name.xqy) script on the MarkLogic console to clear documents created by a previous run.
+
 ## Verifying document status after a bulk upload
 
 ### Get logs

--- a/backlog/docs/marklogic-delete-by-annotation-name.xqy
+++ b/backlog/docs/marklogic-delete-by-annotation-name.xqy
@@ -1,0 +1,49 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+(: 
+   Deletes documents created by a previous run of the backlog parser. Do not use in production.
+   See bulk-upload-process.md for full details.
+:)
+
+let $csv-filename := "PUT_METADATA_CSV_NAME_HERE.csv"
+
+(: Step 1: Find docs in the judgment collection imported via this CSV, via their DLS annotation :)
+let $csv-docs := cts:search(
+  collection("judgment"),
+  cts:properties-fragment-query(
+    cts:element-word-query(xs:QName("dls:annotation"), fn:concat('"name": "', $csv-filename, '"'))
+  )
+)
+
+(: Step 2: Extract distinct parser-run-id values — first from the direct property,
+   falling back to the parser_run_id field inside the dls:annotation JSON payload :)
+let $run-ids := fn:distinct-values(
+  for $doc in $csv-docs
+  let $props := xdmp:document-properties(xdmp:node-uri($doc))
+  let $direct-run-id := $props//parser-run-id/text()
+  return
+    if (fn:exists($direct-run-id)) then
+      $direct-run-id
+    else
+      for $annotation in $props//dls:annotation/text()
+      let $parsed := xdmp:from-json-string($annotation)
+      let $parser-params := map:get(map:get(map:get(map:get($parsed, "payload"), "tre_raw_metadata"), "parameters"), "PARSER")
+      where fn:exists($parser-params)
+      return map:get($parser-params, "parser_run_id")
+)
+
+(: Step 3: Find all judgment docs with any of those run IDs :)
+let $result := cts:search(
+  collection("judgment"),
+  cts:properties-fragment-query(
+    cts:element-value-query(xs:QName("parser-run-id"), $run-ids)
+  )
+)
+
+return (
+  fn:concat("Run IDs found: ", fn:string-join($run-ids, ", ")),
+  for $doc in $result
+    (: return dls:document-delete(xdmp:node-uri($doc), fn:false(), fn:false()) :)
+    return xdmp:node-uri($doc)
+)

--- a/backlog/docs/marklogic-delete-by-annotation-name.xqy
+++ b/backlog/docs/marklogic-delete-by-annotation-name.xqy
@@ -1,0 +1,78 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+(: 
+   Deletes documents created by a previous run of the backlog parser. Do not use in production.
+   See bulk-upload-process.md for full details.
+
+   Do not run this script with either destructive block uncommented until the
+   matching documents have been verified. To check whether a document is
+   checked out, replace the final `return xdmp:node-uri($doc)` with the
+   commented block below that prints which documents which are checked out.
+
+   If any documents are checked out, uncomment the break-checkout block and run
+   the script. Review the results, then uncomment the document-delete block and
+   run it again. Keep both blocks commented until the matching documents have
+   been verified.
+:)
+
+let $csv-filename := "PUT_METADATA_CSV_NAME_HERE.csv"
+
+(: Step 1: Find docs in the judgment collection imported via this CSV, via their DLS annotation :)
+let $csv-docs := cts:search(
+  collection("judgment"),
+  cts:properties-fragment-query(
+    cts:element-word-query(xs:QName("dls:annotation"), fn:concat('"name": "', $csv-filename, '"'))
+  )
+)
+
+(: Step 2: Extract distinct parser-run-id values — first from the direct property,
+   falling back to the parser_run_id field inside the dls:annotation JSON payload :)
+let $run-ids := fn:distinct-values(
+  for $doc in $csv-docs
+  let $props := xdmp:document-properties(xdmp:node-uri($doc))
+  let $direct-run-id := $props//parser-run-id/text()
+  return
+    if (fn:exists($direct-run-id)) then
+      $direct-run-id
+    else
+      for $annotation in $props//dls:annotation/text()
+      let $parsed := xdmp:from-json-string($annotation)
+      let $parser-params := map:get(map:get(map:get(map:get($parsed, "payload"), "tre_raw_metadata"), "parameters"), "PARSER")
+      where fn:exists($parser-params)
+      return map:get($parser-params, "parser_run_id")
+)
+
+let $deep := fn:true()
+
+(: Step 3: Find all judgment docs with any of those run IDs :)
+let $result := cts:search(
+  collection("judgment"),
+  cts:properties-fragment-query(
+    cts:element-value-query(xs:QName("parser-run-id"), $run-ids)
+  )
+)
+
+return (
+  fn:concat("Run IDs found: ", fn:string-join($run-ids, ", ")),
+  for $doc in $result
+
+    (: Uncomment to print documents which are checked out.
+    let $uri := xdmp:node-uri($doc)
+    let $checkout-status := dls:document-checkout-status($uri)
+    where fn:string-length(fn:string($checkout-status)) gt 0
+    return fn:concat($uri, " checked out: ", $checkout-status)
+    :)
+
+    (: Uncomment to break checkout before deleting checked-out documents.
+    let $uri := xdmp:node-uri($doc)
+    where dls:document-checkout-status($uri)
+    return dls:break-checkout($uri, $deep)
+    :)
+
+    (: Uncomment to delete the matching documents.
+    return dls:document-delete(xdmp:node-uri($doc), fn:false(), fn:false())
+    :)
+
+    return xdmp:node-uri($doc)
+)

--- a/backlog/docs/marklogic-delete-by-parser-run-id.xqy
+++ b/backlog/docs/marklogic-delete-by-parser-run-id.xqy
@@ -1,0 +1,49 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+(: 
+   Deletes documents created by a previous run of the backlog parser. Do not use in production.
+   See bulk-upload-process.md for full details.
+
+   Do not run this script with either destructive block uncommented until the
+   matching documents have been verified. To check whether a document is
+   checked out, replace the final `return $uri` with the commented block below
+   that prints which documents which are checked out.
+
+   If any documents are checked out, uncomment the break-checkout block and run
+   the script. Review the results, then uncomment the document-delete block and
+   run it again. Keep both blocks commented until the matching documents have
+   been verified.
+:)
+
+(: CHANGE ME to the specific parser run ID you want to look for :)
+let $target-run-id := "PUT_PARSER_RUN_ID_HERE"
+
+(: Create CSV output :)
+let $csv-header := "document_URI,fake_TRE_UUID,published,AWS_request_id"
+let $deep := fn:true()
+return (
+  for $uri in cts:uris("", (), cts:and-query(
+    (
+      cts:collection-query("http://marklogic.com/collections/dls/latest-version"),
+      cts:collection-query("judgment"),
+      cts:properties-fragment-query(cts:element-value-query(xs:QName("parser-run-id"), $target-run-id))
+    )))
+
+    (: Uncomment to print documents which are checked out.
+    let $checkout-status := dls:document-checkout-status($uri)
+    where fn:string-length(fn:string($checkout-status)) gt 0
+    return fn:concat($uri, " checked out: ", $checkout-status)
+    :)
+
+    (: Uncomment to break checkout before deleting checked-out documents.
+    where dls:document-checkout-status($uri) 
+    return dls:break-checkout($uri, $deep)
+    :)
+    
+    (: Uncomment to delete the matching documents.
+    return dls:document-delete($uri, fn:false(), fn:false())
+    :)
+
+    return $uri
+)


### PR DESCRIPTION
Add MarkLogic xquery and docs for clearing a previous run of the backlog parser.

FCLC-2290