### PR TITLE
FCLC-431: Simplify `EnrichCell`

### DIFF
--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1582,23 +1582,15 @@ internal class PartyEnricher : Enricher
     {
         var lineContents = line.Contents.ToArray();
 
-        return lineContents switch
+        static bool IsPartOfPartyName(WText wText)
+            => IsNotBlank(wText)
+            && !IsInBrackets(wText.Text)
+            && !IsConnectorText(wText.Text);
+
+        return lineContents.OfType<WText>().Count(IsPartOfPartyName) switch
         {
-            [] => line,
-
-            [WText { Text: "SECRETARY OF STATE " }, WLineBreak, WText] // [2021] EWCA Civ 1876
-                => WLine.Make(line, [new WParty2(lineContents.Cast<ITextOrWhitespace>()) { Role = role }]),
-
-            _ when lineContents.OfType<WText>().Count(wText => IsNotBlank(wText)
-                    && !IsInBrackets(wText.Text)
-                    && !IsConnectorText(wText.Text)) == 1
-                => WLine.Make(line, lineContents.SelectMany(inline => EnrichWTextWithParties(inline, role)).ToArray()),
-
-            _ when lineContents.OfType<WText>()
-                               .Count(wText => IsNotBlank(wText) && !IsInBrackets(wText.Text)
-                                   && !IsConnectorText(wText.Text)) > 1
-                => WLine.Make(line, [new WParty2(lineContents.Cast<WText>()) { Role = role }]),
-
+            1 => WLine.Make(line, lineContents.SelectMany(inline => EnrichWTextWithParties(inline, role)).ToArray()),
+            > 1 => WLine.Make(line, [new WParty2(lineContents.Cast<ITextOrWhitespace>()) { Role = role }]),
             _ => line
         };
     }

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-using DocumentFormat.OpenXml.Wordprocessing;
-
 using UK.Gov.Legislation.Judgments.Utils;
 
 namespace UK.Gov.Legislation.Judgments.Parse;
@@ -855,23 +853,6 @@ internal class PartyEnricher : Enricher
         return false;
     }
 
-    private static IInline[] MakeOrSplitParty(string text, RunProperties props, PartyRole role)
-    {
-        if (text.StartsWith("(1)") && text.Contains("(2)"))
-        {
-            // ewhc/admin/2022/273
-            var i = text.IndexOf("(2)");
-            var text1 = text.Substring(0, i);
-            var text2 = text.Substring(i);
-            var party1 = new WParty(text1, props) { Role = role };
-            var party2 = new WParty(text2, props) { Role = role };
-            return [party1, party2];
-        }
-
-        var party = new WParty(text, props) { Role = role };
-        return [party];
-    }
-
     private static WLine MakeParty(WLine line, PartyRole? role)
     {
         var lineContents = line.Contents.ToArray();
@@ -1255,7 +1236,7 @@ internal class PartyEnricher : Enricher
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
                 first,
-                EnrichCell(second, role),
+                EnrichCellWithParty(second, role),
                 EnrichCellWithPartyRole(third, role)
             ]);
         }
@@ -1293,7 +1274,7 @@ internal class PartyEnricher : Enricher
         {
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
-                EnrichCell(first, role),
+                EnrichCellWithParty(first, role),
                 EnrichCellWithPartyRole(second, role)
             ]);
         }
@@ -1419,7 +1400,7 @@ internal class PartyEnricher : Enricher
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
                 thisRowFirstCell,
-                EnrichCell(thisRowMiddleCell, role),
+                EnrichCellWithParty(thisRowMiddleCell, role),
                 thisRowLastCell
             ]);
         }
@@ -1577,221 +1558,74 @@ internal class PartyEnricher : Enricher
         (new Regex(@"^(First|Second|Third|Fourth) Respondent$", RegexOptions.IgnoreCase), PartyRole.Respondent)
     ];
 
