### PR TITLE
FCLC-431: Use Try pattern and extract some role mapping logic

### DIFF
--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -59,9 +59,9 @@ internal class PartyEnricher : Enricher
             }
 
             var rest = before[i..];
-            var found = EnrichMultiLinePartyBockOrNull(rest);
-            found ??= EnrichMultiLinePartyBockOrNull2(rest);
-            found ??= EnrichMultiLinePartyBockOrNull3(rest);
+            var found = EnrichMultiLinePartyBlockOrNull(rest);
+            found ??= EnrichMultiLinePartyBlockWithInlineRolesOrNull(rest);
+            found ??= EnrichMultiLinePartyBlockWithTwoGroupsBeforeVOrNull(rest);
             if (found is not null)
             {
                 after.AddRange(found);
@@ -316,7 +316,7 @@ internal class PartyEnricher : Enricher
 
     /* multi-line */
 
-    private static List<IBlock> EnrichMultiLinePartyBockOrNull(IBlock[] rest, bool successive = false)
+    private static List<IBlock> EnrichMultiLinePartyBlockOrNull(IBlock[] rest, bool successive = false)
     {
         if (rest.Length == 0)
         {
@@ -363,7 +363,7 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        var firstGroupOfParites = Magic1(rest[i..]);
+        var firstGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
         if (firstGroupOfParites is null)
         {
             return null;
@@ -390,7 +390,7 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        var secondGroupOfParites = Magic2(rest[i..]);
+        var secondGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
         if (secondGroupOfParites is null)
         {
             return null;
@@ -417,14 +417,14 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        var thirdGroupOfParites = Magic2(rest[i..]);
+        var thirdGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
         if (thirdGroupOfParites is not null)
         {
             enriched.AddRange(thirdGroupOfParites);
             i += thirdGroupOfParites.Count;
         }
 
-        var fourthGroupOfParites = Magic2(rest[i..]);
+        var fourthGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
         if (fourthGroupOfParites is not null)
         {
             enriched.AddRange(fourthGroupOfParites);
@@ -443,7 +443,7 @@ internal class PartyEnricher : Enricher
             return enriched;
         }
 
-        var another = EnrichMultiLinePartyBockOrNull(rest[i..], true);
+        var another = EnrichMultiLinePartyBlockOrNull(rest[i..], true);
         if (another is not null)
         {
             enriched.AddRange(another);
@@ -453,7 +453,7 @@ internal class PartyEnricher : Enricher
         return enriched;
     }
 
-    private static List<IBlock> EnrichMultiLinePartyBockOrNull2(IBlock[] rest)
+    private static List<IBlock> EnrichMultiLinePartyBlockWithInlineRolesOrNull(IBlock[] rest)
     {
         // EWHC/Admin/2018/3311
         if (rest.Length == 0)
@@ -543,7 +543,7 @@ internal class PartyEnricher : Enricher
     }
 
     /* this one has two types of parties before the v */
-    private static List<IBlock> EnrichMultiLinePartyBockOrNull3(IBlock[] rest)
+    private static List<IBlock> EnrichMultiLinePartyBlockWithTwoGroupsBeforeVOrNull(IBlock[] rest)
     {
         // EWHC/Admin/2015/897
         if (rest.Length == 0)
@@ -574,7 +574,7 @@ internal class PartyEnricher : Enricher
 
         enriched.Add(line);
         i += 1;
-        var firstGroupOfParites = Magic1(rest[i..]);
+        var firstGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
         if (firstGroupOfParites is null)
         {
             return null;
@@ -602,7 +602,7 @@ internal class PartyEnricher : Enricher
         }
 
         _ = rest[i];
-        var secondGroupOfParites = Magic1(rest[i..]);
+        var secondGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
         if (secondGroupOfParites is null)
         {
             return null;
@@ -630,7 +630,7 @@ internal class PartyEnricher : Enricher
         }
 
         _ = rest[i];
-        var thirdGroupOfParites = Magic2(rest[i..]);
+        var thirdGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
         if (thirdGroupOfParites is null)
         {
             return null;
@@ -653,17 +653,17 @@ internal class PartyEnricher : Enricher
         return null;
     }
 
-    private static List<IBlock> Magic1(IBlock[] rest)
+    private static List<IBlock> EnrichFirstPartyGroupOrNull(IBlock[] rest)
     {
-        return Magic(rest, IsFirstPartyType, GetFirstPartyRole);
+        return EnrichPartyNamesWithRoleLabelOrNull(rest, IsFirstPartyType, GetFirstPartyRole);
     }
 
-    private static List<IBlock> Magic2(IBlock[] rest)
+    private static List<IBlock> EnrichSecondPartyGroupOrNull(IBlock[] rest)
     {
-        return Magic(rest, IsSecondPartyType, GetSecondPartyRole);
+        return EnrichPartyNamesWithRoleLabelOrNull(rest, IsSecondPartyType, GetSecondPartyRole);
     }
 
-    private static List<IBlock> Magic(IBlock[] rest, Func<IBlock, bool> test, Func<IBlock, PartyRole> construct)
+    private static List<IBlock> EnrichPartyNamesWithRoleLabelOrNull(IBlock[] rest, Func<IBlock, bool> test, Func<IBlock, PartyRole> construct)
     {
         var i = 0;
         if (i == rest.Length)
@@ -1607,7 +1607,7 @@ internal class PartyEnricher : Enricher
         var rowCells = row.Cells.ToArray();
         if (rowCells.Length == 2)
         {
-            return EnrichRow2(row);
+            return EnrichTwoCellRow(row);
         }
 
         if (rowCells.Length != 3)
@@ -1663,7 +1663,7 @@ internal class PartyEnricher : Enricher
         return row;
     }
 
-    private WRow EnrichRow2(WRow row)
+    private WRow EnrichTwoCellRow(WRow row)
     {
         var rowCells = row.Cells.ToArray();
         var first = (WCell)rowCells[0];
@@ -2243,7 +2243,7 @@ internal class PartyEnricher : Enricher
             return PartyRole.Appellant;
         }
 
-        return GetPartyRole2(one, two);
+        return GetPartyRoleForCombinedLabels(one, two);
     }
 
     private static PartyRole? GetNLinePartyRole(WCell cell)
@@ -2794,7 +2794,7 @@ internal class PartyEnricher : Enricher
             if (!string.IsNullOrWhiteSpace(one) &&
                 !string.IsNullOrWhiteSpace(two)) // not if at beginning or end of line
             {
-                return GetPartyRole2(one, two);
+                return GetPartyRoleForCombinedLabels(one, two);
             }
         }
 
@@ -2803,14 +2803,14 @@ internal class PartyEnricher : Enricher
             var (one, two) = s.Split(" and ", 2) switch { var x => (x[0], x[1]) };
             if (!string.IsNullOrWhiteSpace(one) && !string.IsNullOrWhiteSpace(two))
             {
-                return GetPartyRole2(one, two);
+                return GetPartyRoleForCombinedLabels(one, two);
             }
         }
 
-        return GetPartyRole1(s);
+        return GetPartyRoleForSingleLabel(s);
     }
 
-    private static PartyRole? GetPartyRole1(string s)
+    private static PartyRole? GetPartyRoleForSingleLabel(string s)
     {
         s = Regex.Replace(s, @"\s+", " ").Trim(' ', '/', '(', ')');
         if (s.StartsWith("Part 20 ", StringComparison.InvariantCultureIgnoreCase))
@@ -2902,7 +2902,7 @@ internal class PartyEnricher : Enricher
         return null;
     }
 
-    private static PartyRole? GetPartyRole2(string s1, string s2)
+    private static PartyRole? GetPartyRoleForCombinedLabels(string s1, string s2)
     {
         var role1 = GetPartyRole(s1);
         var role2 = GetPartyRole(s2);

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1903,6 +1903,91 @@ internal class PartyEnricher : Enricher
 
     }
 
+    private static readonly Dictionary<string, PartyRole> OneLinePartyRoleLabels = new()
+    {
+        ["Appellant"] = PartyRole.Appellant,
+        ["APPELLANT"] = PartyRole.Appellant,
+        ["Appellants"] = PartyRole.Appellant,
+        ["Defendant/Appellant"] = PartyRole.Appellant,
+        ["Defendant/ Appellant"] = PartyRole.Appellant,
+        ["Defendants/Appellants"] = PartyRole.Appellant,
+        ["Appellants / Defendants"] = PartyRole.Appellant,
+        ["Defendants/Appellants/"] = PartyRole.Appellant,
+        ["Appellant/ Defendant"] = PartyRole.Appellant,
+        ["Appellants/Claimants"] = PartyRole.Appellant,
+        ["Appellants/ Claimants"] = PartyRole.Appellant,
+        ["Claimant/Appellant"] = PartyRole.Appellant,
+        ["Claimant/ Appellant"] = PartyRole.Appellant,
+        ["Claimant / Appellant"] = PartyRole.Appellant,
+        ["Appellant / Claimant"] = PartyRole.Appellant,
+        ["Appellant / Third Defendant"] = PartyRole.Appellant,
+        ["1st Appellant"] = PartyRole.Appellant,
+        ["Respondent/Appellant"] = PartyRole.Appellant,
+        ["Defendants/ Appellants"] = PartyRole.Appellant,
+        ["Appellant/ Respondent"] = PartyRole.Appellant, // [2021] EWCA Civ 1792
+        ["Claimants/ Appellants"] = PartyRole.Appellant,
+        ["Claimants/Appellants"] = PartyRole.Appellant, // [2021] EWCA Civ 1799
+        ["Appellant/Applicant"] = PartyRole.Appellant, // [2021] EWCA Crim 1877
+
+        ["Applicant"] = PartyRole.Applicant,
+        ["Applicants"] = PartyRole.Applicant,
+        ["Respondent/Applicant"] = PartyRole.Applicant,
+        ["Applicants/Claimants"] = PartyRole.Applicant,
+        ["Applicant/ Claimant"] = PartyRole.Applicant,
+        ["Claimant/Applicant"] = PartyRole.Applicant,
+        ["Defendant/ Applicant"] = PartyRole.Applicant,
+        ["1st Applicant"] = PartyRole.Applicant,
+        ["2nd Applicant"] = PartyRole.Applicant,
+        ["Claimant"] = PartyRole.Claimant,
+        ["Claimants"] = PartyRole.Claimant,
+        ["Claimant/Part 20 Defendant"] = PartyRole.Claimant,
+        ["Claimant/part 20 Defendant"] = PartyRole.Claimant,
+        ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
+        ["Additional Claimant"] = PartyRole.Claimant,
+        ["Defendant"] = PartyRole.Defendant,
+        ["Defendants"] = PartyRole.Defendant,
+        ["Defendant/Part 20 Claimant"] = PartyRole.Defendant,
+        ["First Defendant"] = PartyRole.Defendant,
+        ["Second Defendant"] = PartyRole.Defendant,
+        ["Third Defendant"] = PartyRole.Defendant,
+        ["Defendant / Counterclaimant"] = PartyRole.Defendant,
+        ["Interested Party"] = PartyRole.InterestedParty,
+        ["Interested parties"] = PartyRole.InterestedParty,
+        ["Petitioner"] = PartyRole.Petitioner,
+        ["Respondent"] = PartyRole.Respondent,
+        ["RESPONDENT"] = PartyRole.Respondent,
+        ["Respondents"] = PartyRole.Respondent,
+        ["Claimant/Respondent"] = PartyRole.Respondent,
+        ["Claimant/ Respondent"] = PartyRole.Respondent,
+        ["Claimant / Respondent"] = PartyRole.Respondent,
+        ["Clamaints/ Respondents"] = PartyRole.Respondent,
+        ["Respondent/Claimant"] = PartyRole.Respondent,
+        ["Respondent/ Claimant"] = PartyRole.Respondent,
+        ["Defendant/Respondent"] = PartyRole.Respondent,
+        ["Defendant/ Respondent"] = PartyRole.Respondent,
+        ["Defendant / Respondent"] = PartyRole.Respondent,
+        ["Defendants/Respondents"] = PartyRole.Respondent,
+        ["Defendants/ Respondents"] = PartyRole.Respondent,
+        ["Petitioner/Respondent"] = PartyRole.Respondent,
+        ["First Respondent"] = PartyRole.Respondent,
+        ["Second Respondent"] = PartyRole.Respondent,
+        ["Third Respondent"] = PartyRole.Respondent,
+        ["Fourth Respondent"] = PartyRole.Respondent,
+        ["1st Respondent"] = PartyRole.Respondent,
+        ["2nd Respondent"] = PartyRole.Respondent,
+        ["3rd Respondent"] = PartyRole.Respondent, // EWCA/Civ/2012/378
+        ["Respondents/Defendants"] = PartyRole.Respondent,
+        ["Respond-ents/ Defendants"] = PartyRole.Respondent,
+        ["Respondents/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2015/377, EWHC/QB/2006/582
+        ["Respondent/Defendants"] = PartyRole.Respondent,
+        ["Respondent / Defendant"] = PartyRole.Respondent,
+        ["Respondents Second and Third/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2004/1249
+        ["Respondent/Petitioner"] = PartyRole.Respondent, // [2021] EWCA Civ 1792
+        ["Respondents/Claimants"] = PartyRole.Respondent,
+        ["Respondents / Claimants"] = PartyRole.Respondent,
+        ["Respondent/ First Defendant"] = PartyRole.Respondent
+    };
+
     private static bool TryGetOneLinePartyRole(IBlock block, out PartyRole role)
     {
         if (block is not WLine line)
@@ -1912,139 +1997,8 @@ internal class PartyEnricher : Enricher
         }
 
         var normalized = line.NormalizedContent;
-        ISet<string> types = new HashSet<string>
+        if (OneLinePartyRoleLabels.TryGetValue(normalized, out role))
         {
-            "Appellant",
-            "APPELLANT",
-            "Appellants",
-            "Defendant/Appellant",
-            "Defendant/ Appellant",
-            "Defendants/Appellants",
-            "Appellants / Defendants",
-            "Defendants/Appellants/",
-            "Appellant/ Defendant",
-            "Appellants/Claimants",
-            "Appellants/ Claimants",
-            "Claimant/Appellant",
-            "Claimant/ Appellant",
-            "Claimant / Appellant",
-            "Appellant / Claimant",
-            "Appellant / Third Defendant",
-            "1st Appellant",
-            "Respondent/Appellant",
-            "Defendants/ Appellants",
-            "Appellant/ Respondent", // [2021] EWCA Civ 1792
-            "Claimants/ Appellants",
-            "Claimants/Appellants", // [2021] EWCA Civ 1799
-            "Appellant/Applicant" // [2021] EWCA Crim 1877
-        };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        types = new HashSet<string>
-        {
-            "Claimant",
-            "Claimants",
-            "Claimant/Part 20 Defendant",
-            "Claimant/part 20 Defendant",
-            "Claimant / Defendant to Counterclaim",
-            "Additional Claimant"
-        };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Claimant;
-            return true;
-        }
-
-        types = new HashSet<string>
-        {
-            "Applicant",
-            "Applicants",
-            "Respondent/Applicant",
-            "Applicants/Claimants",
-            "Applicant/ Claimant",
-            "Claimant/Applicant",
-            "Defendant/ Applicant",
-            "1st Applicant",
-            "2nd Applicant"
-        };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Applicant;
-            return true;
-        }
-
-        types = new HashSet<string>
-        {
-            "Defendant",
-            "Defendants",
-            "Defendant/Part 20 Claimant",
-            "First Defendant",
-            "Second Defendant",
-            "Third Defendant",
-            "Defendant / Counterclaimant"
-        };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        types = new HashSet<string>
-        {
-            "Respondent",
-            "RESPONDENT",
-            "Respondents",
-            "Claimant/Respondent",
-            "Claimant/ Respondent",
-            "Claimant / Respondent",
-            "Clamaints/ Respondents",
-            "Respondent/Claimant",
-            "Respondent/ Claimant",
-            "Defendant/Respondent",
-            "Defendant/ Respondent",
-            "Defendant / Respondent",
-            "Defendants/Respondents",
-            "Defendants/ Respondents",
-            "Petitioner/Respondent",
-            "First Respondent",
-            "Second Respondent",
-            "Third Respondent",
-            "Fourth Respondent",
-            "1st Respondent",
-            "2nd Respondent",
-            "3rd Respondent", // EWCA/Civ/2012/378
-            "Respondents/Defendants",
-            "Respond-ents/ Defendants",
-            "Respondents/ Defendants", // EWCA/Civ/2015/377, EWHC/QB/2006/582
-            "Respondent/Defendants",
-            "Respondent / Defendant",
-            "Respondents Second and Third/ Defendants", // EWCA/Civ/2004/1249
-            "Respondent/Petitioner", // [2021] EWCA Civ 1792
-            "Respondents/Claimants",
-            "Respondents / Claimants",
-            "Respondent/ First Defendant"
-        };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        types = new HashSet<string> { "Petitioner" };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.Petitioner;
-            return true;
-        }
-
-        types = new HashSet<string> { "Interested Party", "Interested parties" };
-        if (types.Contains(normalized))
-        {
-            role = PartyRole.InterestedParty;
             return true;
         }
 
@@ -2064,35 +2018,14 @@ internal class PartyEnricher : Enricher
         return false;
     }
 
