### PR TITLE
FCLC-431 merge party role collections

### DIFF
--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -939,33 +939,53 @@ internal class PartyEnricher : Enricher
     {
         ["(APPELLANT)"] = PartyRole.Appellant,
         ["(APPELLANTS)"] = PartyRole.Appellant,
-        ["Appellant"] = PartyRole.Appellant,
+        ["1st Appellant"] = PartyRole.Appellant,
+        ["Appellant / Claimant"] = PartyRole.Appellant,
+        ["Appellant / Third Defendant"] = PartyRole.Appellant,
         ["Appellant"] = PartyRole.Appellant, // EWCA/Civ/2003/1686
+        ["Appellant/ Defendant"] = PartyRole.Appellant,
+        ["Appellant/ Respondent"] = PartyRole.Appellant, // [2021] EWCA Civ 1792
         ["Appellant/Appellant"] = PartyRole.Appellant,
-        ["Appellant/Applicant"] = PartyRole.Appellant,
+        ["Appellant/Applicant"] = PartyRole.Appellant, // [2021] EWCA Crim 1877
         ["Appellant/Claimant"] = PartyRole.Appellant,
         ["Appellant/Defendant"] = PartyRole.Appellant,
         ["Appellant/First Defendant"] = PartyRole.Appellant,
+        ["Appellants / Defendants"] = PartyRole.Appellant,
+        ["Appellants"] = PartyRole.Appellant,
         ["Appellants/ Claimants"] = PartyRole.Appellant,
+        ["Appellants/Claimants"] = PartyRole.Appellant,
         ["Applicant/Appellant"] = PartyRole.Appellant,
+        ["Claimant / Appellant"] = PartyRole.Appellant,
+        ["Claimant/ Appellant"] = PartyRole.Appellant,
         ["Claimant/Appellant"] = PartyRole.Appellant,
-        ["Claimants/Appellants"] = PartyRole.Appellant,
+        ["Claimants/ Appellants"] = PartyRole.Appellant,
+        ["Claimants/Appellants"] = PartyRole.Appellant, // [2021] EWCA Civ 1799
+        ["Defendant/ Appellant"] = PartyRole.Appellant,
         ["Defendant/Appellant"] = PartyRole.Appellant,
         ["Defendants / Appellants"] = PartyRole.Appellant,
+        ["Defendants/ Appellants"] = PartyRole.Appellant,
         ["Defendants/Appellants"] = PartyRole.Appellant,
+        ["Defendants/Appellants/"] = PartyRole.Appellant,
         ["FIRST DEFENDANT’S SOLICITOR/APPELLANT"] = PartyRole.Appellant, // EWCA/Civ/2006/1032
+        ["Respondent/Appellant"] = PartyRole.Appellant,
         ["Third Party/Appellant"] = PartyRole.Appellant, // [2022] EWHC 34 (Ch)
 
+        ["1st Applicant"] = PartyRole.Applicant,
+        ["2nd Applicant"] = PartyRole.Applicant,
         ["Applicant"] = PartyRole.Applicant,
+        ["Applicant/ Claimant"] = PartyRole.Applicant,
         ["Applicants"] = PartyRole.Applicant,
+        ["Applicants/Claimants"] = PartyRole.Applicant,
         ["Claimant/Applicant"] = PartyRole.Applicant,
+        ["Defendant/ Applicant"] = PartyRole.Applicant,
+        ["Respondent/Applicant"] = PartyRole.Applicant,
 
         ["(CLAIMANTS)"] = PartyRole.Claimant,
         ["(Claimant)"] = PartyRole.Claimant,
         ["Additional Claimant"] = PartyRole.Claimant,
         ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
         ["Claimant"] = PartyRole.Claimant,
-        ["Claimant/part 20 Defendant"] = PartyRole.Claimant,
+        ["Claimant/Part 20 Defendant"] = PartyRole.Claimant,
         ["Claimants"] = PartyRole.Claimant,
         ["First Claimant"] = PartyRole.Claimant,
         ["Second Claimant"] = PartyRole.Claimant,
@@ -984,38 +1004,64 @@ internal class PartyEnricher : Enricher
         ["Defendants"] = PartyRole.Defendant,
         ["First Defendant"] = PartyRole.Defendant,
         ["Second Defendant"] = PartyRole.Defendant,
+        ["Third Defendant"] = PartyRole.Defendant,
 
         ["(INTERESTED PARTIES)"] = PartyRole.InterestedParty,
         ["(INTERESTED PARTY)"] = PartyRole.InterestedParty,
         ["Interested Parties"] = PartyRole.InterestedParty,
         ["Interested Party"] = PartyRole.InterestedParty,
+        ["Interested parties"] = PartyRole.InterestedParty,
         ["Second Interested Party"] = PartyRole.InterestedParty,
         ["Third Interested Party"] = PartyRole.InterestedParty,
 
         ["Intervener"] = PartyRole.Intervener,
         ["Interveners"] = PartyRole.Intervener,
 
+        ["Petitioner"] = PartyRole.Petitioner,
+        ["Petitioners"] = PartyRole.Petitioner,
+
+        ["requested person"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+        ["requested persons"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+
+        ["requesting state"] = PartyRole.RequestingState,
+
         ["(RESPONDENT)"] = PartyRole.Respondent,
         ["(RESPONDENTS)"] = PartyRole.Respondent,
+        ["1st Respondent"] = PartyRole.Respondent,
+        ["2nd Respondent"] = PartyRole.Respondent,
+        ["3rd Respondent"] = PartyRole.Respondent, // EWCA/Civ/2012/378
+        ["Claimant / Respondent"] = PartyRole.Respondent,
+        ["Claimant/ Respondent"] = PartyRole.Respondent,
+        ["Claimant/Respondent"] = PartyRole.Respondent,
+        ["Claimants/Respondents"] = PartyRole.Respondent,
+        ["Clamaints/ Respondents"] = PartyRole.Respondent,
+        ["Defendant / Respondent"] = PartyRole.Respondent,
+        ["Defendant/ Respondent"] = PartyRole.Respondent,
         ["Defendant/Respondent"] = PartyRole.Respondent,
+        ["Defendants/ Respondents"] = PartyRole.Respondent,
         ["Defendants/Respondents"] = PartyRole.Respondent,
         ["First Respondent"] = PartyRole.Respondent,
-        ["Respondent"] = PartyRole.Respondent,
+        ["Fourth Respondent"] = PartyRole.Respondent,
+        ["Petitioner/Respondent"] = PartyRole.Respondent,
+        ["Respond-ents/ Defendants"] = PartyRole.Respondent,
+        ["Respondent / Defendant"] = PartyRole.Respondent,
+        ["Respondent"] = PartyRole.Respondent, // EWCA/Civ/2003/1686
+        ["Respondent/ Claimant"] = PartyRole.Respondent,
+        ["Respondent/ First Defendant"] = PartyRole.Respondent,
+        ["Respondent/Claimant"] = PartyRole.Respondent,
+        ["Respondent/Defendants"] = PartyRole.Respondent,
+        ["Respondent/Petitioner"] = PartyRole.Respondent, // [2021] EWCA Civ 1792
         ["Respondent/Respondent"] = PartyRole.Respondent,
+        ["Respondents / Claimants"] = PartyRole.Respondent,
+        ["Respondents Second and Third/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2004/1249
         ["Respondents"] = PartyRole.Respondent,
-        ["Respondents/ Defendants"] = PartyRole.Respondent,
+        ["Respondents/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2015/377, EWHC/QB/2006/582
+        ["Respondents/Claimants"] = PartyRole.Respondent,
         ["Respondents/Defendants"] = PartyRole.Respondent,
         ["Respondents/Respondents"] = PartyRole.Respondent,
         ["Respondnet"] = PartyRole.Respondent, // EWHC/Admin/2010/3393
         ["Second Respondent"] = PartyRole.Respondent,
-
-        ["Claimant/ Respondent"] = PartyRole.Respondent,
-        ["Claimant/Respondent"] = PartyRole.Respondent,
-        ["Claimants/Respondents"] = PartyRole.Respondent,
-        ["Respondent"] = PartyRole.Respondent, // EWCA/Civ/2003/1686
-        ["Respondent/Claimant"] = PartyRole.Respondent,
-
-        ["Petitioner"] = PartyRole.Petitioner
+        ["Third Respondent"] = PartyRole.Respondent,
     };
 
     private static bool IsPartyRole(string s)
@@ -1407,7 +1453,7 @@ internal class PartyEnricher : Enricher
                                .ToArray();
         switch (lineContents)
         {
-            case [var one] when TryGetOneLinePartyRole(one, out role):
+            case [var one] when TryGetPartyRole(one, out role):
                 return true;
 
             case ["defendant/", var two] when two.EndsWith("claimant"): // EWHC/Ch/2008/2079
@@ -1457,8 +1503,8 @@ internal class PartyEnricher : Enricher
     {
         var linesWithContent = cell.Contents.OfType<WLine>().Where(LineHasContent).ToArray();
         if (linesWithContent.Length == 2
-            && TryGetOneLinePartyRole(linesWithContent[0].NormalizedContent, out var role1)
-            && TryGetOneLinePartyRole(linesWithContent[1].NormalizedContent, out var role2)
+            && TryGetPartyRole(linesWithContent[0].NormalizedContent, out var role1)
+            && TryGetPartyRole(linesWithContent[1].NormalizedContent, out var role2)
             && role1 != role2)
         {
             roles = (role1, role2);
@@ -1478,109 +1524,6 @@ internal class PartyEnricher : Enricher
                                                        [
                                                            new WRole { Role = role, Contents = line.Contents }
                                                        ])));
-    }
-
-    private static readonly Dictionary<string, PartyRole> OneLinePartyRoleLabels = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Appellant"] = PartyRole.Appellant,
-        ["Appellants"] = PartyRole.Appellant,
-        ["Defendant/Appellant"] = PartyRole.Appellant,
-        ["Defendant/ Appellant"] = PartyRole.Appellant,
-        ["Defendants/Appellants"] = PartyRole.Appellant,
-        ["Appellants / Defendants"] = PartyRole.Appellant,
-        ["Defendants/Appellants/"] = PartyRole.Appellant,
-        ["Appellant/ Defendant"] = PartyRole.Appellant,
-        ["Appellants/Claimants"] = PartyRole.Appellant,
-        ["Appellants/ Claimants"] = PartyRole.Appellant,
-        ["Claimant/Appellant"] = PartyRole.Appellant,
-        ["Claimant/ Appellant"] = PartyRole.Appellant,
-        ["Claimant / Appellant"] = PartyRole.Appellant,
-        ["Appellant / Claimant"] = PartyRole.Appellant,
-        ["Appellant / Third Defendant"] = PartyRole.Appellant,
-        ["1st Appellant"] = PartyRole.Appellant,
-        ["Respondent/Appellant"] = PartyRole.Appellant,
-        ["Defendants/ Appellants"] = PartyRole.Appellant,
-        ["Appellant/ Respondent"] = PartyRole.Appellant, // [2021] EWCA Civ 1792
-        ["Claimants/ Appellants"] = PartyRole.Appellant,
-        ["Claimants/Appellants"] = PartyRole.Appellant, // [2021] EWCA Civ 1799
-        ["Appellant/Applicant"] = PartyRole.Appellant, // [2021] EWCA Crim 1877
-
-        ["Applicant"] = PartyRole.Applicant,
-        ["Applicants"] = PartyRole.Applicant,
-        ["Respondent/Applicant"] = PartyRole.Applicant,
-        ["Applicants/Claimants"] = PartyRole.Applicant,
-        ["Applicant/ Claimant"] = PartyRole.Applicant,
-        ["Claimant/Applicant"] = PartyRole.Applicant,
-        ["Defendant/ Applicant"] = PartyRole.Applicant,
-        ["1st Applicant"] = PartyRole.Applicant,
-        ["2nd Applicant"] = PartyRole.Applicant,
-
-        ["Claimant"] = PartyRole.Claimant,
-        ["Claimants"] = PartyRole.Claimant,
-        ["Claimant/Part 20 Defendant"] = PartyRole.Claimant,
-        ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
-        ["Additional Claimant"] = PartyRole.Claimant,
-
-        ["Defendant"] = PartyRole.Defendant,
-        ["Defendants"] = PartyRole.Defendant,
-        ["Defendant/Part 20 Claimant"] = PartyRole.Defendant,
-        ["First Defendant"] = PartyRole.Defendant,
-        ["Second Defendant"] = PartyRole.Defendant,
-        ["Third Defendant"] = PartyRole.Defendant,
-        ["Defendant / Counterclaimant"] = PartyRole.Defendant,
-
-        ["Interested Party"] = PartyRole.InterestedParty,
-        ["Interested parties"] = PartyRole.InterestedParty,
-
-        ["intervener"] = PartyRole.Intervener,
-        ["interveners"] = PartyRole.Intervener,
-
-        ["Petitioner"] = PartyRole.Petitioner,
-        ["Petitioners"] = PartyRole.Petitioner,
-
-        ["requested person"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
-        ["requested persons"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
-
-        ["requesting state"] = PartyRole.RequestingState,
-
-        ["Respondent"] = PartyRole.Respondent,
-        ["Respondents"] = PartyRole.Respondent,
-
-        ["Claimant/Respondent"] = PartyRole.Respondent,
-        ["Claimant/ Respondent"] = PartyRole.Respondent,
-        ["Claimant / Respondent"] = PartyRole.Respondent,
-        ["Clamaints/ Respondents"] = PartyRole.Respondent,
-        ["Respondent/Claimant"] = PartyRole.Respondent,
-        ["Respondent/ Claimant"] = PartyRole.Respondent,
-        ["Defendant/Respondent"] = PartyRole.Respondent,
-        ["Defendant/ Respondent"] = PartyRole.Respondent,
-        ["Defendant / Respondent"] = PartyRole.Respondent,
-        ["Defendants/Respondents"] = PartyRole.Respondent,
-        ["Defendants/ Respondents"] = PartyRole.Respondent,
-        ["Petitioner/Respondent"] = PartyRole.Respondent,
-        ["First Respondent"] = PartyRole.Respondent,
-        ["Second Respondent"] = PartyRole.Respondent,
-        ["Third Respondent"] = PartyRole.Respondent,
-        ["Fourth Respondent"] = PartyRole.Respondent,
-        ["1st Respondent"] = PartyRole.Respondent,
-        ["2nd Respondent"] = PartyRole.Respondent,
-        ["3rd Respondent"] = PartyRole.Respondent, // EWCA/Civ/2012/378
-        ["Respondents/Defendants"] = PartyRole.Respondent,
-        ["Respond-ents/ Defendants"] = PartyRole.Respondent,
-        ["Respondents/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2015/377, EWHC/QB/2006/582
-        ["Respondent/Defendants"] = PartyRole.Respondent,
-        ["Respondent / Defendant"] = PartyRole.Respondent,
-        ["Respondents Second and Third/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2004/1249
-        ["Respondent/Petitioner"] = PartyRole.Respondent, // [2021] EWCA Civ 1792
-        ["Respondents/Claimants"] = PartyRole.Respondent,
-        ["Respondents / Claimants"] = PartyRole.Respondent,
-        ["Respondent/ First Defendant"] = PartyRole.Respondent
-    };
-
-    private static bool TryGetOneLinePartyRole(string lineNormalizedContent, out PartyRole role)
-    {
-        return OneLinePartyRoleLabels.TryGetValue(lineNormalizedContent, out role)
-            || TryGetPartyRole(lineNormalizedContent, out role);
     }
 
     private static readonly Dictionary<(string one, string two), PartyRole> TwoLinePartyRoles =
@@ -2131,7 +2074,7 @@ internal class PartyEnricher : Enricher
             s = s.Substring(s.IndexOf(' ') + 1);
         }
 
-        return OneLinePartyRoleLabels.TryGetValue(s, out role);
+        return PartyRoles.TryGetValue(s, out role);
     }
 
     private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1595,7 +1595,16 @@ internal class PartyEnricher : Enricher
         ["Interested Party"] = PartyRole.InterestedParty,
         ["Interested parties"] = PartyRole.InterestedParty,
 
+        ["intervener"] = PartyRole.Intervener,
+        ["interveners"] = PartyRole.Intervener,
+
         ["Petitioner"] = PartyRole.Petitioner,
+        ["Petitioners"] = PartyRole.Petitioner,
+
+        ["requested person"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+        ["requested persons"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
+
+        ["requesting state"] = PartyRole.RequestingState,
 
         ["Respondent"] = PartyRole.Respondent,
         ["Respondents"] = PartyRole.Respondent,
@@ -2166,38 +2175,6 @@ internal class PartyEnricher : Enricher
         "Inquiry " // [2022] EWHC 189 (Pat)
     ];
 
-    private static readonly Dictionary<string, PartyRole> SingleLabelPartyRoles = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["appellant"] = PartyRole.Appellant,
-        ["appellants"] = PartyRole.Appellant,
-
-        ["applicant"] = PartyRole.Applicant,
-        ["applicants"] = PartyRole.Applicant,
-
-        ["claimant"] = PartyRole.Claimant,
-        ["claimants"] = PartyRole.Claimant,
-
-        ["defendant"] = PartyRole.Defendant,
-        ["defendants"] = PartyRole.Defendant,
-
-        ["petitioner"] = PartyRole.Petitioner,
-        ["petitioners"] = PartyRole.Petitioner,
-
-        ["respondent"] = PartyRole.Respondent,
-        ["respondents"] = PartyRole.Respondent,
-
-        ["interested party"] = PartyRole.InterestedParty,
-        ["interested parties"] = PartyRole.InterestedParty,
-
-        ["intervener"] = PartyRole.Intervener,
-        ["interveners"] = PartyRole.Intervener,
-
-        ["requested person"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
-        ["requested persons"] = PartyRole.RequestedPerson, // [2022] EWHC 273 (Admin)
-
-        ["requesting state"] = PartyRole.RequestingState
-    };
-
     private static bool TryGetPartyRoleForSingleLabel(string s, out PartyRole role)
     {
         s = Regex.Replace(s, @"\s+", " ").Trim(' ', '/', '(', ')');
@@ -2217,7 +2194,7 @@ internal class PartyEnricher : Enricher
             s = s.Substring(s.IndexOf(' ') + 1);
         }
 
-        return SingleLabelPartyRoles.TryGetValue(s, out role);
+        return OneLinePartyRoleLabels.TryGetValue(s, out role);
     }
 
     private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -255,7 +255,7 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        if (!TryEnrichFirstPartyGroup(rest[i..], out var firstGroupOfParites))
+        if (!TryEnrichPartyNamesWithRoleLabel(rest[i..], out var firstGroupOfParites))
         {
             return false;
         }
@@ -281,7 +281,7 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        if (!TryEnrichSecondPartyGroup(rest[i..], out var secondGroupOfParites))
+        if (!TryEnrichPartyNamesWithRoleLabel(rest[i..], out var secondGroupOfParites))
         {
             return false;
         }
@@ -307,13 +307,13 @@ internal class PartyEnricher : Enricher
             _ = rest[i];
         }
 
-        if (TryEnrichSecondPartyGroup(rest[i..], out var thirdGroupOfParites))
+        if (TryEnrichPartyNamesWithRoleLabel(rest[i..], out var thirdGroupOfParites))
         {
             result.AddRange(thirdGroupOfParites);
             i += thirdGroupOfParites.Count;
         }
 
-        if (TryEnrichSecondPartyGroup(rest[i..], out var fourthGroupOfParites))
+        if (TryEnrichPartyNamesWithRoleLabel(rest[i..], out var fourthGroupOfParites))
         {
             result.AddRange(fourthGroupOfParites);
             i += fourthGroupOfParites.Count;
@@ -465,7 +465,7 @@ internal class PartyEnricher : Enricher
 
         result.Add(line);
         i += 1;
-        if (!TryEnrichFirstPartyGroup(rest[i..], out var firstGroupOfParites))
+        if (!TryEnrichPartyNamesWithRoleLabel(rest[i..], out var firstGroupOfParites))
         {
             return false;
         }
@@ -492,7 +492,7 @@ internal class PartyEnricher : Enricher
         }
 
         _ = rest[i];
-        if (!TryEnrichFirstPartyGroup(rest[i..], out var secondGroupOfParites))
+        if (!TryEnrichPartyNamesWithRoleLabel(rest[i..], out var secondGroupOfParites))
         {
             return false;
         }
@@ -519,7 +519,7 @@ internal class PartyEnricher : Enricher
         }
 
         _ = rest[i];
-        if (!TryEnrichSecondPartyGroup(rest[i..], out var thirdGroupOfParites))
+        if (!TryEnrichPartyNamesWithRoleLabel(rest[i..], out var thirdGroupOfParites))
         {
             return false;
         }
@@ -542,14 +542,9 @@ internal class PartyEnricher : Enricher
         return false;
     }
 
-    private static bool TryEnrichFirstPartyGroup(IBlock[] rest, out List<IBlock> enriched)
+    private static bool TryEnrichPartyNamesWithRoleLabel(IBlock[] rest, out List<IBlock> enriched)
     {
-        return TryEnrichPartyNamesWithRoleLabel(rest, IsFirstPartyType, GetFirstPartyRole, out enriched);
-    }
-
-    private static bool TryEnrichSecondPartyGroup(IBlock[] rest, out List<IBlock> enriched)
-    {
-        return TryEnrichPartyNamesWithRoleLabel(rest, IsSecondPartyType, GetSecondPartyRole, out enriched);
+        return TryEnrichPartyNamesWithRoleLabel(rest, IsPartyRole, GetPartyRole, out enriched);
     }
 
     private static bool TryEnrichPartyNamesWithRoleLabel(IBlock[] rest, Func<WLine, bool> test,
@@ -735,8 +730,7 @@ internal class PartyEnricher : Enricher
             || IsBetweenPartyMarker(line)
             || IsBetweenPartyMarker2(line)
             || IsAfterPartyMarker(line)
-            || IsFirstPartyType(line)
-            || IsSecondPartyType(line))
+            || IsPartyRole(line))
         {
             return false;
         }