-    private WCell EnrichCell(WCell cell, PartyRole role)
+    private WCell EnrichCellWithParty(WCell cell, PartyRole role)
     {
         var contents = cell.Contents.Select(block =>
             {
-                if (block is WOldNumberedParagraph np)
+                return block switch
                 {
-                    // EWCA/Civ/2015/455
-                    var npContents = np.Contents.ToArray();
-                    if (npContents.Length != 1 || npContents[0] is not WText wText2)
-                    {
-                        return np;
-                    }
+                    WOldNumberedParagraph wOldNumberedParagraph =>
+                        wOldNumberedParagraph.Contents.ToArray() is [WText wText]
+                            ? new WOldNumberedParagraph(wOldNumberedParagraph, [new WParty(wText) { Role = role }])
+                            : wOldNumberedParagraph, // EWCA/Civ/2015/455
 
-                    var party2 = new WParty(wText2) { Role = role };
-                    return new WOldNumberedParagraph(np, [party2]);
-                }
+                    WLine line => EnrichLineWithParty(line, role),
 
-                if (block is not WLine line)
-                {
-                    return block;
-                }
-
-                var lineContents = line.Contents.ToArray();
-                if (lineContents.Length == 0)
-                {
-                    return line;
-                }
-
-                Func<IInline, bool> filter = inline =>
-                {
-                    if (inline is not WText wText)
-                    {
-                        return false;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(wText.Text))
-                    {
-                        return false;
-                    }
-
-                    var trimmed = wText.Text.Trim();
-                    if (trimmed.StartsWith('(') && trimmed.EndsWith(')'))
-                    {
-                        return false;
-                    }
-
-                    if (IsAnd(trimmed))
-                    {
-                        return false;
-                    }
-
-                    return true;
+                    _ => block
                 };
-                var filtered = lineContents.Where(filter);
-                if (filtered.Count() == 1)
-                {
-                    var mapped = lineContents.SelectMany(inline => filter(inline)
-                        ? MakeOrSplitParty(((WText)inline).Text, ((WText)inline).properties, role)
-                        : [inline]);
-                    return WLine.Make(line, mapped);
-                }
-
-                if (lineContents.Any(inline => inline is WText wt && Regex.IsMatch(wt.Text, @"^\(\d+\) ")) &&
-                    lineContents.All(inline => inline is WLineBreak || (inline is WText wt &&
-                        (string.IsNullOrEmpty(wt.Text) ||
-                            Regex.IsMatch(wt.Text, @"^\(\d+\) ")))))
-                {
-                    var mapped = lineContents.Select(inline =>
-                    {
-                        if (inline is WText wt)
-                        {
-                            if (string.IsNullOrEmpty(wt.Text))
-                            {
-                                return inline;
-                            }
-
-                            return new WParty(wt) { Role = role };
-                        }
-
-                        return inline;
-                    });
-                    return WLine.Make(line, mapped);
-                }
-
-                /* these should be rewritten so they do nothing if their conditions aren't met (instead of returning) */
-                if (lineContents.Length == 1)
-                {
-                    if (lineContents[0] is not WText wText)
-                    {
-                        return line;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(wText.Text))
-                    {
-                        return line;
-                    }
-
-                    var trimmed = wText.Text.Trim();
-                    if (trimmed.StartsWith('(') && trimmed.EndsWith(')'))
-                    {
-                        return line;
-                    }
-
-                    if (IsAnd(trimmed))
-                    {
-                        return line;
-                    }
-
-                    var party = new WParty(wText) { Role = role };
-                    return WLine.Make(line, [party]);
-                }
-
-                if (lineContents.Length == 2)
-                {
-                    if (lineContents[0] is not WText wText1)
-                    {
-                        return line;
-                    }
-
-                    if (lineContents[1] is not WText wText2)
-                    {
-                        return line;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(wText1.Text))
-                    {
-                        return line;
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(wText2.Text))
-                    {
-                        return line;
-                    }
-
-                    var trimmed = wText1.Text.Trim();
-                    if (trimmed.StartsWith('(') && trimmed.EndsWith(')'))
-                    {
-                        return line;
-                    }
-
-                    if (IsAnd(trimmed))
-                    {
-                        return line;
-                    }
-
-                    var party = new WParty(wText1) { Role = role };
-                    return WLine.Make(line, [party, lineContents[1]]);
-                }
-
-                if (lineContents.Length == 3)
-                {
-                    // [2021] EWCA Civ 1876
-                    if (lineContents[0] is WText wText1
-                        && lineContents[1] is WLineBreak
-                        && lineContents[2] is WText
-                        && string.Equals(wText1.Text, "SECRETARY OF STATE ", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var party = new WParty2(lineContents.Cast<ITextOrWhitespace>()) { Role = role };
-                        return WLine.Make(line, [party]);
-                    }
-                }
-
-                if (lineContents.All(inline => inline is WText))
-                {
-                    var party = new WParty2(lineContents.Cast<WText>());
-                    return WLine.Make(line, [party]);
-                }
-
-                if (lineContents.Length == 3)
-                {
-                    // EWHC/Ch/2018/2498
-                    if (lineContents[0] is not WText wText1)
-                    {
-                        return line;
-                    }
-
-                    if (lineContents[1] is not WTab)
-                    {
-                        return line;
-                    }
-
-                    if (lineContents[2] is not WText wText3)
-                    {
-                        return line;
-                    }
-
-                    if (!Regex.IsMatch(wText1.Text, @"^\d\.$"))
-                    {
-                        return line;
-                    }
-
-                    var trimmed = wText3.Text.Trim();
-                    if (trimmed.StartsWith('(') && trimmed.EndsWith(')'))
-                    {
-                        return line;
-                    }
-
-                    if (IsAnd(trimmed))
-                    {
-                        return line;
-                    }
-
-                    var party = new WParty(wText3) { Role = role };
-                    return WLine.Make(line,
-                    [
-                        lineContents[0],
-                        lineContents[1],
-                        party
-                    ]);
-                }
-
-                return line;
             }
-        );
+        ).ToArray();
         return new WCell(cell.Row, cell.Props, contents);
+    }
+
+    private static WLine EnrichLineWithParty(WLine line, PartyRole role)
+    {
+        var lineContents = line.Contents.ToArray();
+
+        return lineContents switch
+        {
+            [] => line,
+
+            [WText { Text: "SECRETARY OF STATE " }, WLineBreak, WText] // [2021] EWCA Civ 1876
+                => WLine.Make(line, [new WParty2(lineContents.Cast<ITextOrWhitespace>()) { Role = role }]),
+
+            _ when lineContents.OfType<WText>().Count(wText => IsNotBlank(wText)
+                    && !IsInBrackets(wText.Text)
+                    && !IsConnectorText(wText.Text)) == 1
+                => WLine.Make(line, lineContents.SelectMany(inline => EnrichWTextWithParties(inline, role)).ToArray()),
+
+            _ when lineContents.OfType<WText>()
+                               .Count(wText => IsNotBlank(wText) && !IsInBrackets(wText.Text)
+                                   && !IsConnectorText(wText.Text)) > 1
+                => WLine.Make(line, [new WParty2(lineContents.Cast<WText>()) { Role = role }]),
+
+            _ => line
+        };
+    }
+
+    private static IEnumerable<IInline> EnrichWTextWithParties(IInline inline, PartyRole role)
+    {
+        if (inline is WText text)
+        {
+            // Is this a case of two party names in one line - ewhc/admin/2022/273
+            if (text.Text.StartsWith("(1)") && text.Text.Contains("(2)"))
+            {
+                var i = text.Text.IndexOf("(2)", StringComparison.Ordinal);
+                return
+                [
+                    new WParty(text.Text[..i], text.properties) { Role = role },
+                    new WParty(text.Text[i..], text.properties) { Role = role }
+                ];
+            }
+
+            // Make sure this is the wText with a party name in it rather than some connection or descriptive text
+            if (IsNotBlank(text) && !IsConnectorText(text.Text) && !IsInBrackets(text.Text))
+            {
+                return [new WParty(text.Text, text.properties) { Role = role }];
+            }
+        }
+
+        return [inline];
     }
 
     private static bool IsNotBlank(WText wText)