-    private static bool TryGetTwoLinePartyRole(string one, string two, out PartyRole role)
+    /// <summary>
+    ///  one/two combinations that aren't exact matches, so can't live in TwoLinePartyRoles
+    /// </summary>
+    private static bool TryGetTwoLinePartyRoleFromPattern(string one, string two, out PartyRole role)
     {
         if (one == "Defendant/" && two.EndsWith("Claimant")) // EWHC/Ch/2008/2079
         {
             role = PartyRole.Defendant;
-            return true;
-        }
-
-        if (one == "Defendant/" && two == "Applicant") // EWHC/Ch/2017/916
-        {
-            role = PartyRole.Applicant;
-            return true;
-        }
-
-        if (one == "Defendant/" && two == "Appellant") // EWCA/Civ/2011/1383
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Claimant/" && two == "Respondent") // EWCA/Civ/2008/183
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Claimants/" && two == "Respondents") // EWHC/Ch/2017/916
-        {
-            role = PartyRole.Respondent;
             return true;
         }
 
@@ -2102,176 +2035,72 @@ internal class PartyEnricher : Enricher
             return true;
         }
 
-        if (one == "Claimant/" && two == "Appellant") // EWCA/Civ/2011/1277
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Respondent/" && two == "Claimant") // EWCA/Civ/2017/97
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Appellants/" && two == "Defendants")
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Appellants/" && two == "Defendants & Counterclaimants") // EWCA/Civ/2017/97
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Appellants/" && two == "Claimants") // EWCA/Civ/2015/377
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Appellants" && two == "Claimants") // EWCA/Civ/2018/601
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Respondent" && two == "Intervener") // EWCA/Civ/2016/176
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
         if (one == "Respondents" && two.StartsWith("Respondent")) // EWHC/Fam/2013/1956
         {
             role = PartyRole.Respondent;
             return true;
         }
 