@@ -941,85 +935,108 @@ internal class PartyEnricher : Enricher
         return WLine.Make(line, [new WRole { Role = role, Contents = line.Contents }]);
     }
 
-    private static bool IsAnyPartyType(string s)
+    private static readonly Dictionary<string, PartyRole> PartyRoles = new(StringComparer.OrdinalIgnoreCase)
     {
-        if (IsFirstPartyType(s))
-        {
-            return true;
-        }
+        ["(APPELLANT)"] = PartyRole.Appellant,
+        ["(APPELLANTS)"] = PartyRole.Appellant,
+        ["Appellant"] = PartyRole.Appellant,
+        ["Appellant"] = PartyRole.Appellant, // EWCA/Civ/2003/1686
+        ["Appellant/Appellant"] = PartyRole.Appellant,
+        ["Appellant/Applicant"] = PartyRole.Appellant,
+        ["Appellant/Claimant"] = PartyRole.Appellant,
+        ["Appellant/Defendant"] = PartyRole.Appellant,
+        ["Appellant/First Defendant"] = PartyRole.Appellant,
+        ["Appellants/ Claimants"] = PartyRole.Appellant,
+        ["Applicant/Appellant"] = PartyRole.Appellant,
+        ["Claimant/Appellant"] = PartyRole.Appellant,
+        ["Claimants/Appellants"] = PartyRole.Appellant,
+        ["Defendant/Appellant"] = PartyRole.Appellant,
+        ["Defendants / Appellants"] = PartyRole.Appellant,
+        ["Defendants/Appellants"] = PartyRole.Appellant,
+        ["FIRST DEFENDANT’S SOLICITOR/APPELLANT"] = PartyRole.Appellant, // EWCA/Civ/2006/1032
+        ["Third Party/Appellant"] = PartyRole.Appellant, // [2022] EWHC 34 (Ch)
 
-        if (IsSecondPartyType(s))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static readonly Dictionary<string, PartyRole> FirstPartyTypeRoles = new(StringComparer.OrdinalIgnoreCase)
-    {
         ["Applicant"] = PartyRole.Applicant,
         ["Applicants"] = PartyRole.Applicant,
         ["Claimant/Applicant"] = PartyRole.Applicant,
 
-        ["Appellant"] = PartyRole.Appellant,
-        ["(APPELLANT)"] = PartyRole.Appellant,
-        ["(APPELLANTS)"] = PartyRole.Appellant,
-        ["Appellant/Appellant"] = PartyRole.Appellant,
-        ["Applicant/Appellant"] = PartyRole.Appellant,
-        ["Appellant/Applicant"] = PartyRole.Appellant,
-        ["Appellant/Claimant"] = PartyRole.Appellant,
-        ["Appellants/ Claimants"] = PartyRole.Appellant,
-        ["Claimant/Appellant"] = PartyRole.Appellant,
-        ["Claimants/Appellants"] = PartyRole.Appellant,
-
-        ["Claimant"] = PartyRole.Claimant,
-        ["Claimants"] = PartyRole.Claimant,
-        ["(Claimant)"] = PartyRole.Claimant,
         ["(CLAIMANTS)"] = PartyRole.Claimant,
+        ["(Claimant)"] = PartyRole.Claimant,
+        ["Additional Claimant"] = PartyRole.Claimant,
+        ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
+        ["Claimant"] = PartyRole.Claimant,
         ["Claimant/part 20 Defendant"] = PartyRole.Claimant,
+        ["Claimants"] = PartyRole.Claimant,
         ["First Claimant"] = PartyRole.Claimant,
         ["Second Claimant"] = PartyRole.Claimant,
-        ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
 
-        ["Claimant/Respondent"] = PartyRole.Respondent,
+        ["(1st DEFENDANT)"] = PartyRole.Defendant,
+        ["(2nd DEFENDANT)"] = PartyRole.Defendant,
+        ["(3rd DEFENDANT)"] = PartyRole.Defendant,
+        ["(DEFENDANTS)"] = PartyRole.Defendant,
+        ["(Defendant)"] = PartyRole.Defendant,
+        ["(FIRST DEFENDANT)"] = PartyRole.Defendant,
+        ["(SECOND DEFENDANT)"] = PartyRole.Defendant,
+        ["Applicants/Defendants"] = PartyRole.Defendant,
+        ["Defendant / Counterclaimant"] = PartyRole.Defendant,
+        ["Defendant"] = PartyRole.Defendant,
+        ["Defendant/Part 20 Claimant"] = PartyRole.Defendant,
+        ["Defendants"] = PartyRole.Defendant,
+        ["First Defendant"] = PartyRole.Defendant,
+        ["Second Defendant"] = PartyRole.Defendant,
+
+        ["(INTERESTED PARTIES)"] = PartyRole.InterestedParty,
+        ["(INTERESTED PARTY)"] = PartyRole.InterestedParty,
+        ["Interested Parties"] = PartyRole.InterestedParty,
+        ["Interested Party"] = PartyRole.InterestedParty,
+        ["Second Interested Party"] = PartyRole.InterestedParty,
+        ["Third Interested Party"] = PartyRole.InterestedParty,
+
+        ["Intervener"] = PartyRole.Intervener,
+        ["Interveners"] = PartyRole.Intervener,
+
+        ["(RESPONDENT)"] = PartyRole.Respondent,
+        ["(RESPONDENTS)"] = PartyRole.Respondent,
+        ["Defendant/Respondent"] = PartyRole.Respondent,
+        ["Defendants/Respondents"] = PartyRole.Respondent,
+        ["First Respondent"] = PartyRole.Respondent,
+        ["Respondent"] = PartyRole.Respondent,
+        ["Respondent/Respondent"] = PartyRole.Respondent,
+        ["Respondents"] = PartyRole.Respondent,
+        ["Respondents/ Defendants"] = PartyRole.Respondent,
+        ["Respondents/Defendants"] = PartyRole.Respondent,
+        ["Respondents/Respondents"] = PartyRole.Respondent,
+        ["Respondnet"] = PartyRole.Respondent, // EWHC/Admin/2010/3393
+        ["Second Respondent"] = PartyRole.Respondent,
+
         ["Claimant/ Respondent"] = PartyRole.Respondent,
-        ["Respondent/Claimant"] = PartyRole.Respondent,
+        ["Claimant/Respondent"] = PartyRole.Respondent,
         ["Claimants/Respondents"] = PartyRole.Respondent,
         ["Respondent"] = PartyRole.Respondent, // EWCA/Civ/2003/1686
+        ["Respondent/Claimant"] = PartyRole.Respondent,
 
         ["Petitioner"] = PartyRole.Petitioner
     };
 
-    private static bool IsFirstPartyType(string s)
+    private static bool IsPartyRole(string s)
     {
-        return FirstPartyTypeRoles.ContainsKey(s) || TryGetPartyRole(s, out _);
+        return PartyRoles.ContainsKey(s) || TryGetPartyRole(s, out _);
     }
 
-    private static bool IsFirstPartyType(WLine line)
+    private static bool IsPartyRole(WLine line)
     {
         var normalized = line.NormalizedContent;
-        return IsFirstPartyType(normalized);
+        return IsPartyRole(normalized);
     }
 
     private static PartyRole GetAnyPartyRole(string s)
     {
-        if (IsFirstPartyType(s))
-        {
-            return GetFirstPartyRole(s);
-        }
-
-        if (IsSecondPartyType(s))
-        {
-            return GetSecondPartyRole(s);
-        }
-
-        throw new Exception();
+        return IsPartyRole(s) ? GetPartyRole(s) : throw new Exception();
     }
 
-    private static PartyRole GetFirstPartyRole(string s)
+    private static PartyRole GetPartyRole(string s)
     {
-        if (FirstPartyTypeRoles.TryGetValue(s, out var role))
+        if (PartyRoles.TryGetValue(s, out var role))
         {
             return role;
         }
@@ -1027,10 +1044,10 @@ internal class PartyEnricher : Enricher
         return TryGetPartyRole(s, out role) ? role : throw new Exception();
     }
 
-    private static PartyRole GetFirstPartyRole(WLine line)
+    private static PartyRole GetPartyRole(WLine line)
     {
         var normalized = line.NormalizedContent;
-        return GetFirstPartyRole(normalized);
+        return GetPartyRole(normalized);
     }
 
     private static bool IsPartyNameAndRole(WLine line)
@@ -1060,7 +1077,7 @@ internal class PartyEnricher : Enricher
             }
 
             var s = Regex.Replace(wText2.Text, @"\s+", " ").Trim();