@@ -1829,6 +1663,11 @@ internal class PartyEnricher : Enricher
     {
         var trimmed = s.Trim();
         return trimmed.StartsWith('(') && trimmed.EndsWith(')');
+    }
+
+    private static bool IsConnectorText(string s)
+    {
+        return Regex.IsMatch(s, @"^(\s|_|-|–|\d|\.|\+|&|and)*$", RegexOptions.IgnoreCase);
     }
 
     private WCell EnrichPartyNamesWithTwoRoles(WCell cell, (PartyRole first, PartyRole second) roles)

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1597,24 +1597,26 @@ internal class PartyEnricher : Enricher
 
     private static IEnumerable<IInline> EnrichWTextWithParties(IInline inline, PartyRole role)
     {
-        if (inline is WText text)
+        if (inline is not WText text)
         {
-            // Is this a case of two party names in one line - ewhc/admin/2022/273
-            if (text.Text.StartsWith("(1)") && text.Text.Contains("(2)"))
-            {
-                var i = text.Text.IndexOf("(2)", StringComparison.Ordinal);
-                return
-                [
-                    new WParty(text.Text[..i], text.properties) { Role = role },
-                    new WParty(text.Text[i..], text.properties) { Role = role }
-                ];
-            }
+            return [inline];
+        }
 
-            // Make sure this is the wText with a party name in it rather than some connection or descriptive text
-            if (IsNotBlank(text) && !IsConnectorText(text.Text) && !IsInBrackets(text.Text))
-            {
-                return [new WParty(text.Text, text.properties) { Role = role }];
-            }
+        // Is this a case of two party names in one line - ewhc/admin/2022/273
+        if (text.Text.StartsWith("(1)") && text.Text.Contains("(2)"))
+        {
+            var i = text.Text.IndexOf("(2)", StringComparison.Ordinal);
+            return
+            [
+                new WParty(text.Text[..i], text.properties) { Role = role },
+                new WParty(text.Text[i..], text.properties) { Role = role }
+            ];
+        }
+
+        // Make sure this is the wText with a party name in it rather than some connection or descriptive text
+        if (IsNotBlank(text) && !IsConnectorText(text.Text) && !IsInBrackets(text.Text))
+        {
+            return [new WParty(text.Text, text.properties) { Role = role }];
         }
 
         return [inline];

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1657,12 +1657,13 @@ internal class PartyEnricher : Enricher
     }
 
     /// <summary>