-        if (one == "Appellant/" && two == "Claimant") // EWHC/Ch/2017/541
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Appellant" && two == "/Claimant") // [2021] EWHC 3453 (QB)
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Appellant/" && two == "Defendant") // EWHC/QB/2013/196
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Respondent/" && two == "Defendant") // EWHC/Ch/2017/541
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Respondent" && two == "Defendant") // EWCA/Civ/2018/601
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "1st Respondent" && two == "/Defendant") // [2021] EWHC 3453 (QB)
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Claimants/" && two == "Appellants") // EWHC/Admin/2016/321
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Defendant/" && two == "Respondent") // EWHC/Admin/2015/1639
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Defendants/" && two == "Respondents") // EWHC/Admin/2016/321
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Defendants/" && two == "Appellants") // EWCA/Civ/2004/277
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (one == "Defendants/" && two == "Applicants") // [2021] EWHC 2684 (Comm)
-        {
-            role = PartyRole.Applicant;
-            return true;
-        }
-
-        if (one == "1st Respondent" && two == "2nd Respondent") // EWHC/Fam/2017/364, EWHC/Fam/2013/1864?
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "1st Respondent" && two == "2ndRespondent") // EWCA/Civ/2011/1253
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "First Defendant" && two == "Second Defendant") // EWHC/Admin/2010/2
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        if (one == "Defendant/Part 20 Claimant" && two == "Part 20 Claimant") // EWHC/Ch/2003/812
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        if (one == "1st Defendant/Part 20 Claimant" && two == "2nd Defendant/Part 20 Defendant") // EWHC/QB/2004/1260
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        if (one == "Defendant/" && two == "Cross appellant") // EWHC/QB/2013/652
-        {
-            role = PartyRole.Defendant;
-            return true; // ??? other role is Appellant
-        }
-
-        if (one == "Applicant/" && two == "Respondent") // [2021] EWCA Civ 1725
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Appellant/" && two == "Respondent") // [2020] EWHC 3409 (QB)
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (one == "Respondent/" && two == "Appellant") // [2021] EWCA Civ 1961
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        return TryGetPartyRoleForCombinedLabels(one, two, out role);
+        role = default;
+        return false;
     }
+
+    private static readonly Dictionary<(string one, string two), PartyRole> TwoLinePartyRoles = new()
+    {
+        [("Defendant/", "Appellant")] = PartyRole.Appellant, // EWCA/Civ/2011/1383
+        [("Claimant/", "Appellant")] = PartyRole.Appellant, // EWCA/Civ/2011/1277
+        [("Appellants/", "Defendants")] = PartyRole.Appellant,
+        [("Appellants/", "Defendants & Counterclaimants")] = PartyRole.Appellant, // EWCA/Civ/2017/97
+        [("Appellants/", "Claimants")] = PartyRole.Appellant, // EWCA/Civ/2015/377
+        [("Appellants", "Claimants")] = PartyRole.Appellant, // EWCA/Civ/2018/601
+        [("Appellant/", "Claimant")] = PartyRole.Appellant, // EWHC/Ch/2017/541
+        [("Appellant", "/Claimant")] = PartyRole.Appellant, // [2021] EWHC 3453 (QB)
+        [("Appellant/", "Defendant")] = PartyRole.Appellant, // EWHC/QB/2013/196
+        [("Claimants/", "Appellants")] = PartyRole.Appellant, // EWHC/Admin/2016/321
+        [("Defendants/", "Appellants")] = PartyRole.Appellant, // EWCA/Civ/2004/277
+        [("Respondent/", "Appellant")] = PartyRole.Appellant, // [2021] EWCA Civ 1961
+
+        [("Defendant/", "Applicant")] = PartyRole.Applicant, // EWHC/Ch/2017/916
+        [("Defendants/", "Applicants")] = PartyRole.Applicant, // [2021] EWHC 2684 (Comm)
+
+        [("First Defendant", "Second Defendant")] = PartyRole.Defendant, // EWHC/Admin/2010/2
+        [("Defendant/Part 20 Claimant", "Part 20 Claimant")] = PartyRole.Defendant, // EWHC/Ch/2003/812
+        [("1st Defendant/Part 20 Claimant", "2nd Defendant/Part 20 Defendant")] =
+            PartyRole.Defendant, // EWHC/QB/2004/1260
+        [("Defendant/", "Cross appellant")] = PartyRole.Defendant, // EWHC/QB/2013/652 ??? other role is Appellant
+
+        [("Claimant/", "Respondent")] = PartyRole.Respondent, // EWCA/Civ/2008/183
+        [("Claimants/", "Respondents")] = PartyRole.Respondent, // EWHC/Ch/2017/916
+        [("Respondent/", "Claimant")] = PartyRole.Respondent, // EWCA/Civ/2017/97
+        [("Respondent", "Intervener")] = PartyRole.Respondent, // EWCA/Civ/2016/176
+        [("Respondent/", "Defendant")] = PartyRole.Respondent, // EWHC/Ch/2017/541
+        [("Respondent", "Defendant")] = PartyRole.Respondent, // EWCA/Civ/2018/601
+        [("1st Respondent", "/Defendant")] = PartyRole.Respondent, // [2021] EWHC 3453 (QB)
+        [("Defendant/", "Respondent")] = PartyRole.Respondent, // EWHC/Admin/2015/1639
+        [("Defendants/", "Respondents")] = PartyRole.Respondent, // EWHC/Admin/2016/321
+        [("1st Respondent", "2nd Respondent")] = PartyRole.Respondent, // EWHC/Fam/2017/364, EWHC/Fam/2013/1864?
+        [("1st Respondent", "2ndRespondent")] = PartyRole.Respondent, // EWCA/Civ/2011/1253
+        [("Applicant/", "Respondent")] = PartyRole.Respondent, // [2021] EWCA Civ 1725
+        [("Appellant/", "Respondent")] = PartyRole.Respondent // [2020] EWHC 3409 (QB)
+    };
+
+    private static bool TryGetTwoLinePartyRole(string one, string two, out PartyRole role)
+    {
+        return TryGetTwoLinePartyRoleFromPattern(one, two, out role)
+            || TwoLinePartyRoles.TryGetValue((one, two), out role)
+            || TryGetPartyRoleForCombinedLabels(one, two, out role);
+    }
+
+    private static readonly (Regex Pattern, PartyRole Role)[] NLinePartyRolePatterns =
+    [
+        (new Regex(@"^\d(st|nd|rd|th)? Defendant$", RegexOptions.IgnoreCase), PartyRole.Defendant),
+        (new Regex(@"^(First|Second|Third|Fourth) Defendant$", RegexOptions.IgnoreCase),
+            PartyRole.Defendant), // EWHC/Fam/2003/365
+        (new Regex(@"^\d(st|nd|rd|th)? Appellant$", RegexOptions.IgnoreCase), PartyRole.Appellant),
+        (new Regex(@"^(\d(st|nd|rd|th)? ?)?Respondent$", RegexOptions.IgnoreCase),
+            PartyRole.Respondent), // EWFC/HCJ/2014/34, no space in EWHC/Fam/2013/1864
+        (new Regex(@"^(First|Second|Third|Fourth) Respondent$", RegexOptions.IgnoreCase), PartyRole.Respondent)
+    ];
 
     private static bool TryGetNLinePartyRole(WCell cell, out PartyRole role)
     {
@@ -2305,61 +2134,13 @@ internal class PartyEnricher : Enricher
             }
         }
 