-            if (!IsAnyPartyType(s))
+            if (!IsPartyRole(s))
             {
                 return false;
             }
@@ -1107,86 +1124,6 @@ internal class PartyEnricher : Enricher
     {
         var normalized = line.NormalizedContent;
         return IsAnd(normalized);
-    }
-
-    private static readonly Dictionary<string, PartyRole> SecondPartyTypeRoles = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Defendant/Appellant"] = PartyRole.Appellant,
-        ["Defendants/Appellants"] = PartyRole.Appellant,
-        ["Defendants / Appellants"] = PartyRole.Appellant,
-        ["Appellant/Defendant"] = PartyRole.Appellant,
-        ["Appellant/First Defendant"] = PartyRole.Appellant,
-        ["Appellant"] = PartyRole.Appellant, // EWCA/Civ/2003/1686
-        ["FIRST DEFENDANT’S SOLICITOR/APPELLANT"] = PartyRole.Appellant, // EWCA/Civ/2006/1032
-        ["Third Party/Appellant"] = PartyRole.Appellant, // [2022] EWHC 34 (Ch)
-
-        ["Additional Claimant"] = PartyRole.Claimant,
-
-        ["Defendant"] = PartyRole.Defendant,
-        ["Defendants"] = PartyRole.Defendant,
-        ["(Defendant)"] = PartyRole.Defendant,
-        ["(DEFENDANTS)"] = PartyRole.Defendant,
-        ["Defendant/Part 20 Claimant"] = PartyRole.Defendant,
-        ["First Defendant"] = PartyRole.Defendant,
-        ["Second Defendant"] = PartyRole.Defendant,
-        ["(FIRST DEFENDANT)"] = PartyRole.Defendant,
-        ["(SECOND DEFENDANT)"] = PartyRole.Defendant,
-        ["(1st DEFENDANT)"] = PartyRole.Defendant,
-        ["(2nd DEFENDANT)"] = PartyRole.Defendant,
-        ["(3rd DEFENDANT)"] = PartyRole.Defendant,
-        ["Applicants/Defendants"] = PartyRole.Defendant,
-        ["Defendant / Counterclaimant"] = PartyRole.Defendant,
-
-        ["Interested Party"] = PartyRole.InterestedParty,
-        ["Interested Parties"] = PartyRole.InterestedParty,
-        ["(INTERESTED PARTY)"] = PartyRole.InterestedParty,
-        ["(INTERESTED PARTIES)"] = PartyRole.InterestedParty,
-        ["Second Interested Party"] = PartyRole.InterestedParty,
-        ["Third Interested Party"] = PartyRole.InterestedParty,
-
-        ["Intervener"] = PartyRole.Intervener,
-        ["Interveners"] = PartyRole.Intervener,
-
-        ["Respondent"] = PartyRole.Respondent,
-        ["Respondents"] = PartyRole.Respondent,
-        ["(RESPONDENT)"] = PartyRole.Respondent,
-        ["(RESPONDENTS)"] = PartyRole.Respondent,
-        ["Defendant/Respondent"] = PartyRole.Respondent,
-        ["Defendants/Respondents"] = PartyRole.Respondent,
-        ["Respondent/Respondent"] = PartyRole.Respondent,
-        ["Respondents/Respondents"] = PartyRole.Respondent,
-        ["Respondents/Defendants"] = PartyRole.Respondent,
-        ["Respondents/ Defendants"] = PartyRole.Respondent,
-        ["Respondnet"] = PartyRole.Respondent, // EWHC/Admin/2010/3393
-        ["First Respondent"] = PartyRole.Respondent,
-        ["Second Respondent"] = PartyRole.Respondent
-    };
-
-    private static bool IsSecondPartyType(string s)
-    {
-        return SecondPartyTypeRoles.ContainsKey(s) || TryGetPartyRole(s, out _);
-    }
-
-    private static bool IsSecondPartyType(WLine line)
-    {
-        var normalized = line.NormalizedContent;
-        return IsSecondPartyType(normalized);
-    }
-
-    private static PartyRole GetSecondPartyRole(string s)
-    {
-        if (SecondPartyTypeRoles.TryGetValue(s, out var role))
-        {
-            return role;
-        }
-
-        return TryGetPartyRole(s, out role) ? role : throw new Exception();
-    }
-
-    private static PartyRole GetSecondPartyRole(WLine line)
-    {
-        var normalized = line.NormalizedContent;
-        return GetSecondPartyRole(normalized);
     }
 
     private static bool IsAfterPartyMarker(WLine line)
@@ -1375,7 +1312,7 @@ internal class PartyEnricher : Enricher
         var middle2 = rows[1].TypedCells[1];
         var middle3 = rows[2].TypedCells[1];
         if (!middle1.Contents.All(block => block is WLine line &&
-                                           (IsEmptyLine(line) || (IsPartyName(line) && !IsFirstPartyType(line)))))
+                                           (IsEmptyLine(line) || (IsPartyName(line) && !IsPartyRole(line)))))
         {
             return false;
         }
@@ -1393,7 +1330,7 @@ internal class PartyEnricher : Enricher
         }
 
         if (!middle3.Contents.All(block => block is WLine line &&
-                                           (IsEmptyLine(line) || (IsPartyName(line) && !IsSecondPartyType(line)))))
+                                           (IsEmptyLine(line) || (IsPartyName(line) && !IsPartyRole(line)))))
         {
             return false;
         }


### PR DESCRIPTION
There were several party role collections which were used in similar scenarios and sometimes as fallbacks for each other but there was no logic that required them to be held separately. This PR merges these collections together so there's only one place that needs updating should a new variant be found