-    /// Returns true if this is a string enclosed in brackets
+    /// Returns true if this is a string enclosed in brackets unless there are nested brackets
+    /// "(some string in brackets)   " => true
+    /// "(3) Appellant CAKE (Cats Against Kipper Exploitation)" => false
     /// </summary>
     private static bool IsInBrackets(string s)
     {
-        var trimmed = s.Trim();
-        return trimmed.StartsWith('(') && trimmed.EndsWith(')');
+        return Regex.IsMatch(s, @"^\s*\([^()]+\)\s*$", RegexOptions.IgnoreCase);
     }
 
     private static bool IsConnectorText(string s)

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1558,24 +1558,34 @@ internal class PartyEnricher : Enricher
         (new Regex(@"^(First|Second|Third|Fourth) Respondent$", RegexOptions.IgnoreCase), PartyRole.Respondent)
     ];
 
-    private WCell EnrichCellWithParty(WCell cell, PartyRole role)
+    private static IBlock EnrichBlockWithParty(IBlock block, PartyRole role)
     {
-        var contents = cell.Contents.Select(block =>
-            {
-                return block switch
-                {
-                    WOldNumberedParagraph wOldNumberedParagraph =>
-                        wOldNumberedParagraph.Contents.ToArray() is [WText wText]
-                            ? new WOldNumberedParagraph(wOldNumberedParagraph, [new WParty(wText) { Role = role }])
-                            : wOldNumberedParagraph, // EWCA/Civ/2015/455
+        return block switch
+        {
+            WOldNumberedParagraph p => EnrichOldNumberedParagraphWithParty(p, role),
+            WLine line => EnrichLineWithParty(line, role),
+            _ => block
+        };
+    }
 
-                    WLine line => EnrichLineWithParty(line, role),
+    private static WCell EnrichCellWithParty(WCell cell, PartyRole role)
+    {
+        var contents = cell.Contents
+                           .Select(block => EnrichBlockWithParty(block, role))
+                           .ToArray();
 
-                    _ => block
-                };
-            }
-        ).ToArray();
         return new WCell(cell.Row, cell.Props, contents);
+    }
+
+    private static WOldNumberedParagraph EnrichOldNumberedParagraphWithParty(WOldNumberedParagraph paragraph,
+        PartyRole role)
+    {
+        if (paragraph.Contents.ToArray() is [WText wText])
+        {
+            return new WOldNumberedParagraph(paragraph, [new WParty(wText) { Role = role }]); // EWCA/Civ/2015/455
+        }
+
+        return paragraph;
     }
 
     private static WLine EnrichLineWithParty(WLine line, PartyRole role)