-        Func<WLine, bool> defendant = line =>
+        foreach (var (pattern, patternRole) in NLinePartyRolePatterns)
         {
-            var normalized = line.NormalizedContent;
-            return Regex.IsMatch(normalized, @"^\d(st|nd|rd|th)? Defendant$");
-        };
-        if (blocks.Cast<WLine>().All(defendant))
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        Func<WLine, bool> defendant2 = line =>
-        {
-            // EWHC/Fam/2003/365
-            var normalized = line.NormalizedContent;
-            return Regex.IsMatch(normalized, @"^(First|Second|Third|Fourth) Defendant$", RegexOptions.IgnoreCase);
-        };
-        if (blocks.Cast<WLine>().All(defendant2))
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        Func<WLine, bool> appellant = line =>
-        {
-            var normalized = line.NormalizedContent;
-            return Regex.IsMatch(normalized, @"^\d(st|nd|rd|th)? Appellant$", RegexOptions.IgnoreCase);
-        };
-        if (blocks.Cast<WLine>().All(appellant))
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        Func<WLine, bool> respondent = line =>
-        {
-            var normalized = line.NormalizedContent;
-            return Regex.IsMatch(normalized, @"^(\d(st|nd|rd|th)? ?)?Respondent$",
-                RegexOptions.IgnoreCase); // EWFC/HCJ/2014/34, no space in EWHC/Fam/2013/1864
-        };
-        if (blocks.Cast<WLine>().All(respondent))
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        Func<WLine, bool> respondent2 = line =>
-        {
-            var normalized = line.NormalizedContent;
-            return Regex.IsMatch(normalized, @"^(First|Second|Third|Fourth) Respondent$", RegexOptions.IgnoreCase);
-        };
-        if (blocks.Cast<WLine>().All(respondent2))
-        {
-            role = PartyRole.Respondent;
-            return true;
+            if (blocks.Cast<WLine>().All(line => pattern.IsMatch(line.NormalizedContent)))
+            {
+                role = patternRole;
+                return true;
+            }
         }
 
         return false;
@@ -2845,6 +2626,46 @@ internal class PartyEnricher : Enricher
         return TryGetPartyRoleForSingleLabel(s, out role);
     }
 
+    private static readonly HashSet<string> PrefixesToStrip =
+    [
+        "1st ",
+        "2nd ",
+        "3rd ",
+        "4th ",
+        "5th ",
+        "6th ",
+        "First ",
+        "Second ",
+        "Third ",
+        "Fourth ",
+        "Fifth ",
+        "Sixth ",
+        "Inquiry " // [2022] EWHC 189 (Pat)
+    ];
+
+    private static readonly Dictionary<string, PartyRole> SingleLabelPartyRoles = new()
+    {
+        ["appellant"] = PartyRole.Appellant,
+        ["appellants"] = PartyRole.Appellant,
+        ["applicant"] = PartyRole.Applicant,
+        ["applicants"] = PartyRole.Applicant,
+        ["claimant"] = PartyRole.Claimant,
+        ["claimants"] = PartyRole.Claimant,
+        ["defendant"] = PartyRole.Defendant,
+        ["defendants"] = PartyRole.Defendant,
+        ["petitioner"] = PartyRole.Petitioner,
+        ["petitioners"] = PartyRole.Petitioner,
+        ["respondent"] = PartyRole.Respondent,
+        ["respondents"] = PartyRole.Respondent,
+        ["interested party"] = PartyRole.InterestedParty,
+        ["interested parties"] = PartyRole.InterestedParty,
+        ["intervener"] = PartyRole.Intervener,
+        ["interveners"] = PartyRole.Intervener,
+        ["requested person"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+        ["requested persons"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+        ["requesting state"] = PartyRole.RequestingState
+    };
+
     private static bool TryGetPartyRoleForSingleLabel(string s, out PartyRole role)
     {
         s = Regex.Replace(s, @"\s+", " ").Trim(' ', '/', '(', ')');
@@ -2859,133 +2680,45 @@ internal class PartyEnricher : Enricher
             return true;
         }
 
-        ISet<string> starts = new HashSet<string>
+        if (PrefixesToStrip.Any(prefix => s.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)))
         {
-            "1st ",
-            "2nd ",
-            "3rd ",
-            "4th ",
-            "5th ",
-            "6th ",
-            "First ",
-            "Second ",
-            "Third ",
-            "Fourth ",
-            "Fifth ",
-            "Sixth ",
-            "Inquiry " // [2022] EWHC 189 (Pat)
-        };
-        foreach (var start in starts)
-        {
-            if (s.StartsWith(start, StringComparison.InvariantCultureIgnoreCase))
-            {
-                s = s.Substring(s.IndexOf(' ') + 1);
-                break;
-            }
+            s = s.Substring(s.IndexOf(' ') + 1);
         }
 
-        s = s.ToLower();
-        if (s == "appellant" || s == "appellants")
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (s == "applicant" || s == "applicants")
-        {
-            role = PartyRole.Applicant;
-            return true;
-        }
-
-        if (s == "claimant" || s == "claimants")
-        {
-            role = PartyRole.Claimant;
-            return true;
-        }
-
-        if (s == "defendant" || s == "defendants")
-        {
-            role = PartyRole.Defendant;
-            return true;
-        }
-
-        if (s == "petitioner" || s == "petitioners")
-        {
-            role = PartyRole.Petitioner;
-            return true;
-        }
-
-        if (s == "respondent" || s == "respondents")
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (s == "interested party" || s == "interested parties")
-        {
-            role = PartyRole.InterestedParty;
-            return true;
-        }
-
-        if (s == "intervener" || s == "interveners")
-        {
-            role = PartyRole.Intervener;
-            return true;
-        }
-
-        if (s == "requested person" || s == "requested persons") // [2022] EWHC 273 (Admin)
-        {
-            role = PartyRole.RequestedPerson;
-            return true;
-        }
-
-        if (s == "requesting state")
-        {
-            role = PartyRole.RequestingState;
-            return true;
-        }
-
-        role = default;
-        return false;
+        return SingleLabelPartyRoles.TryGetValue(s.ToLower(), out role);
     }
 
     private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)
     {
+        if (TryGetPartyRole(s1, out var role1)
+            && TryGetPartyRole(s2, out var role2))
+        {
+            if (role1 == PartyRole.Appellant || role2 == PartyRole.Appellant)
+            {
+                role = PartyRole.Appellant;
+                return true;
+            }
+
+            if (role1 == PartyRole.Respondent || role2 == PartyRole.Respondent)
+            {
+                role = PartyRole.Respondent;
+                return true;
+            }
+
+            if (role1 == PartyRole.Claimant && role2 == PartyRole.Defendant) // [2022] EWCA Civ 102
+            {
+                role = PartyRole.Claimant;
+                return true;
+            }
+
+            if (role1 == PartyRole.Defendant && role2 == PartyRole.Applicant) // [2019] EWHC 3963 (QB)
+            {
+                role = PartyRole.Applicant;
+                return true;
+            }
+        }
+
         role = default;
-        if (!TryGetPartyRole(s1, out var role1))
-        {
-            return false;
-        }
-
-        if (!TryGetPartyRole(s2, out var role2))
-        {
-            return false;
-        }
-
-        if (role1 == PartyRole.Appellant || role2 == PartyRole.Appellant)
-        {
-            role = PartyRole.Appellant;
-            return true;
-        }
-
-        if (role1 == PartyRole.Respondent || role2 == PartyRole.Respondent)
-        {
-            role = PartyRole.Respondent;
-            return true;
-        }
-
-        if (role1 == PartyRole.Claimant && role2 == PartyRole.Defendant) // [2022] EWCA Civ 102
-        {
-            role = PartyRole.Claimant;
-            return true;
-        }
-
-        if (role1 == PartyRole.Defendant && role2 == PartyRole.Applicant) // [2019] EWHC 3963 (QB)
-        {
-            role = PartyRole.Applicant;
-            return true;
-        }
-
         return false;
     }
 }

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -59,10 +59,9 @@ internal class PartyEnricher : Enricher
             }
 
             var rest = before[i..];
