### PR TITLE
feat(parser): Add First Tier Tribunal Immigration and Asylum

### DIFF
--- a/NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj
+++ b/NationalArchives.FindCaseLaw.Utils/NationalArchives.FindCaseLaw.Utils.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <CourtsJson>https://raw.githubusercontent.com/nationalarchives/ds-caselaw-utils/refs/tags/v4.8.0/src/autogen/courts.json</CourtsJson>
+      <CourtsJson>https://raw.githubusercontent.com/nationalarchives/ds-caselaw-utils/refs/tags/v4.9.0/src/autogen/courts.json</CourtsJson>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/model/Courts.cs
+++ b/src/model/Courts.cs
@@ -154,6 +154,7 @@ public static partial class Courts
     public static readonly Court EmploymentAppealTribunal = GetByCode("EAT");
 
     public static readonly Court FirstTierTribunal_Tax = GetByCode("UKFTT-TC");
+    public static readonly Court FirstTierTribunal_ImmigrationAndAsylum = GetByCode("UKFTT-IAC");
 
     public static readonly Court FirstTierTribunal_GRC = GetByCode("UKFTT-GRC");
 

--- a/src/parsers/ukut/Court.cs
+++ b/src/parsers/ukut/Court.cs
@@ -22,7 +22,7 @@ internal class CourtType : AbstractCourtType
 
         new GRCCombo()
     ];
-    
+
     protected override IEnumerable<Combo2> Combo2s { get; } =
     [
         new()
@@ -44,6 +44,13 @@ internal class CourtType : AbstractCourtType
             Re1 = new Regex("^(IN THE )?UPPER TRIBUNAL$", RegexOptions.IgnoreCase),
             Re2 = new Regex(@"^\(?ADMINISTRATIVE APPEALS CHAMBER\)?$", RegexOptions.IgnoreCase),
             Court = Courts.UpperTribunal_AdministrativeAppealsChamber
+        },
+
+        new()
+        {
+            Re1 = Courts.FirstTierTribunalIdentifierRegex(),
+            Re2 = new Regex(@"^\(?Immigration and Asylum Chamber\)?$", RegexOptions.IgnoreCase),
+            Court = Courts.FirstTierTribunal_ImmigrationAndAsylum
         },
 
         new()


### PR DESCRIPTION
Adds UKFTT Immigration and Asylum Chamber to the UKUT parser.

## Changes

- Update courts.json to latest release (https://github.com/nationalarchives/ds-caselaw-utils/pull/900)
- Add ability for UKUT parser to identify that a document belongs to the UKFTT-IAC tribunal