--- a/test/judgments/test73.xml
+++ b/test/judgments/test73.xml
@@ -10,7 +10,7 @@
           <FRBRauthor href="#ewhc-chancery-insolvencyandcompanies" />
           <FRBRcountry value="GB-UKM" />
           <FRBRnumber value="3056" />
-          <FRBRname value="THE JOINT ADMINISTRATORS OF LEHMAN BROTHERS HOLDINGS PLC v LEHMAN BROTHERS HOLDINGS INC." />
+          <FRBRname value="THE JOINT ADMINISTRATORS OF LEHMAN BROTHERS HOLDINGS PLC v LB GP NO.1 LIMITED (in Liquidation)" />
         </FRBRWork>
         <FRBRExpression>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/3056" />
@@ -22,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/3056/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/3056/data.xml" />
-          <FRBRdate date="2026-01-22T09:58:22" name="transform" />
+          <FRBRdate date="2026-08-26T14:29:54" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -35,6 +35,7 @@
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
         <TLCEvent eId="judgment" href="#" showAs="judgment" />
         <TLCPerson eId="the-joint-administrators-of-lehman-brothers-holdings-plc" href="" showAs="THE JOINT ADMINISTRATORS OF LEHMAN BROTHERS HOLDINGS PLC" />
+        <TLCPerson eId="lb-gp-no1-limited-in-liquidation" href="" showAs="LB GP NO.1 LIMITED (in Liquidation)" />
         <TLCPerson eId="lehman-brothers-holdings-inc" href="" showAs="LEHMAN BROTHERS HOLDINGS INC." />
         <TLCPerson eId="deutsche-bank-ag-london-branch" href="" showAs="DEUTSCHE BANK A.G. (London Branch)" />
         <TLCRole eId="applicant" href="" showAs="Applicant" />
@@ -47,7 +48,7 @@
         <uk:number>3056</uk:number>
         <uk:cite>[2023] EWHC 3056 (Ch)</uk:cite>
         <uk:caseNumber>CR-2008-000026</uk:caseNumber>
-        <uk:parser>1.4.0</uk:parser>
+        <uk:parser>1.12.0</uk:parser>
         <uk:hash>9e8d8e35ba95486c9bf89b2e4d4757b475afe4f478f663dbdd0ba4c87f0513c0</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -182,7 +183,7 @@
             <p />
           </td>
           <td>
-            <p style="text-align:center"><span style="font-weight:bold;font-size:10pt"> (1) LB GP NO.1 LIMITED (in Liquidation)</span></p>
+            <p style="text-align:center"><party refersTo="#lb-gp-no1-limited-in-liquidation" as="#respondent" style="font-weight:bold;font-size:10pt"> (1) LB GP NO.1 LIMITED (in Liquidation)</party></p>
             <p style="text-align:center"><party refersTo="#lehman-brothers-holdings-inc" as="#respondent" style="font-weight:bold;font-size:10pt">(2) LEHMAN BROTHERS HOLDINGS INC.</party></p>
             <p style="text-align:center"><party refersTo="#deutsche-bank-ag-london-branch" as="#respondent" style="font-weight:bold;font-size:10pt">(3) DEUTSCHE BANK A.G. (London Branch)</party></p>
           </td>