-            var found = EnrichMultiLinePartyBlockOrNull(rest);
-            found ??= EnrichMultiLinePartyBlockWithInlineRolesOrNull(rest);
-            found ??= EnrichMultiLinePartyBlockWithTwoGroupsBeforeVOrNull(rest);
-            if (found is not null)
+            if (TryEnrichMultiLinePartyBlock(rest, false, out var found) ||
+                TryEnrichMultiLinePartyBlockWithInlineRoles(rest, out found) ||
+                TryEnrichMultiLinePartyBlockWithTwoGroupsBeforeV(rest, out found))
             {
                 after.AddRange(found);
                 i += found.Count;
@@ -316,36 +315,37 @@ internal class PartyEnricher : Enricher
 
     /* multi-line */
 
-    private static List<IBlock> EnrichMultiLinePartyBlockOrNull(IBlock[] rest, bool successive = false)
+    private static bool TryEnrichMultiLinePartyBlock(IBlock[] rest, bool successive, out List<IBlock> enriched)
     {
+        enriched = null;
         if (rest.Length == 0)
         {
-            return null;
+            return false;
         }
 
         var i = 0;
         var line = rest[i];
         if (!IsBeforePartyMarker(line) && !IsBeforePartyMarker2(line) && !(successive && IsBeforePartyMarker3(line)))
         {
-            return null;
+            return false;
         }
 
-        List<IBlock> enriched = [line];
+        List<IBlock> result = [line];
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (line is WLine inPrivate && inPrivate.NormalizedContent == "IN PRIVATE")
         {
             // EWHC/Admin/2012/2822
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             line = rest[i];
@@ -353,137 +353,134 @@ internal class PartyEnricher : Enricher
 
         if (IsBeforePartyMarker2(line))
         {
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             _ = rest[i];
         }
 
-        var firstGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
-        if (firstGroupOfParites is null)
+        if (!TryEnrichFirstPartyGroup(rest[i..], out var firstGroupOfParites))
         {
-            return null;
+            return false;
         }
 
-        enriched.AddRange(firstGroupOfParites);
+        result.AddRange(firstGroupOfParites);
         i += firstGroupOfParites.Count;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         /* no "v" or "and" in EWHC/Comm/2013/3920 */
         if (IsBetweenPartyMarker(line) || IsBetweenPartyMarker2(line))
         {
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             _ = rest[i];
         }
 
-        var secondGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
-        if (secondGroupOfParites is null)
+        if (!TryEnrichSecondPartyGroup(rest[i..], out var secondGroupOfParites))
         {
-            return null;
+            return false;
         }
 
-        enriched.AddRange(secondGroupOfParites);
+        result.AddRange(secondGroupOfParites);
         i += secondGroupOfParites.Count;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
 
         if (IsBetweenPartyMarker2(line))
         {
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             _ = rest[i];
         }
 
-        var thirdGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
-        if (thirdGroupOfParites is not null)
+        if (TryEnrichSecondPartyGroup(rest[i..], out var thirdGroupOfParites))
         {
-            enriched.AddRange(thirdGroupOfParites);
+            result.AddRange(thirdGroupOfParites);
             i += thirdGroupOfParites.Count;
         }
 
-        var fourthGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
-        if (fourthGroupOfParites is not null)
+        if (TryEnrichSecondPartyGroup(rest[i..], out var fourthGroupOfParites))
         {
-            enriched.AddRange(fourthGroupOfParites);
+            result.AddRange(fourthGroupOfParites);
             i += fourthGroupOfParites.Count;
         }
 
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (IsAfterPartyMarker(line))
         {
-            enriched.Add(line);
-            return enriched;
+            result.Add(line);
+            enriched = result;
+            return true;
         }
 
-        var another = EnrichMultiLinePartyBlockOrNull(rest[i..], true);
-        if (another is not null)
+        if (TryEnrichMultiLinePartyBlock(rest[i..], true, out var another))
         {
-            enriched.AddRange(another);
-            return enriched;
+            result.AddRange(another);
         }
 
-        return enriched;
+        enriched = result;
+        return true;
     }
 
-    private static List<IBlock> EnrichMultiLinePartyBlockWithInlineRolesOrNull(IBlock[] rest)
+    private static bool TryEnrichMultiLinePartyBlockWithInlineRoles(IBlock[] rest, out List<IBlock> enriched)
     {
         // EWHC/Admin/2018/3311
+        enriched = null;
         if (rest.Length == 0)
         {
-            return null;
+            return false;
         }
 
         var i = 0;
         var line = rest[i];
         if (!IsBeforePartyMarker(line) && !IsBeforePartyMarker2(line))
         {
-            return null;
+            return false;
         }
 
-        List<IBlock> enriched = [line];
+        List<IBlock> result = [line];
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (IsBeforePartyMarker2(line))
         {
             // perhaps do this only if first line isn't marker 2
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             line = rest[i];
@@ -491,190 +488,191 @@ internal class PartyEnricher : Enricher
 
         if (!IsPartyNameAndRole(line))
         {
-            return null;
+            return false;
         }
 
         var party1 = MakePartyAndRole(line);
-        enriched.Add(party1);
+        result.Add(party1);
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (IsBetweenPartyMarker(line) || IsBetweenPartyMarker2(line))
         {
-            enriched.Add(line);
+            result.Add(line);
             i += 1;
         }
         else
         {
-            return null;
+            return false;
         }
 
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (!IsPartyNameAndRole(line))
         {
-            return null;
+            return false;
         }
 
         var party2 = MakePartyAndRole(line);
-        enriched.Add(party2);
+        result.Add(party2);
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (!IsAfterPartyMarker(line))
         {
-            return null;
+            return false;
         }
 
-        enriched.Add(line);
-        return enriched;
+        result.Add(line);
+        enriched = result;
+        return true;
     }
 
     /* this one has two types of parties before the v */
-    private static List<IBlock> EnrichMultiLinePartyBlockWithTwoGroupsBeforeVOrNull(IBlock[] rest)
+    private static bool TryEnrichMultiLinePartyBlockWithTwoGroupsBeforeV(IBlock[] rest, out List<IBlock> enriched)
     {
         // EWHC/Admin/2015/897
+        enriched = null;
         if (rest.Length == 0)
         {
-            return null;
+            return false;
         }
 
         var i = 0;
         var line = rest[i];
         if (!IsBeforePartyMarker(line))
         {
-            return null;
+            return false;
         }
 
-        List<IBlock> enriched = [line];
+        List<IBlock> result = [line];
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         /* between */
         if (!IsBeforePartyMarker2(line))
         {
-            return null;
+            return false;
         }
 
-        enriched.Add(line);
+        result.Add(line);
         i += 1;
-        var firstGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
-        if (firstGroupOfParites is null)
+        if (!TryEnrichFirstPartyGroup(rest[i..], out var firstGroupOfParites))
         {
-            return null;
+            return false;
         }
 
-        enriched.AddRange(firstGroupOfParites);
+        result.AddRange(firstGroupOfParites);
         i += firstGroupOfParites.Count;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         /* and */
         if (!IsBetweenPartyMarker2(line))
         {
-            return null;
+            return false;
         }
 
-        enriched.Add(line);
+        result.Add(line);
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         _ = rest[i];
-        var secondGroupOfParites = EnrichFirstPartyGroupOrNull(rest[i..]);
-        if (secondGroupOfParites is null)
+        if (!TryEnrichFirstPartyGroup(rest[i..], out var secondGroupOfParites))
         {
-            return null;
+            return false;
         }
 
-        enriched.AddRange(secondGroupOfParites);
+        result.AddRange(secondGroupOfParites);
         i += secondGroupOfParites.Count;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         /* v */
         if (!IsBetweenPartyMarker(line))
         {
-            return null;
+            return false;
         }
 
-        enriched.Add(line);
+        result.Add(line);
         i += 1;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         _ = rest[i];
-        var thirdGroupOfParites = EnrichSecondPartyGroupOrNull(rest[i..]);
-        if (thirdGroupOfParites is null)
+        if (!TryEnrichSecondPartyGroup(rest[i..], out var thirdGroupOfParites))
         {
-            return null;
+            return false;
         }
 
-        enriched.AddRange(thirdGroupOfParites);
+        result.AddRange(thirdGroupOfParites);
         i += thirdGroupOfParites.Count;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         line = rest[i];
         if (IsAfterPartyMarker(line))
         {
-            enriched.Add(line);
-            return enriched;
+            result.Add(line);
+            enriched = result;
+            return true;
         }
 
-        return null;
+        return false;
     }
 
-    private static List<IBlock> EnrichFirstPartyGroupOrNull(IBlock[] rest)
+    private static bool TryEnrichFirstPartyGroup(IBlock[] rest, out List<IBlock> enriched)
     {
-        return EnrichPartyNamesWithRoleLabelOrNull(rest, IsFirstPartyType, GetFirstPartyRole);
+        return TryEnrichPartyNamesWithRoleLabel(rest, IsFirstPartyType, GetFirstPartyRole, out enriched);
     }
 
-    private static List<IBlock> EnrichSecondPartyGroupOrNull(IBlock[] rest)
+    private static bool TryEnrichSecondPartyGroup(IBlock[] rest, out List<IBlock> enriched)
     {
-        return EnrichPartyNamesWithRoleLabelOrNull(rest, IsSecondPartyType, GetSecondPartyRole);
+        return TryEnrichPartyNamesWithRoleLabel(rest, IsSecondPartyType, GetSecondPartyRole, out enriched);
     }
 
-    private static List<IBlock> EnrichPartyNamesWithRoleLabelOrNull(IBlock[] rest, Func<IBlock, bool> test, Func<IBlock, PartyRole> construct)
+    private static bool TryEnrichPartyNamesWithRoleLabel(IBlock[] rest, Func<IBlock, bool> test, Func<IBlock, PartyRole> construct, out List<IBlock> enriched)
     {
+        enriched = null;
         var i = 0;
         if (i == rest.Length)
         {
-            return null;
+            return false;
         }
 
         var line = rest[i];
         if (!IsPartyName(line))
         {
-            return null;
+            return false;
         }
 
         List<IBlock> stack = [line];
@@ -683,18 +681,19 @@ internal class PartyEnricher : Enricher
         {
             if (i == rest.Length)
             {
-                return null;
+                return false;
             }
 
             line = rest[i];
             if (test(line))
             {
                 var role1 = construct(line);
-                return
+                enriched =
                 [
                     .. stack.Select(block => MakeParty(block, role1)),
                     MakeRole(line, role1)
                 ];
+                return true;
             }
 
             if (IsPartyName(line))
@@ -704,7 +703,7 @@ internal class PartyEnricher : Enricher
             }
             else
             {
-                return null;
+                return false;
             }
         }
     }
@@ -1169,7 +1168,7 @@ internal class PartyEnricher : Enricher
             return true;
         }
 
-        return GetPartyRole(s) is not null;
+        return TryGetPartyRole(s, out _);
     }
 
     private static bool IsFirstPartyType(IBlock block)
@@ -1239,7 +1238,7 @@ internal class PartyEnricher : Enricher
             case "Petitioner":
                 return PartyRole.Petitioner;
             default:
-                return GetPartyRole(s).Value;
+                return TryGetPartyRole(s, out var role) ? role : throw new Exception();
         }
     }
 
@@ -1406,7 +1405,7 @@ internal class PartyEnricher : Enricher
             return true;
         }
 
-        return GetPartyRole(s) is not null;
+        return TryGetPartyRole(s, out _);
     }
 
     private static bool IsSecondPartyType(IBlock block)
@@ -1481,7 +1480,7 @@ internal class PartyEnricher : Enricher
             case "Additional Claimant":
                 return PartyRole.Claimant;
             default:
-                return GetPartyRole(s).Value;
+                return TryGetPartyRole(s, out var role) ? role : throw new Exception();
         }
     }
 
@@ -1549,9 +1548,9 @@ internal class PartyEnricher : Enricher
     private WTable EnrichTable(WTable table)
     {
         IEnumerable<WRow> rows = null;
-        if (table.TypedRows.Count == 3)
+        if (table.TypedRows.Count == 3 && TryEnrichThreeRowsWithNoRoles(table.TypedRows, out var threeRows))
         {
-            rows = EnrichThreeRowsWithNoRolesOrNull(table.TypedRows);
+            rows = threeRows;
         }
 
         rows ??= EnrichRows(table.TypedRows);
@@ -1623,11 +1622,10 @@ internal class PartyEnricher : Enricher
             return row;
         }
 
-        var role = GetPartyRole(third);
-        if (role is not null)
+        if (TryGetPartyRole(third, out var role))
         {
-            second = EnrichCell(second, role.Value);
-            third = EnrichCellWithPartyRole(third, (PartyRole)role);
+            second = EnrichCell(second, role);
+            third = EnrichCellWithPartyRole(third, role);
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
                 first,
@@ -1647,11 +1645,10 @@ internal class PartyEnricher : Enricher
             ]);
         }
 
-        var twoRoles = GetTwoDifferentRoles(third);
-        if (twoRoles is not null)
+        if (TryGetTwoDifferentRoles(third, out var twoRoles))
         {
-            second = EnrichPartyNamesWithTwoRoles(second, twoRoles.Value);
-            third = EnrichPartyTypesWithTwoRoles(third, twoRoles.Value);
+            second = EnrichPartyNamesWithTwoRoles(second, twoRoles);
+            third = EnrichPartyTypesWithTwoRoles(third, twoRoles);
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
                 first,
@@ -1673,66 +1670,66 @@ internal class PartyEnricher : Enricher
             return row;
         }
 
-        var role = GetPartyRole(second);
-        if (role is null)
+        if (!TryGetPartyRole(second, out var role))
         {
             return row;
         }
 
-        first = EnrichCell(first, role.Value);
-        second = EnrichCellWithPartyRole(second, role.Value);
+        first = EnrichCell(first, role);
+        second = EnrichCellWithPartyRole(second, role);
         return new WRow(row.Table, row.TablePropertyExceptions, row.Properties, [first, second]);
     }
 
-    private WRow[] EnrichThreeRowsWithNoRolesOrNull(List<WRow> rows)
+    private bool TryEnrichThreeRowsWithNoRoles(List<WRow> rows, out WRow[] enrichedRows)
     {
         // EWCA/Crim/2007/854, EWCA/Crim/2014/465
+        enrichedRows = null;
         var firstRowCells = rows[0].Cells.ToArray();
         if (firstRowCells.Length != 3)
         {
-            return null;
+            return false;
         }
 
         var secondRowCells = rows[1].Cells.ToArray();
         if (secondRowCells.Length != 3)
         {
-            return null;
+            return false;
         }
 
         var thirdRowCells = rows[2].Cells.ToArray();
         if (thirdRowCells.Length != 3)
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(firstRowCells[0]))
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(firstRowCells[^1]))
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(secondRowCells[0]))
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(secondRowCells[^1]))
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(thirdRowCells[0]))
         {
-            return null;
+            return false;
         }
 
         if (!IsEmptyCell(thirdRowCells[^1]))
         {
-            return null;
+            return false;
         }
 
         var middle1 = rows[0].TypedCells[1];
@@ -1741,25 +1738,25 @@ internal class PartyEnricher : Enricher
         if (!middle1.Contents.All(block => block is WLine line &&
                                            (IsEmptyLine(line) || (IsPartyName(line) && !IsFirstPartyType(line)))))
         {
-            return null;
+            return false;
         }
 
         if (!middle2.Contents.All(block => block is WLine line &&
                                            (IsEmptyLine(line) || IsBetweenPartyMarker(line) ||
                                             IsBetweenPartyMarker2(line))))
         {
-            return null;
+            return false;
         }
 
         if (middle2.Contents.Count(block => !IsEmptyLine(block)) != 1)
         {
-            return null;
+            return false;
         }
 
         if (!middle3.Contents.All(block => block is WLine line &&
                                            (IsEmptyLine(line) || (IsPartyName(line) && !IsSecondPartyType(line)))))
         {
-            return null;
+            return false;
         }
 
         var newMiddle1 = new WCell(middle1.Row, middle1.Props,
@@ -1768,7 +1765,7 @@ internal class PartyEnricher : Enricher
         var newMiddle3 = new WCell(middle3.Row, middle3.Props,
             middle3.Contents.Cast<WLine>()
                    .Select(line => IsEmptyLine(line) ? line : MakeParty(line, PartyRole.AfterTheV)));
-        return
+        enrichedRows =
         [
 
             new(rows[0].Table, rows[0].TablePropertyExceptions, rows[0].Properties,
@@ -1786,6 +1783,7 @@ internal class PartyEnricher : Enricher
                     rows[2].TypedCells[^1]
             ])
         ];
+        return true;
     }
 
     private WRow EnrichRow(WRow row, WRow next)
@@ -1836,10 +1834,9 @@ internal class PartyEnricher : Enricher
             return row;
         }
 
-        var role = GetPartyRole(roleCell);
-        if (role is not null)
+        if (TryGetPartyRole(roleCell, out var role))
         {
-            partyCell = EnrichCell(partyCell, role.Value);
+            partyCell = EnrichCell(partyCell, role);
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
                     before,
@@ -1851,55 +1848,35 @@ internal class PartyEnricher : Enricher
         return row;
     }
 
-    public static PartyRole? GetPartyRole(WCell cell)
+    public static bool TryGetPartyRole(WCell cell, out PartyRole role)
     {
-        var role = GetOneLinePartyRole(cell);
-        if (role is not null)
+        if (TryGetOneLinePartyRole(cell, out role))
         {
-            return role;
+            return true;
         }
 
-        role = GetTwoLinePartyRole(cell);
-        if (role is not null)
+        if (TryGetTwoLinePartyRole(cell, out role))
         {
-            return role;
+            return true;
         }
 
-        role = GetNLinePartyRole(cell);
-        if (role is not null)
-        {
-            return role;
-        }
-
-        return null;
+        return TryGetNLinePartyRole(cell, out role);
     }
 