--- a/test/parsers/common/enrich/TestPartyEnricher.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher.cs
@@ -17,9 +17,9 @@ public class TestPartyEnricher
 
     private static readonly WLine LineTemplate = new(null, new Paragraph());
 
-    private static WLine TextLine(string text)
+    private static WLine TextLine(params string[] text)
     {
-        return new WLine(LineTemplate, [new WText(text, null)]);
+        return new WLine(LineTemplate, text.Select(t => new WText(t, null)));
     }
 
     private static WRow RowOf(params string[] cells)
@@ -27,14 +27,29 @@ public class TestPartyEnricher
         return new WRow(TableOf(), null, null, cells.Select(c => CellOf(c)));
     }
 
+    private static WRow RowOf(WCell[] cells)
+    {
+        return new WRow(TableOf(), null, null, cells);
+    }
+
     private static WCell CellOf(params string[] lines)
     {
-        return new WCell(RowOf(), null, lines.Select(TextLine));
+        return new WCell(RowOf(), null, lines.Select(l => TextLine(l)));
+    }
+
+    private static WCell CellWithOneLineOf(params string[] text)
+    {
+        return new WCell(RowOf(), null, [TextLine(text)]);
     }
 
     private static WTable TableOf(params string[][] rows)
     {
         return new WTable(null, null, null, rows.Select(RowOf));
+    }
+
+    private static WTable TableOf(WRow[] rows)
+    {
+        return new WTable(null, null, null, rows);
     }
 
     [Theory]
@@ -619,118 +634,102 @@ public class TestPartyEnricher
                .Role.ShouldBe(PartyRole.Claimant);
     }
 