-    private static (PartyRole first, PartyRole second)? GetTwoDifferentRoles(WCell cell)
+    private static bool TryGetTwoDifferentRoles(WCell cell, out (PartyRole first, PartyRole second) roles)
     {
         var lines = cell.Contents.Where(block => !IsEmptyLine(block)).ToArray();
-        if (lines.Length != 2)
+        if (lines.Length == 2
+            && TryGetOneLinePartyRole(lines[0], out var role1)
+            && TryGetOneLinePartyRole(lines[1], out var role2)
+            && role1 != role2)
         {
-            return null;
+            roles = (role1, role2);
+            return true;
         }
 
-        var role1 = GetOneLinePartyRole(lines[0]);
-        if (role1 is null)
-        {
-            return null;
-        }
-
-        var role2 = GetOneLinePartyRole(lines[1]);
-        if (role2 is null)
-        {
-            return null;
-        }
-
-        if (role1 == role2)
-        {
-            return null;
-        }
-
-        return (role1.Value, role2.Value);
+        roles = default;
+        return false;
     }
 
     private static WCell EnrichCellWithPartyRole(WCell cell, PartyRole role)
@@ -1913,17 +1890,25 @@ internal class PartyEnricher : Enricher
                                                        ])));
     }
 
-    private static PartyRole? GetOneLinePartyRole(WCell cell)
+    private static bool TryGetOneLinePartyRole(WCell cell, out PartyRole role)
     {
         var lines = cell.Contents.Where(block => !IsEmptyLine(block)).ToArray();
-        return lines.Length == 1 ? GetOneLinePartyRole(lines[0]) : null;
+        if (lines.Length == 1)
+        {
+            return TryGetOneLinePartyRole(lines[0], out role);
+        }
+
+        role = default;
+        return false;
+
     }
 
-    private static PartyRole? GetOneLinePartyRole(IBlock block)
+    private static bool TryGetOneLinePartyRole(IBlock block, out PartyRole role)
     {
         if (block is not WLine line)
         {
-            return null;
+            role = default;
+            return false;
         }
 
         var normalized = line.NormalizedContent;
@@ -1955,7 +1940,8 @@ internal class PartyEnricher : Enricher
         };
         if (types.Contains(normalized))
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         types = new HashSet<string>
@@ -1969,7 +1955,8 @@ internal class PartyEnricher : Enricher
         };
         if (types.Contains(normalized))
         {
-            return PartyRole.Claimant;
+            role = PartyRole.Claimant;
+            return true;
         }
 
         types = new HashSet<string>
@@ -1986,7 +1973,8 @@ internal class PartyEnricher : Enricher
         };
         if (types.Contains(normalized))
         {
-            return PartyRole.Applicant;
+            role = PartyRole.Applicant;
+            return true;
         }
 
         types = new HashSet<string>
@@ -2001,7 +1989,8 @@ internal class PartyEnricher : Enricher
         };
         if (types.Contains(normalized))
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         types = new HashSet<string>
@@ -2041,222 +2030,261 @@ internal class PartyEnricher : Enricher
         };
         if (types.Contains(normalized))
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         types = new HashSet<string> { "Petitioner" };
         if (types.Contains(normalized))
         {
-            return PartyRole.Petitioner;
+            role = PartyRole.Petitioner;
+            return true;
         }
 
         types = new HashSet<string> { "Interested Party", "Interested parties" };
         if (types.Contains(normalized))
         {
-            return PartyRole.InterestedParty;
+            role = PartyRole.InterestedParty;
+            return true;
         }
 
-        return GetPartyRole(normalized);
+        return TryGetPartyRole(normalized, out role);
     }
 
-    private static PartyRole? GetTwoLinePartyRole(WCell cell)
+    private static bool TryGetTwoLinePartyRole(WCell cell, out PartyRole role)
     {
         var lines = cell.Contents.Where(l => !IsEmptyLine(l)).ToArray();
 
         if (lines is [WLine line1, WLine line2])
         {
-            return GetTwoLinePartyRole(line1.NormalizedContent, line2.NormalizedContent);
+            return TryGetTwoLinePartyRole(line1.NormalizedContent, line2.NormalizedContent, out role);
         }
 
-        return null;
+        role = default;
+        return false;
     }
 
-    private static PartyRole? GetTwoLinePartyRole(string one, string two)
+    private static bool TryGetTwoLinePartyRole(string one, string two, out PartyRole role)
     {
         if (one == "Defendant/" && two.EndsWith("Claimant")) // EWHC/Ch/2008/2079
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         if (one == "Defendant/" && two == "Applicant") // EWHC/Ch/2017/916
         {
-            return PartyRole.Applicant;
+            role = PartyRole.Applicant;
+            return true;
         }
 
         if (one == "Defendant/" && two == "Appellant") // EWCA/Civ/2011/1383
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Claimant/" && two == "Respondent") // EWCA/Civ/2008/183
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Claimants/" && two == "Respondents") // EWHC/Ch/2017/916
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Claimant/" && two.EndsWith("Defendant")) // EWHC/Ch/2008/2079
         {
-            return PartyRole.Claimant;
+            role = PartyRole.Claimant;
+            return true;
         }
 
         if (one == "Claimant/" && two == "Appellant") // EWCA/Civ/2011/1277
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Respondent/" && two == "Claimant") // EWCA/Civ/2017/97
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Appellants/" && two == "Defendants")
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Appellants/" && two == "Defendants & Counterclaimants") // EWCA/Civ/2017/97
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Appellants/" && two == "Claimants") // EWCA/Civ/2015/377
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Appellants" && two == "Claimants") // EWCA/Civ/2018/601
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Respondent" && two == "Intervener") // EWCA/Civ/2016/176
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Respondents" && two.StartsWith("Respondent")) // EWHC/Fam/2013/1956
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Appellant/" && two == "Claimant") // EWHC/Ch/2017/541
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Appellant" && two == "/Claimant") // [2021] EWHC 3453 (QB)
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Appellant/" && two == "Defendant") // EWHC/QB/2013/196
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Respondent/" && two == "Defendant") // EWHC/Ch/2017/541
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Respondent" && two == "Defendant") // EWCA/Civ/2018/601
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "1st Respondent" && two == "/Defendant") // [2021] EWHC 3453 (QB)
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Claimants/" && two == "Appellants") // EWHC/Admin/2016/321
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Defendant/" && two == "Respondent") // EWHC/Admin/2015/1639
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Defendants/" && two == "Respondents") // EWHC/Admin/2016/321
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Defendants/" && two == "Appellants") // EWCA/Civ/2004/277
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (one == "Defendants/" && two == "Applicants") // [2021] EWHC 2684 (Comm)
         {
-            return PartyRole.Applicant;
+            role = PartyRole.Applicant;
+            return true;
         }
 
         if (one == "1st Respondent" && two == "2nd Respondent") // EWHC/Fam/2017/364, EWHC/Fam/2013/1864?
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "1st Respondent" && two == "2ndRespondent") // EWCA/Civ/2011/1253
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "First Defendant" && two == "Second Defendant") // EWHC/Admin/2010/2
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         if (one == "Defendant/Part 20 Claimant" && two == "Part 20 Claimant") // EWHC/Ch/2003/812
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         if (one == "1st Defendant/Part 20 Claimant" && two == "2nd Defendant/Part 20 Defendant") // EWHC/QB/2004/1260
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         if (one == "Defendant/" && two == "Cross appellant") // EWHC/QB/2013/652
         {
-            return PartyRole.Defendant; // ??? other role is Appellant
+            role = PartyRole.Defendant;
+            return true; // ??? other role is Appellant
         }
 
         if (one == "Applicant/" && two == "Respondent") // [2021] EWCA Civ 1725
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Appellant/" && two == "Respondent") // [2020] EWHC 3409 (QB)
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (one == "Respondent/" && two == "Appellant") // [2021] EWCA Civ 1961
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
-        return GetPartyRoleForCombinedLabels(one, two);
+        return TryGetPartyRoleForCombinedLabels(one, two, out role);
     }
 
-    private static PartyRole? GetNLinePartyRole(WCell cell)
+    private static bool TryGetNLinePartyRole(WCell cell, out PartyRole role)
     {
         var blocks = cell.Contents.Where(block => !IsEmptyLine(block)).ToArray();
+        role = default;
         if (blocks.Length < 2)
         {
-            return null;
+            return false;
         }
 
         if (!blocks.All(block => block is WLine))
         {
-            return null;
+            return false;
         }
 
         if (blocks.Length == 3)
@@ -2266,12 +2294,14 @@ internal class PartyEnricher : Enricher
             var three = ((WLine)blocks[2]).NormalizedContent;
             if (one == "Defendants" && two == "Part 20 Claimant/" && three == "Appellant")
             {
-                return PartyRole.Appellant;
+                role = PartyRole.Appellant;
+                return true;
             }
 
             if (one == "Respondents" && two == "Appellant" && three == "Respondent") // EWCA/Civ/2010/180
             {
-                return PartyRole.Respondent;
+                role = PartyRole.Respondent;
+                return true;
             }
         }
 
@@ -2282,7 +2312,8 @@ internal class PartyEnricher : Enricher
         };
         if (blocks.Cast<WLine>().All(defendant))
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         Func<WLine, bool> defendant2 = line =>
@@ -2293,7 +2324,8 @@ internal class PartyEnricher : Enricher
         };
         if (blocks.Cast<WLine>().All(defendant2))
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         Func<WLine, bool> appellant = line =>
@@ -2303,7 +2335,8 @@ internal class PartyEnricher : Enricher
         };
         if (blocks.Cast<WLine>().All(appellant))
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         Func<WLine, bool> respondent = line =>
@@ -2314,7 +2347,8 @@ internal class PartyEnricher : Enricher
         };
         if (blocks.Cast<WLine>().All(respondent))
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         Func<WLine, bool> respondent2 = line =>
@@ -2324,10 +2358,11 @@ internal class PartyEnricher : Enricher
         };
         if (blocks.Cast<WLine>().All(respondent2))
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
-        return null;
+        return false;
     }
 
     private WCell EnrichCell(WCell cell, PartyRole role)
@@ -2786,7 +2821,7 @@ internal class PartyEnricher : Enricher
 
     /* new methods */
 
-    public static PartyRole? GetPartyRole(string s)
+    public static bool TryGetPartyRole(string s, out PartyRole role)
     {
         if (s.Contains('/'))
         {
@@ -2794,7 +2829,7 @@ internal class PartyEnricher : Enricher
             if (!string.IsNullOrWhiteSpace(one) &&
                 !string.IsNullOrWhiteSpace(two)) // not if at beginning or end of line
             {
-                return GetPartyRoleForCombinedLabels(one, two);
+                return TryGetPartyRoleForCombinedLabels(one, two, out role);
             }
         }
 
@@ -2803,14 +2838,14 @@ internal class PartyEnricher : Enricher
             var (one, two) = s.Split(" and ", 2) switch { var x => (x[0], x[1]) };
             if (!string.IsNullOrWhiteSpace(one) && !string.IsNullOrWhiteSpace(two))
             {
-                return GetPartyRoleForCombinedLabels(one, two);
+                return TryGetPartyRoleForCombinedLabels(one, two, out role);
             }
         }
 
-        return GetPartyRoleForSingleLabel(s);
+        return TryGetPartyRoleForSingleLabel(s, out role);
     }
 
-    private static PartyRole? GetPartyRoleForSingleLabel(string s)
+    private static bool TryGetPartyRoleForSingleLabel(string s, out PartyRole role)
     {
         s = Regex.Replace(s, @"\s+", " ").Trim(' ', '/', '(', ')');
         if (s.StartsWith("Part 20 ", StringComparison.InvariantCultureIgnoreCase))
@@ -2820,7 +2855,8 @@ internal class PartyEnricher : Enricher
 
         if (s.Equals("Third Party", StringComparison.InvariantCultureIgnoreCase))
         {
-            return PartyRole.ThirdParty;
+            role = PartyRole.ThirdParty;
+            return true;
         }
 
         ISet<string> starts = new HashSet<string>
@@ -2851,86 +2887,105 @@ internal class PartyEnricher : Enricher
         s = s.ToLower();
         if (s == "appellant" || s == "appellants")
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (s == "applicant" || s == "applicants")
         {
-            return PartyRole.Applicant;
+            role = PartyRole.Applicant;
+            return true;
         }
 
         if (s == "claimant" || s == "claimants")
         {
-            return PartyRole.Claimant;
+            role = PartyRole.Claimant;
+            return true;
         }
 
         if (s == "defendant" || s == "defendants")
         {
-            return PartyRole.Defendant;
+            role = PartyRole.Defendant;
+            return true;
         }
 
         if (s == "petitioner" || s == "petitioners")
         {
-            return PartyRole.Petitioner;
+            role = PartyRole.Petitioner;
+            return true;
         }
 
         if (s == "respondent" || s == "respondents")
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (s == "interested party" || s == "interested parties")
         {
-            return PartyRole.InterestedParty;
+            role = PartyRole.InterestedParty;
+            return true;
         }
 
         if (s == "intervener" || s == "interveners")
         {
-            return PartyRole.Intervener;
+            role = PartyRole.Intervener;
+            return true;
         }
 
         if (s == "requested person" || s == "requested persons") // [2022] EWHC 273 (Admin)
         {
-            return PartyRole.RequestedPerson;
+            role = PartyRole.RequestedPerson;
+            return true;
         }
 
         if (s == "requesting state")
         {
-            return PartyRole.RequestingState;
+            role = PartyRole.RequestingState;
+            return true;
         }
 
-        return null;
+        role = default;
+        return false;
     }
 
-    private static PartyRole? GetPartyRoleForCombinedLabels(string s1, string s2)
+    private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)
     {
-        var role1 = GetPartyRole(s1);
-        var role2 = GetPartyRole(s2);
-        if (role1 is null || role2 is null)
+        role = default;
+        if (!TryGetPartyRole(s1, out var role1))
         {
-            return null;
+            return false;
+        }
+
+        if (!TryGetPartyRole(s2, out var role2))
+        {
+            return false;
         }
 
         if (role1 == PartyRole.Appellant || role2 == PartyRole.Appellant)
         {
-            return PartyRole.Appellant;
+            role = PartyRole.Appellant;
+            return true;
         }
 
         if (role1 == PartyRole.Respondent || role2 == PartyRole.Respondent)
         {
-            return PartyRole.Respondent;
+            role = PartyRole.Respondent;
+            return true;
         }
 
         if (role1 == PartyRole.Claimant && role2 == PartyRole.Defendant) // [2022] EWCA Civ 102
         {
-            return PartyRole.Claimant;
+            role = PartyRole.Claimant;
+            return true;
         }
 
         if (role1 == PartyRole.Defendant && role2 == PartyRole.Applicant) // [2019] EWHC 3963 (QB)
         {
-            return PartyRole.Applicant;
+            role = PartyRole.Applicant;
+            return true;
         }
 
-        return null;
+        return false;
     }
 }

--- a/test/parsers/common/enrich/TestPartyEnricher.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher.cs
@@ -65,9 +65,13 @@ public class TestPartyEnricher
     [InlineData("Claimant/NotARole", null)]
     public void GetPartyRole_ParsesRoleFromFreeText(string text, PartyRole? expected)
     {
-        var actual = PartyEnricher.GetPartyRole(text);
+        var found = PartyEnricher.TryGetPartyRole(text, out var actual);
 
-        actual.ShouldBe(expected);
+        found.ShouldBe(expected is not null);
+        if (expected is not null)
+        {
+            actual.ShouldBe(expected.Value);
+        }
     }
 
     [Theory]
@@ -84,9 +88,13 @@ public class TestPartyEnricher
     {
         var cell = CellOf(text);
 
-        var actual = PartyEnricher.GetPartyRole(cell);
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
 
-        actual.ShouldBe(expected);
+        found.ShouldBe(expected is not null);
+        if (expected is not null)
+        {
+            actual.ShouldBe(expected.Value);
+        }
     }
 
     [Theory]
@@ -100,8 +108,9 @@ public class TestPartyEnricher
     {
         var cell = CellOf(first, second);
 
-        var actual = PartyEnricher.GetPartyRole(cell);
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
 
+        found.ShouldBeTrue();
         actual.ShouldBe(expected);
     }
 
@@ -110,8 +119,9 @@ public class TestPartyEnricher
     {
         var cell = CellOf("1st Defendant", "2nd Defendant", "3rd Defendant");
 
-        var actual = PartyEnricher.GetPartyRole(cell);
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
 
+        found.ShouldBeTrue();
         actual.ShouldBe(PartyRole.Defendant);
     }
 


### PR DESCRIPTION
The `PartyEnricher` had null returns and null handling throughout the class which obscured the intention of the methods and made it tricky to rely on the output of any given method. This PR transitions the `PartyEnricher` to the more standard "try" pattern where failure is explicitly indicated by the returned boolean being false.

Some methods have also been renamed and some of the role mapping logic has been extracted into static sets/dictionaries in order to make this transition to a try pattern slightly cleaner