-    [Fact]
-    public void Enrich_TwoCellTableRow_NameCellWithTrailingConnectorTextRun_LeavesConnectorTextRunUnwrapped()
+    [Theory]
+    [InlineData("NNB Generation Company (SZC) Limited", " -and- ", PartyRole.Claimant)]
+    [InlineData("John Smith", " (formerly known as John Doe)", PartyRole.Appellant)]
+    public void Enrich_TwoCellTableRow_NameCellWithTrailingNonPartyTextRun_LeavesNonPartyTextRunUnwrapped(string partyName, string otherText, PartyRole role)
     {
-        var nameLine = new WLine(LineTemplate,
-            [new WText("NNB Generation Company (SZC) Limited", null), new WText(" -and- ", null)]);
-        var table = new WTable(null, null, null,
-        [
-            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
+        var table = TableOf([
+            RowOf([
+                CellWithOneLineOf(partyName, otherText),
+                CellOf(role.ToString())
+            ])
         ]);
 
         var result = PartyEnricher.Enrich([table]);
 
         var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
-        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+        var resultCell = resultTable.TypedRows.ShouldHaveSingleItem()
                                       .TypedCells[0].Contents.ShouldHaveSingleItem()
                                       .ShouldBeOfType<WLine>();
 
-        var party = nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WParty>();
-        party.Role.ShouldBe(PartyRole.Claimant);
-        party.Text.ShouldBe("NNB Generation Company (SZC) Limited");
+        var party = resultCell.Contents.ElementAt(0).ShouldBeOfType<WParty>();
+        party.Role.ShouldBe(role);
+        party.Text.ShouldBe(partyName);
 
-        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe(" -and- ");
-    }
-
-    [Fact]
-    public void Enrich_TwoCellTableRow_NameCellWithParentheticalAsideTextRun_LeavesAsideTextRunUnwrapped()
-    {
-        var nameLine = new WLine(LineTemplate,
-            [new WText("John Smith", null), new WText(" (formerly known as John Doe)", null)]);
-        var table = new WTable(null, null, null,
-        [
-            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Appellant")])
-        ]);
-
-        var result = PartyEnricher.Enrich([table]);
-
-        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
-        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
-                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
-                                      .ShouldBeOfType<WLine>();
-
-        var party = nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WParty>();
-        party.Role.ShouldBe(PartyRole.Appellant);
-        party.Text.ShouldBe("John Smith");
-
-        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe(" (formerly known as John Doe)");
-    }
-
-    [Fact]
-    public void Enrich_TwoCellTableRow_NameCellWithNumberedTabbedName_AssignsPartyToNameAfterTab()
-    {
-        var nameLine = new WLine(LineTemplate,
-            [new WText("1.", null), new WTab(new TabChar()), new WText("John Smith", null)]);
-        var table = new WTable(null, null, null,
-        [
-            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
-        ]);
-
-        var result = PartyEnricher.Enrich([table]);
-
-        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
-        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
-                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
-                                      .ShouldBeOfType<WLine>();
-
-        nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("1.");
-        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WTab>();
-        var party = nameCellLine.Contents.ElementAt(2).ShouldBeOfType<WParty>();
-        party.Role.ShouldBe(PartyRole.Claimant);
-        party.Text.ShouldBe("John Smith");
+        resultCell.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe(otherText);
     }
 
     [Fact]
     public void Enrich_TwoCellTableRow_NameCellWithTwoQualifyingTextRuns_WrapsBothRunsAsOneParty()
     {
-        var nameLine = new WLine(LineTemplate,
-            [new WText("Big Company ", null), new WText("Limited", null)]);
-        var table = new WTable(null, null, null,
-        [
-            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
+        var table = TableOf([
+            RowOf([
+                CellWithOneLineOf("Big Company ", "Limited"), CellOf("Claimant")
+            ])
         ]);
 
         var result = PartyEnricher.Enrich([table]);
 
         var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
-        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+        var resultCell = resultTable.TypedRows.ShouldHaveSingleItem()
                                       .TypedCells[0].Contents.ShouldHaveSingleItem()
                                       .ShouldBeOfType<WLine>();
 
-        var party = nameCellLine.Contents.ShouldHaveSingleItem().ShouldBeOfType<WParty2>();
+        var party = resultCell.Contents.ShouldHaveSingleItem().ShouldBeOfType<WParty2>();
         party.Role.ShouldBe(PartyRole.Claimant);
         party.Text.ShouldBe("Big Company Limited");
     }
 
     [Fact]
-    public void Enrich_TwoCellTableRow_NameCellIsBareAndMarker_DoesNotWrapEitherRunAsParty()
+    public void Enrich_TwoCellTableRow_NameCellWithNumberedTabbedName_AssignsPartyToNameAfterTab()
     {
-        var nameLine = new WLine(LineTemplate, [new WText("- and ", null), new WText("–", null)]);
-        var table = new WTable(null, null, null,
-        [
-            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Defendant")])
+        var cellWithNumberedTabbedName = new WCell(RowOf(), null, [
+            new WLine(LineTemplate, [
+                new WText("1.", null),
+                new WTab(new TabChar()),
+                new WText("John Smith", null)
+            ])
+        ]);
+
+        var table = TableOf([
+            RowOf([cellWithNumberedTabbedName, CellOf("Claimant")])
         ]);
 
         var result = PartyEnricher.Enrich([table]);
 
         var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
-        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+        var resultCell = resultTable.TypedRows.ShouldHaveSingleItem()
                                       .TypedCells[0].Contents.ShouldHaveSingleItem()
                                       .ShouldBeOfType<WLine>();
 
-        nameCellLine.Contents.Count().ShouldBe(2);
-        nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("- and ");
-        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe("–");
+        resultCell.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("1.");
+        resultCell.Contents.ElementAt(1).ShouldBeOfType<WTab>();
+
+        var party = resultCell.Contents.ElementAt(2).ShouldBeOfType<WParty>();
+        party.Role.ShouldBe(PartyRole.Claimant);
+        party.Text.ShouldBe("John Smith");
+    }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellIsBareAndMarker_DoesNotWrapEitherRunAsParty()
+    {
+        var table = TableOf([
+            RowOf([
+                CellWithOneLineOf("- and ", "–"),
+                CellOf("Defendant")
+            ])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var resultCell = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        resultCell.Contents.Count().ShouldBe(2);
+        resultCell.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("- and ");
+        resultCell.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe("–");
     }
 }

--- a/test/parsers/common/enrich/TestPartyEnricher.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher.cs
@@ -618,4 +618,119 @@ public class TestPartyEnricher
                .Contents.ShouldHaveSingleItem().ShouldBeOfType<WRole>()
                .Role.ShouldBe(PartyRole.Claimant);
     }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellWithTrailingConnectorTextRun_LeavesConnectorTextRunUnwrapped()
+    {
+        var nameLine = new WLine(LineTemplate,
+            [new WText("NNB Generation Company (SZC) Limited", null), new WText(" -and- ", null)]);
+        var table = new WTable(null, null, null,
+        [
+            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        var party = nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WParty>();
+        party.Role.ShouldBe(PartyRole.Claimant);
+        party.Text.ShouldBe("NNB Generation Company (SZC) Limited");
+
+        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe(" -and- ");
+    }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellWithParentheticalAsideTextRun_LeavesAsideTextRunUnwrapped()
+    {
+        var nameLine = new WLine(LineTemplate,
+            [new WText("John Smith", null), new WText(" (formerly known as John Doe)", null)]);
+        var table = new WTable(null, null, null,
+        [
+            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Appellant")])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        var party = nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WParty>();
+        party.Role.ShouldBe(PartyRole.Appellant);
+        party.Text.ShouldBe("John Smith");
+
+        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe(" (formerly known as John Doe)");
+    }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellWithNumberedTabbedName_AssignsPartyToNameAfterTab()
+    {
+        var nameLine = new WLine(LineTemplate,
+            [new WText("1.", null), new WTab(new TabChar()), new WText("John Smith", null)]);
+        var table = new WTable(null, null, null,
+        [
+            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("1.");
+        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WTab>();
+        var party = nameCellLine.Contents.ElementAt(2).ShouldBeOfType<WParty>();
+        party.Role.ShouldBe(PartyRole.Claimant);
+        party.Text.ShouldBe("John Smith");
+    }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellWithTwoQualifyingTextRuns_WrapsBothRunsAsOneParty()
+    {
+        var nameLine = new WLine(LineTemplate,
+            [new WText("Big Company ", null), new WText("Limited", null)]);
+        var table = new WTable(null, null, null,
+        [
+            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Claimant")])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        var party = nameCellLine.Contents.ShouldHaveSingleItem().ShouldBeOfType<WParty2>();
+        party.Role.ShouldBe(PartyRole.Claimant);
+        party.Text.ShouldBe("Big Company Limited");
+    }
+
+    [Fact]
+    public void Enrich_TwoCellTableRow_NameCellIsBareAndMarker_DoesNotWrapEitherRunAsParty()
+    {
+        var nameLine = new WLine(LineTemplate, [new WText("- and ", null), new WText("–", null)]);
+        var table = new WTable(null, null, null,
+        [
+            new WRow(TableOf(), null, null, [new WCell(RowOf(), null, [nameLine]), CellOf("Defendant")])
+        ]);
+
+        var result = PartyEnricher.Enrich([table]);
+
+        var resultTable = result.ShouldHaveSingleItem().ShouldBeOfType<WTable>();
+        var nameCellLine = resultTable.TypedRows.ShouldHaveSingleItem()
+                                      .TypedCells[0].Contents.ShouldHaveSingleItem()
+                                      .ShouldBeOfType<WLine>();
+
+        nameCellLine.Contents.Count().ShouldBe(2);
+        nameCellLine.Contents.ElementAt(0).ShouldBeOfType<WText>().Text.ShouldBe("- and ");
+        nameCellLine.Contents.ElementAt(1).ShouldBeOfType<WText>().Text.ShouldBe("–");
+    }
 }


### PR DESCRIPTION
`EnrichCell` was an extremely difficult method to understand and contained unreachable code. This PR strips it down to its core, adding more unit tests to catch edgecases highlighted by the e2e tests and fixes an existing bug unveiled by these changes.

## Changes

- `EnrichCell` is renamed to `EnrichCellWithParty`
- The `EnrichCell` code concerned with `WLine` is moved to new `EnrichLineWithParty` and is cut back significantly
- `MakeOrSplitParty` becomes enveloped in new `EnrichWTextWithParties`
- Existing bug in party identification when there are multiple parties and one contains brackets in the name is fixed