### PR TITLE
FCLC-431: Simplify party role identification

### DIFF
--- a/src/api/Parser.cs
+++ b/src/api/Parser.cs
@@ -95,6 +95,20 @@ public class Parser(ILogger<Parser> logger, AkN.IValidator validator) : IParser
             var preParsed = new PreParser().Parse(doc);
             var attach2 = AkN.Parser.ConvertAttachments(attachments);
             IJudgment judgment = f(doc, preParsed, meta, attach2);
+
+            //** HACK - suppress misidentified parties by calling `CaseName.Extract` **
+            // For KBD and QBD cases, the king/queen and "on the application of" pieces of text are misidentified as
+            // their own parties.
+            // On a clean parse of the document, we create a case name which uses these misidentified parties to decide
+            // whether or not to add "(R on the application of)" to the case name and then "suppresses" these
+            // misidentified parties so they are not output in the xml.
+            // On a reparse of the document we are supplied with a case name via the outside metadata so we don't
+            // attempt to generate one. This means that the misidentified king/queen and "on the application of" parties
+            // are never suppressed on reparse and so incorrectly end up in the final xml.
+            // This hack fixes this issue by ensuring that the case name generation (and thus the misidentified party
+            // suppression) is always called.
+            _ = CaseName.Extract(judgment);
+
             return new AkN.Bundle(doc, judgment);
         };
     }

--- a/src/api/Parser.cs
+++ b/src/api/Parser.cs
@@ -1,35 +1,31 @@
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml;
 using System.Xml.Schema;
-
-using DocumentFormat.OpenXml.Packaging;
 
 using Microsoft.Extensions.Logging;
 
 using UK.Gov.Legislation.Judgments;
-using UK.Gov.NationalArchives.CaseLaw.Parse;
-using AkN = UK.Gov.Legislation.Judgments.AkomaNtoso;
-using PS = UK.Gov.NationalArchives.CaseLaw.PressSummaries;
-
-using AttachmentPair = System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>;
-using ParseFunction = System.Func<byte[], UK.Gov.Legislation.Judgments.IOutsideMetadata, System.Collections.Generic.IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>>, UK.Gov.Legislation.Judgments.AkomaNtoso.ILazyBundle>;
-
-using AttachmentPair1 = System.Tuple<DocumentFormat.OpenXml.Packaging.WordprocessingDocument, UK.Gov.Legislation.Judgments.AttachmentType>;
-using OptimizedParseFunction = System.Func<DocumentFormat.OpenXml.Packaging.WordprocessingDocument, UK.Gov.NationalArchives.CaseLaw.Parse.WordDocument, UK.Gov.Legislation.Judgments.IOutsideMetadata, System.Collections.Generic.IEnumerable<System.Tuple<DocumentFormat.OpenXml.Packaging.WordprocessingDocument, UK.Gov.Legislation.Judgments.AttachmentType>>, UK.Gov.Legislation.Judgments.Parse.Judgment>;
 using UK.Gov.Legislation.Judgments.Parse;
+using UK.Gov.NationalArchives.CaseLaw.Parse;
+
+using AkN = UK.Gov.Legislation.Judgments.AkomaNtoso;
+using AttachmentPair = System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>;
+using OptimizedParseFunction = System.Func<DocumentFormat.OpenXml.Packaging.WordprocessingDocument,
+    UK.Gov.NationalArchives.CaseLaw.Parse.WordDocument, UK.Gov.Legislation.Judgments.IOutsideMetadata, System.Collections.Generic.IEnumerable<System.Tuple<DocumentFormat.OpenXml.Packaging.WordprocessingDocument,
+        UK.Gov.Legislation.Judgments.AttachmentType>>, UK.Gov.Legislation.Judgments.Parse.Judgment>;
+using ParseFunction = System.Func<byte[], UK.Gov.Legislation.Judgments.IOutsideMetadata, System.Collections.Generic.IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>>,
+    UK.Gov.Legislation.Judgments.AkomaNtoso.ILazyBundle>;
+using PS = UK.Gov.NationalArchives.CaseLaw.PressSummaries;
 
 namespace UK.Gov.NationalArchives.Judgments.Api;
 
 public enum Hint { UKSC, EWCA, EWHC, UKUT, Judgment, PressSummary }
 
-public class InvalidAkNException : Exception {
-
-    public InvalidAkNException(ValidationEventArgs cause) : base(cause.Message, cause.Exception) { }
-}
+public class InvalidAkNException(ValidationEventArgs cause) : Exception(cause.Message, cause.Exception);
 
 public interface IParser
 {
@@ -39,200 +35,274 @@ public interface IParser
 public class Parser(ILogger<Parser> logger, AkN.IValidator validator) : IParser
 {
     /// <exception cref="InvalidAkNException"></exception>
-    public Response Parse(Request request) {
-
+    public Response Parse(Request request)
+    {
         if (request.Filename is not null)
-            logger.LogInformation($"parsing { request.Filename }");
+        {
+            logger.LogInformation("parsing {RequestFilename}", request.Filename);
+        }
 
-        ParseFunction parse = GetParser(request.Hint);
+        var parse = GetParser(request.Hint);
 
-        IOutsideMetadata meta1 = (request.Meta is null) ? null : new MetaWrapper() { Meta = request.Meta };
-        IEnumerable<AttachmentPair> attachments = (request.Attachments is null) ? Enumerable.Empty<AttachmentPair>() : request.Attachments.Select(a => ConvertAttachment(a));
+        IOutsideMetadata meta1 = request.Meta is null ? null : new MetaWrapper { Meta = request.Meta };
+        var attachments = request.Attachments is null
+            ? Enumerable.Empty<AttachmentPair>()
+            : request.Attachments.Select(a => new AttachmentPair(a.Content, MapAttachmentType(a.Type)));
 
-        AkN.ILazyBundle bundle = parse(request.Content, meta1, attachments);
+        var bundle = parse(request.Content, meta1, attachments);
 
-        List<ValidationEventArgs> errors = validator.Validate(bundle.Judgment);
+        var errors = validator.Validate(bundle.Judgment);
         if (errors.Any())
+        {
             throw new InvalidAkNException(errors.First());
+        }
 
-        string xml = SerializeXml(bundle.Judgment);
-        AkN.Meta aknMetadata = AkN.MetadataExtractor.Extract(bundle.Judgment);
-        Meta meta2 = ConvertInternalMetadata(aknMetadata);
+        var xml = SerializeXml(bundle.Judgment);
+        var aknMetadata = AkN.MetadataExtractor.Extract(bundle.Judgment);
+        var meta2 = ConvertInternalMetadata(aknMetadata);
         Log(meta2);
-        List<Image> images = bundle.Images.Select(i => ConvertImage(i)).ToList();
+        var images = bundle.Images.Select(ConvertImage).ToList();
 
         bundle.Dispose();
 
-        return new Response() {
+        return new Response
+        {
             Xml = xml,
             Meta = meta2,
             Images = images
         };
     }
 
-    private ParseFunction GetParser(Hint? hint) {
-        if (!hint.HasValue)
-            return JudgmentOrPressSummary;
-        if (hint.Value == Hint.Judgment)
-            return ParseAnyJudgment;
-        if (hint.Value == Hint.EWHC || hint.Value == Hint.EWCA)
-            return Wrap(OptimizedEWHCParser.Parse);
-        if (hint.Value == Hint.UKSC)
-            return Wrap(OptimizedUKSCParser.Parse);
-        if (hint.Value == Hint.UKUT)
-            return Wrap(OptimizedUKUTParser.Parse);
-        if (hint.Value == Hint.PressSummary)
-            return ParsePressSummary;
-        throw new Exception("unsupported hint: " + Enum.GetName(typeof(Hint), hint));
+    private ParseFunction GetParser(Hint? hint)
+    {
+        return hint switch
+        {
+            null => JudgmentOrPressSummary,
+            Hint.Judgment => ParseAnyJudgment,
+            Hint.EWHC or Hint.EWCA => Wrap(OptimizedEWHCParser.Parse),
+            Hint.UKSC => Wrap(OptimizedUKSCParser.Parse),
+            Hint.UKUT => Wrap(OptimizedUKUTParser.Parse),
+            Hint.PressSummary => ParsePressSummary,
+            _ => throw new ArgumentOutOfRangeException(nameof(hint), hint, "unsupported hint")
+        };
     }
 
-    private static ParseFunction Wrap(OptimizedParseFunction f) {
-        return (docx, meta, attachments) => {
-            WordprocessingDocument doc = AkN.Parser.Read(docx);
-            WordDocument preParsed = new PreParser().Parse(doc);
-            IEnumerable<AttachmentPair1> attach2 = AkN.Parser.ConvertAttachments(attachments);
+    private static ParseFunction Wrap(OptimizedParseFunction f)
+    {
+        return (docx, meta, attachments) =>
+        {
+            var doc = AkN.Parser.Read(docx);
+            var preParsed = new PreParser().Parse(doc);
+            var attach2 = AkN.Parser.ConvertAttachments(attachments);
             IJudgment judgment = f(doc, preParsed, meta, attach2);
             return new AkN.Bundle(doc, judgment);
         };
     }
 
-    private AkN.ILazyBundle ParseAnyJudgment(byte[] docx, IOutsideMetadata meta, IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>> attachments) {
-        WordprocessingDocument doc = AkN.Parser.Read(docx);
-        WordDocument preParsed = new PreParser().Parse(doc);
+    private AkN.ILazyBundle ParseAnyJudgment(byte[] docx, IOutsideMetadata meta,
+        IEnumerable<Tuple<byte[], Legislation.Judgments.AttachmentType>> attachments)
+    {
+        var doc = AkN.Parser.Read(docx);
+        var preParsed = new PreParser().Parse(doc);
         IJudgment judgment = BestJudgment(preParsed, meta, attachments);
         return new AkN.Bundle(doc, judgment);
     }
 
-    private Judgment BestJudgment(WordDocument preParsed, IOutsideMetadata meta, IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>> attachments) {
-        IEnumerable<AttachmentPair1> attach2 = AkN.Parser.ConvertAttachments(attachments);
+    private Judgment BestJudgment(WordDocument preParsed, IOutsideMetadata meta,
+        IEnumerable<Tuple<byte[], Legislation.Judgments.AttachmentType>> attachments)
+    {
+        var attach2 = AkN.Parser.ConvertAttachments(attachments);
         OptimizedParseFunction first = OptimizedEWHCParser.Parse;
-        List<OptimizedParseFunction> others = new List<OptimizedParseFunction>(2) {
-            OptimizedUKSCParser.Parse,
-            OptimizedUKUTParser.Parse
-        };
-        Judgment judgment1 = first(preParsed.Docx, preParsed, meta, attach2);
-        int score1 = Score(judgment1);
+        var others = new List<OptimizedParseFunction>(2) { OptimizedUKSCParser.Parse, OptimizedUKUTParser.Parse };
+        var judgment1 = first(preParsed.Docx, preParsed, meta, attach2);
+        var score1 = Score(judgment1);
         if (score1 == PerfectScore)
+        {
             return judgment1;
-        foreach (var other in others) {
-            Judgment judgment2 = other(preParsed.Docx, preParsed, meta, attach2);
-            int score2 = Score(judgment2);
+        }
+
+        foreach (var other in others)
+        {
+            var judgment2 = other(preParsed.Docx, preParsed, meta, attach2);
+            var score2 = Score(judgment2);
             if (score2 == PerfectScore)
+            {
                 return judgment2;
-            if (score2 > score1) {
+            }
+
+            if (score2 > score1)
+            {
                 judgment1 = judgment2;
                 score1 = score2;
             }
         }
+
         return judgment1;
     }
 
-    private AkN.ILazyBundle JudgmentOrPressSummary(byte[] docx, IOutsideMetadata meta, IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>> attachments) {
-        WordprocessingDocument doc = AkN.Parser.Read(docx);
-        WordDocument preParsed = new PreParser().Parse(doc);
+    private AkN.ILazyBundle JudgmentOrPressSummary(byte[] docx, IOutsideMetadata meta,
+        IEnumerable<Tuple<byte[], Legislation.Judgments.AttachmentType>> attachments)
+    {
+        var doc = AkN.Parser.Read(docx);
+        var preParsed = new PreParser().Parse(doc);
 
-        Judgment judgment = BestJudgment(preParsed, meta, attachments);
+        var judgment = BestJudgment(preParsed, meta, attachments);
         if (Score(judgment) == PerfectScore)
+        {
             return new AkN.Bundle(doc, judgment);
+        }
 
-        PS.PressSummary ps = PS.Parser.Parse(preParsed, meta);
+        var ps = PS.Parser.Parse(preParsed, meta);
         if (ps.InternalMetadata.DocType is not null)
+        {
             return new AkN.PSBundle(doc, ps);
+        }
 
         return new AkN.Bundle(doc, judgment);
     }
 
-    private static int PerfectScore = 7;
+    private static readonly int PerfectScore = 7;
 
-    private static int Score(Judgment judgment) {
-        int score = 0;
+    private static int Score(Judgment judgment)
+    {
+        var score = 0;
         if (judgment.Header is not null && judgment.Header.Any())
+        {
             score += 2;
+        }
+
         if (judgment.InternalMetadata.ShortUriComponent is not null)
+        {
             score += 1;
+        }
+
         if (judgment.InternalMetadata.Court is not null)
+        {
             score += 1;
+        }
+
         if (judgment.InternalMetadata.Cite is not null)
+        {
             score += 1;
+        }
+
         if (judgment.InternalMetadata.Date is not null)
+        {
             score += 1;
+        }
+
         if (judgment.InternalMetadata.Name is not null)
+        {
             score += 1;
+        }
+
         return score;
     }
 
-    private AkN.ILazyBundle ParsePressSummary(byte[] docx, IOutsideMetadata meta, IEnumerable<System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>> attachments) {
-        WordprocessingDocument doc = AkN.Parser.Read(docx);
-        PS.PressSummary ps = PS.Parser.Parse(doc, meta);
+    private AkN.ILazyBundle ParsePressSummary(byte[] docx, IOutsideMetadata meta,
+        IEnumerable<Tuple<byte[], Legislation.Judgments.AttachmentType>> attachments)
+    {
+        var doc = AkN.Parser.Read(docx);
+        var ps = PS.Parser.Parse(doc, meta);
         return new AkN.PSBundle(doc, ps);
     }
 
-    /* */
-
-    internal static string SerializeXml(XmlDocument judgment) {
-        using MemoryStream memStrm = new MemoryStream();
+    internal static string SerializeXml(XmlDocument judgment)
+    {
+        using var memStrm = new MemoryStream();
         AkN.Serializer.Serialize(judgment, memStrm);
-        return System.Text.Encoding.UTF8.GetString(memStrm.ToArray());
+        return Encoding.UTF8.GetString(memStrm.ToArray());
     }
 
-    internal static Meta ConvertInternalMetadata(UK.Gov.Legislation.Judgments.AkomaNtoso.Meta meta) {
-        return new Meta() {
+    internal static Meta ConvertInternalMetadata(AkN.Meta meta)
+    {
+        return new Meta
+        {
             DocumentType = meta.DocElementName,
             Uri = URI.IsEmpty(meta.WorkUri) ? null : meta.WorkUri,
             Court = meta.UKCourt,
             Cite = meta.UKCite,
             Date = meta.WorkDate,
             Name = meta.WorkName,
-            Attachments = meta.ExternalAttachments.Select(a => new ExternalAttachment() { Name = a.ShowAs, Link = a.Href })
+            Attachments =
+                meta.ExternalAttachments.Select(a => new ExternalAttachment { Name = a.ShowAs, Link = a.Href })
         };
     }
 
-    internal static Image ConvertImage(IImage image) {
-        return new Image() {
+    internal static Image ConvertImage(IImage image)
+    {
+        return new Image
+        {
             Name = image.Name,
             Type = image.ContentType,
             Content = image.Read()
         };
     }
 
-    internal static AttachmentPair ConvertAttachment(Attachment a) {
-        var content = a.Content;
-        var type1 = a.Type;
-        UK.Gov.Legislation.Judgments.AttachmentType type2;
-        if (type1 == Api.AttachmentType.Order)
-            type2 = UK.Gov.Legislation.Judgments.AttachmentType.Order;
-        else if (type1 == Api.AttachmentType.Appendix)
-            type2 = UK.Gov.Legislation.Judgments.AttachmentType.Appendix;
-        else
-            throw new System.Exception();
-        return new System.Tuple<byte[], UK.Gov.Legislation.Judgments.AttachmentType>(content, type2);
+    private static Legislation.Judgments.AttachmentType MapAttachmentType(AttachmentType attachmentType)
+    {
+        return attachmentType switch
+        {
+            AttachmentType.Order => Legislation.Judgments.AttachmentType.Order,
+            AttachmentType.Appendix => Legislation.Judgments.AttachmentType.Appendix,
+            _ => throw new ArgumentOutOfRangeException(nameof(attachmentType), attachmentType, null)
+        };
     }
 
-    internal void Log(Api.Meta meta) {
+    internal void Log(Meta meta)
+    {
         if (string.IsNullOrEmpty(meta.DocumentType))
+        {
             logger.LogWarning("The document type is null");
+        }
         else
+        {
             logger.LogInformation("The document type is {DocumentType}", meta.DocumentType);
-        if (string.IsNullOrEmpty(URI.ExtractShortURIComponent(meta.Uri)))
-            logger.LogWarning("The {DocumentType} uri is null", meta.DocumentType);
-        else
-            logger.LogInformation("The {DocumentType} uri is {Uri}", meta.DocumentType, meta.Uri);
-        if (meta.Court is null)
-            logger.LogWarning("The court is null");
-        else
-            logger.LogInformation("The court is {Court}", meta.Court);
-        if (meta.Cite is null)
-            logger.LogWarning("The case citation is null");
-        else
-            logger.LogInformation("The case citation is {Cite}", meta.Cite);
-        if (meta.Date is null)
-            logger.LogWarning("The {DocumentType} date is null", meta.DocumentType);
-        else
-            logger.LogInformation("The {DocumentType} date is {Date}", meta.DocumentType, meta.Date);
-        if (meta.Name is null)
-            logger.LogWarning("The {DocumentType} name is null", meta.DocumentType);
-        else
-            logger.LogInformation("The {DocumentType} name is {Name}", meta.DocumentType, meta.Name);
-    }
+        }
 
+        if (string.IsNullOrEmpty(URI.ExtractShortURIComponent(meta.Uri)))
+        {
+            logger.LogWarning("The {DocumentType} uri is null", meta.DocumentType);
+        }
+        else
+        {
+            logger.LogInformation("The {DocumentType} uri is {Uri}", meta.DocumentType, meta.Uri);
+        }
+
+        if (meta.Court is null)
+        {
+            logger.LogWarning("The court is null");
+        }
+        else
+        {
+            logger.LogInformation("The court is {Court}", meta.Court);
+        }
+
+        if (meta.Cite is null)
+        {
+            logger.LogWarning("The case citation is null");
+        }
+        else
+        {
+            logger.LogInformation("The case citation is {Cite}", meta.Cite);
+        }
+
+        if (meta.Date is null)
+        {
+            logger.LogWarning("The {DocumentType} date is null", meta.DocumentType);
+        }
+        else
+        {
+            logger.LogInformation("The {DocumentType} date is {Date}", meta.DocumentType, meta.Date);
+        }
+
+        if (meta.Name is null)
+        {
+            logger.LogWarning("The {DocumentType} name is null", meta.DocumentType);
+        }
+        else
+        {
+            logger.LogInformation("The {DocumentType} name is {Name}", meta.DocumentType, meta.Name);
+        }
+    }
 }

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1383,15 +1383,8 @@ internal class PartyEnricher : Enricher
                     .ToArray();
         }
 
-        var cleanedParts = parts.Select(p => p.CleanWhitespace()
-                                              .Trim('(', ')')
-                                              .Trim());
-
-        var cleanedPartsWithoutPrefixes = cleanedParts
-                                          .Select(p => p.Equals("Third Party", StringComparison.OrdinalIgnoreCase)
-                                              ? p
-                                              : StripRolePrefix(p))
-                                          .ToArray();
+        var cleanedParts = parts.Select(p => p.CleanWhitespace().Trim('(', ')').Trim());
+        var cleanedPartsWithoutPrefixes = cleanedParts.Select(StripRolePrefix).ToArray();
 
         if (!cleanedPartsWithoutPrefixes.All(PartyRoles.ContainsKey))
         {
@@ -1405,6 +1398,11 @@ internal class PartyEnricher : Enricher
 
     private static string StripRolePrefix(string s)
     {
+        if (s.Equals("Third Party", StringComparison.OrdinalIgnoreCase))
+        {
+            return s;
+        }
+
         foreach (var prefix in
                  PrefixesToStrip.Where(prefix => s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
         {

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-using UK.Gov.Legislation.Judgments.Utils;
-
 namespace UK.Gov.Legislation.Judgments.Parse;
 
 // there are "third" paries in EWCA/Civ/2015/631
@@ -961,7 +959,7 @@ internal class PartyEnricher : Enricher
 
     private static bool IsPartyRole(string s)
     {
-        return TryGetPartyRole(out _, s);
+        return TryGetSinglePartyRole(out _, s);
     }
 
     private static bool IsPartyRole(WLine line)
@@ -972,7 +970,7 @@ internal class PartyEnricher : Enricher
 
     private static PartyRole GetPartyRole(string s)
     {
-        return TryGetPartyRole(out var role, s) ? role : throw new Exception();
+        return TryGetSinglePartyRole(out var role, s) ? role : throw new Exception();
     }
 
     private static PartyRole GetPartyRole(WLine line)
@@ -1134,7 +1132,7 @@ internal class PartyEnricher : Enricher
             return row;
         }
 
-        if (TryGetPartyRole(third, out var role))
+        if (TryGetSinglePartyRole(third, out var role))
         {
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
@@ -1173,7 +1171,7 @@ internal class PartyEnricher : Enricher
         var first = (WCell)rowCells[0];
         var second = (WCell)rowCells[1];
 
-        if (IsCellWithContent(first) && TryGetPartyRole(second, out var role))
+        if (IsCellWithContent(first) && TryGetSinglePartyRole(second, out var role))
         {
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
@@ -1298,7 +1296,7 @@ internal class PartyEnricher : Enricher
             && next.Cells.ToArray() is [WCell nextRowFirstCell, WCell nextRowMiddleCell, WCell nextRowLastCell]
             && IsEmptyCell(thisRowFirstCell) && IsCellWithContent(thisRowMiddleCell) && IsEmptyCell(thisRowLastCell)
             && IsEmptyCell(nextRowFirstCell) && IsEmptyCell(nextRowMiddleCell) && IsCellWithContent(nextRowLastCell)
-            && TryGetPartyRole(nextRowLastCell, out var role))
+            && TryGetSinglePartyRole(nextRowLastCell, out var role))
         {
             return new WRow(row.Table, row.TablePropertyExceptions, row.Properties,
             [
@@ -1311,17 +1309,17 @@ internal class PartyEnricher : Enricher
         return row;
     }
 
-    public static bool TryGetPartyRole(WCell cell, out PartyRole role)
+    internal static bool TryGetSinglePartyRole(WCell cell, out PartyRole role)
     {
         var lineContents = cell.Contents
                                .OfType<WLine>()
                                .Where(LineHasContent)
                                .Select(l => l.NormalizedContent)
                                .ToArray();
-        return TryGetPartyRole(out role, lineContents);
+        return TryGetSinglePartyRole(out role, lineContents);
     }
 
-    public static bool TryGetPartyRole(out PartyRole role, params string[] inputRoleStrings)
+    internal static bool TryGetSinglePartyRole(out PartyRole role, params string[] inputRoleStrings)
     {
         if (!TryGetPartyRoleParts(inputRoleStrings, out var roleParts))
         {
@@ -1434,8 +1432,8 @@ internal class PartyEnricher : Enricher
     {
         var linesWithContent = cell.Contents.OfType<WLine>().Where(LineHasContent).ToArray();
         if (linesWithContent.Length == 2
-            && TryGetPartyRole(out var role1, linesWithContent[0].NormalizedContent)
-            && TryGetPartyRole(out var role2, linesWithContent[1].NormalizedContent)
+            && TryGetSinglePartyRole(out var role1, linesWithContent[0].NormalizedContent)
+            && TryGetSinglePartyRole(out var role2, linesWithContent[1].NormalizedContent)
             && role1 != role2)
         {
             roles = (role1, role2);

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -1335,6 +1335,8 @@ internal class PartyEnricher : Enricher
             [var partyRole] => partyRole,
             [var partyRole, ..] when AllRolesAre(partyRole) => partyRole, // All roles are the same
 
+            [.., PartyRole.ThirdParty or PartyRole.InterestedParty] => null,
+
             [PartyRole.Appellant, PartyRole.Respondent] => PartyRole.Respondent, // [2020] EWHC 3409 (QB)
             [PartyRole.Respondent, PartyRole.Appellant] => PartyRole.Appellant, // [2021] EWCA Civ 1961
 
@@ -1619,7 +1621,7 @@ internal class PartyEnricher : Enricher
                     continue;
                 }
 
-                if (andFound)
+                if (firstPartyFound && andFound)
                 {
                     secondPartyFound = true;
                     var party = new WParty(wText) { Role = roles.second };

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -959,7 +959,7 @@ internal class PartyEnricher : Enricher
 
     private static bool IsPartyRole(string s)
     {
-        return TryGetSinglePartyRole(out _, s);
+        return TryGetSinglePartyRole(s, out _);
     }
 
     private static bool IsPartyRole(WLine line)
@@ -970,7 +970,7 @@ internal class PartyEnricher : Enricher
 
     private static PartyRole GetPartyRole(string s)
     {
-        return TryGetSinglePartyRole(out var role, s) ? role : throw new Exception();
+        return TryGetSinglePartyRole(s, out var role) ? role : throw new Exception();
     }
 
     private static PartyRole GetPartyRole(WLine line)
@@ -1316,10 +1316,15 @@ internal class PartyEnricher : Enricher
                                .Where(LineHasContent)
                                .Select(l => l.NormalizedContent)
                                .ToArray();
-        return TryGetSinglePartyRole(out role, lineContents);
+        return TryGetSinglePartyRole(lineContents, out role);
     }
 
-    internal static bool TryGetSinglePartyRole(out PartyRole role, params string[] inputRoleStrings)
+    internal static bool TryGetSinglePartyRole(string inputRoleStrings, out PartyRole role)
+    {
+        return TryGetSinglePartyRole([inputRoleStrings], out role);
+    }
+
+    internal static bool TryGetSinglePartyRole(string[] inputRoleStrings, out PartyRole role)
     {
         if (!TryGetPartyRoleParts(inputRoleStrings, out var roleParts))
         {
@@ -1432,8 +1437,8 @@ internal class PartyEnricher : Enricher
     {
         var linesWithContent = cell.Contents.OfType<WLine>().Where(LineHasContent).ToArray();
         if (linesWithContent.Length == 2
-            && TryGetSinglePartyRole(out var role1, linesWithContent[0].NormalizedContent)
-            && TryGetSinglePartyRole(out var role2, linesWithContent[1].NormalizedContent)
+            && TryGetSinglePartyRole(linesWithContent[0].NormalizedContent, out var role1)
+            && TryGetSinglePartyRole(linesWithContent[1].NormalizedContent, out var role2)
             && role1 != role2)
         {
             roles = (role1, role2);

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -968,6 +968,8 @@ internal class PartyEnricher : Enricher
         ["Claimant"] = PartyRole.Claimant,
         ["Claimant/Part 20 Defendant"] = PartyRole.Claimant,
         ["Claimants"] = PartyRole.Claimant,
+        ["Clamaint"] = PartyRole.Claimant,
+        ["Clamaints"] = PartyRole.Claimant,
         ["First Claimant"] = PartyRole.Claimant,
         ["Second Claimant"] = PartyRole.Claimant,
 
@@ -1024,6 +1026,8 @@ internal class PartyEnricher : Enricher
         ["First Respondent"] = PartyRole.Respondent,
         ["Fourth Respondent"] = PartyRole.Respondent,
         ["Petitioner/Respondent"] = PartyRole.Respondent,
+        ["Respond-ent"] = PartyRole.Respondent,
+        ["Respond-ents"] = PartyRole.Respondent,
         ["Respond-ents/ Defendants"] = PartyRole.Respondent,
         ["Respondent / Defendant"] = PartyRole.Respondent,
         ["Respondent"] = PartyRole.Respondent, // EWCA/Civ/2003/1686
@@ -1043,11 +1047,12 @@ internal class PartyEnricher : Enricher
         ["Respondnet"] = PartyRole.Respondent, // EWHC/Admin/2010/3393
         ["Second Respondent"] = PartyRole.Respondent,
         ["Third Respondent"] = PartyRole.Respondent,
+        ["Third Party"] = PartyRole.ThirdParty
     };
 
     private static bool IsPartyRole(string s)
     {
-        return PartyRoles.ContainsKey(s) || TryGetPartyRole(s, out _);
+        return TryGetPartyRole(s, out _);
     }
 
     private static bool IsPartyRole(WLine line)
@@ -1056,19 +1061,9 @@ internal class PartyEnricher : Enricher
         return IsPartyRole(normalized);
     }
 
-    private static PartyRole GetAnyPartyRole(string s)
-    {
-        return IsPartyRole(s) ? GetPartyRole(s) : throw new Exception();
-    }
-
     private static PartyRole GetPartyRole(string s)
     {
-        if (PartyRoles.TryGetValue(s, out var role))
-        {
-            return role;
-        }
-
-        return TryGetPartyRole(s, out role) ? role : throw new Exception();
+        return TryGetPartyRole(s, out var role) ? role : throw new Exception();
     }
 
     private static PartyRole GetPartyRole(WLine line)
@@ -1125,8 +1120,7 @@ internal class PartyEnricher : Enricher
             var penult = (WTab)lineContents[^2];
             var last = (WText)lineContents[^1];
 
-            var s = Regex.Replace(last.Text, @"\s+", " ").Trim();
-            var role = GetAnyPartyRole(s);
+            var role = GetPartyRole(last.Text);
 
             var contents = before.Concat(
             [
@@ -1410,20 +1404,73 @@ internal class PartyEnricher : Enricher
 
     public static bool TryGetPartyRole(string s, out PartyRole role)
     {
-        if (s.Split('/', 2) is [var beforeSlash, var afterSlash]
-            && !string.IsNullOrWhiteSpace(beforeSlash) && !string.IsNullOrWhiteSpace(afterSlash))
+        var parts = s.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 2)
         {
-            return TryGetPartyRoleForCombinedLabels(beforeSlash, afterSlash, out role);
+            parts = s.Split(" and ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         }
 
-        if (s.Split(" and ", 2) is [var beforeAnd, var afterAnd]
-            && !string.IsNullOrWhiteSpace(beforeAnd) && !string.IsNullOrWhiteSpace(afterAnd))
+        var cleanedParts = parts.Select(p => p.CleanWhitespace()
+                                              .Trim('(', ')')
+                                              .Trim());
+
+        var cleanedPartsWithoutPrefixes = cleanedParts.Select(p =>
+            p.Equals("Third Party", StringComparison.OrdinalIgnoreCase)
+                ? p
+                : StripRolePrefix(p)).ToArray();
+
+        if (!cleanedPartsWithoutPrefixes.All(PartyRoles.ContainsKey))
         {
-            return TryGetPartyRoleForCombinedLabels(beforeAnd, afterAnd, out role);
+            role = default;
+            return false;
         }
 
-        return TryGetPartyRoleForSingleLabel(s, out role);
+        var roleParts = cleanedPartsWithoutPrefixes.Select(p => PartyRoles[p]).ToArray();
+
+        PartyRole? result = roleParts switch
+        {
+            [var partyRole] => partyRole,
+            { Length: > 1 } when TryGetPartyRoleForCombinedLabels(out var partyRole, roleParts) => partyRole,
+            _ => null
+        };
+
+        if (result.HasValue)
+        {
+            role = result.Value;
+            return true;
+        }
+
+        role = default;
+        return false;
     }
+
+    private static string StripRolePrefix(string s)
+    {
+        foreach (var prefix in PrefixesToStrip)
+        {
+            if (s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                s = s.Remove(0, prefix.Length).Trim();
+            }
+        }
+
+        s = Regex.Replace(s, @"^\d+(st|nd|rd|th)", "", RegexOptions.IgnoreCase).Trim();
+
+        return s;
+    }
+
+    private static readonly HashSet<string> PrefixesToStrip =
+    [
+        "First",
+        "Second",
+        "Third",
+        "Fourth",
+        "Fifth",
+        "Sixth",
+
+        "Part 20",
+        "Inquiry" // [2022] EWHC 189 (Pat)
+    ];
 
     public static bool TryGetPartyRole(WCell cell, out PartyRole role)
     {
@@ -1882,76 +1929,39 @@ internal class PartyEnricher : Enricher
         };
     }
 
-    private static readonly HashSet<string> PrefixesToStrip =
-    [
-        "1st ",
-        "2nd ",
-        "3rd ",
-        "4th ",
-        "5th ",
-        "6th ",
-        "First ",
-        "Second ",
-        "Third ",
-        "Fourth ",
-        "Fifth ",
-        "Sixth ",
-        "Inquiry " // [2022] EWHC 189 (Pat)
-    ];
-
-    private static bool TryGetPartyRoleForSingleLabel(string s, out PartyRole role)
-    {
-        s = Regex.Replace(s, @"\s+", " ").Trim(' ', '/', '(', ')');
-        if (s.StartsWith("Part 20 ", StringComparison.OrdinalIgnoreCase))
-        {
-            s = s.Substring(8);
-        }
-
-        if (s.Equals("Third Party", StringComparison.OrdinalIgnoreCase))
-        {
-            role = PartyRole.ThirdParty;
-            return true;
-        }
-
-        if (PrefixesToStrip.Any(prefix => s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
-        {
-            s = s.Substring(s.IndexOf(' ') + 1);
-        }
-
-        return PartyRoles.TryGetValue(s, out role);
-    }
-
     private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)
     {
         if (TryGetPartyRole(s1, out var role1)
-            && TryGetPartyRole(s2, out var role2))
+            && TryGetPartyRole(s2, out var role2)
+            && TryGetPartyRoleForCombinedLabels(out role, role1, role2))
         {
-            if (role1 == PartyRole.Appellant || role2 == PartyRole.Appellant)
-            {
-                role = PartyRole.Appellant;
-                return true;
-            }
-
-            if (role1 == PartyRole.Respondent || role2 == PartyRole.Respondent)
-            {
-                role = PartyRole.Respondent;
-                return true;
-            }
-
-            if (role1 == PartyRole.Claimant && role2 == PartyRole.Defendant) // [2022] EWCA Civ 102
-            {
-                role = PartyRole.Claimant;
-                return true;
-            }
-
-            if (role1 == PartyRole.Defendant && role2 == PartyRole.Applicant) // [2019] EWHC 3963 (QB)
-            {
-                role = PartyRole.Applicant;
-                return true;
-            }
+            return true;
         }
 
         role = default;
+        return false;
+    }
+
+    private static bool TryGetPartyRoleForCombinedLabels(out PartyRole resulty, params PartyRole[] rolesToCombine)
+    {
+        PartyRole? result = rolesToCombine switch
+        {
+            [var role1, var role2] when role1 == PartyRole.Appellant || role2 == PartyRole.Appellant
+                => PartyRole.Appellant,
+            [var role1, var role2] when role1 == PartyRole.Respondent || role2 == PartyRole.Respondent
+                => PartyRole.Respondent,
+            [PartyRole.Claimant, PartyRole.Defendant] => PartyRole.Claimant, // [2022] EWCA Civ 102
+            [PartyRole.Defendant, PartyRole.Applicant] => PartyRole.Applicant, // [2019] EWHC 3963 (QB)
+            _ => null
+        };
+
+        if (result.HasValue)
+        {
+            resulty = result.Value;
+            return true;
+        }
+
+        resulty = default;
         return false;
     }
 }

--- a/src/parsers/common/enrich/PartyEnricher.cs
+++ b/src/parsers/common/enrich/PartyEnricher.cs
@@ -918,84 +918,24 @@ internal class PartyEnricher : Enricher
 
     private static readonly Dictionary<string, PartyRole> PartyRoles = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["(APPELLANT)"] = PartyRole.Appellant,
-        ["(APPELLANTS)"] = PartyRole.Appellant,
-        ["1st Appellant"] = PartyRole.Appellant,
-        ["Appellant / Claimant"] = PartyRole.Appellant,
-        ["Appellant / Third Defendant"] = PartyRole.Appellant,
         ["Appellant"] = PartyRole.Appellant, // EWCA/Civ/2003/1686
-        ["Appellant/ Defendant"] = PartyRole.Appellant,
-        ["Appellant/ Respondent"] = PartyRole.Appellant, // [2021] EWCA Civ 1792
-        ["Appellant/Appellant"] = PartyRole.Appellant,
-        ["Appellant/Applicant"] = PartyRole.Appellant, // [2021] EWCA Crim 1877
-        ["Appellant/Claimant"] = PartyRole.Appellant,
-        ["Appellant/Defendant"] = PartyRole.Appellant,
-        ["Appellant/First Defendant"] = PartyRole.Appellant,
-        ["Appellants / Defendants"] = PartyRole.Appellant,
         ["Appellants"] = PartyRole.Appellant,
-        ["Appellants/ Claimants"] = PartyRole.Appellant,
-        ["Appellants/Claimants"] = PartyRole.Appellant,
-        ["Applicant/Appellant"] = PartyRole.Appellant,
-        ["Claimant / Appellant"] = PartyRole.Appellant,
-        ["Claimant/ Appellant"] = PartyRole.Appellant,
-        ["Claimant/Appellant"] = PartyRole.Appellant,
-        ["Claimants/ Appellants"] = PartyRole.Appellant,
-        ["Claimants/Appellants"] = PartyRole.Appellant, // [2021] EWCA Civ 1799
-        ["Defendant/ Appellant"] = PartyRole.Appellant,
-        ["Defendant/Appellant"] = PartyRole.Appellant,
-        ["Defendants / Appellants"] = PartyRole.Appellant,
-        ["Defendants/ Appellants"] = PartyRole.Appellant,
-        ["Defendants/Appellants"] = PartyRole.Appellant,
-        ["Defendants/Appellants/"] = PartyRole.Appellant,
-        ["FIRST DEFENDANT’S SOLICITOR/APPELLANT"] = PartyRole.Appellant, // EWCA/Civ/2006/1032
-        ["Respondent/Appellant"] = PartyRole.Appellant,
-        ["Third Party/Appellant"] = PartyRole.Appellant, // [2022] EWHC 34 (Ch)
 
-        ["1st Applicant"] = PartyRole.Applicant,
-        ["2nd Applicant"] = PartyRole.Applicant,
         ["Applicant"] = PartyRole.Applicant,
-        ["Applicant/ Claimant"] = PartyRole.Applicant,
         ["Applicants"] = PartyRole.Applicant,
-        ["Applicants/Claimants"] = PartyRole.Applicant,
-        ["Claimant/Applicant"] = PartyRole.Applicant,
-        ["Defendant/ Applicant"] = PartyRole.Applicant,
-        ["Respondent/Applicant"] = PartyRole.Applicant,
-
-        ["(CLAIMANTS)"] = PartyRole.Claimant,
-        ["(Claimant)"] = PartyRole.Claimant,
-        ["Additional Claimant"] = PartyRole.Claimant,
-        ["Claimant / Defendant to Counterclaim"] = PartyRole.Claimant,
+        ["Counterclaimant"] = PartyRole.Claimant,
+        ["Defendant to Counterclaim"] = PartyRole.Claimant,
         ["Claimant"] = PartyRole.Claimant,
-        ["Claimant/Part 20 Defendant"] = PartyRole.Claimant,
         ["Claimants"] = PartyRole.Claimant,
         ["Clamaint"] = PartyRole.Claimant,
         ["Clamaints"] = PartyRole.Claimant,
-        ["First Claimant"] = PartyRole.Claimant,
-        ["Second Claimant"] = PartyRole.Claimant,
 
-        ["(1st DEFENDANT)"] = PartyRole.Defendant,
-        ["(2nd DEFENDANT)"] = PartyRole.Defendant,
-        ["(3rd DEFENDANT)"] = PartyRole.Defendant,
-        ["(DEFENDANTS)"] = PartyRole.Defendant,
-        ["(Defendant)"] = PartyRole.Defendant,
-        ["(FIRST DEFENDANT)"] = PartyRole.Defendant,
-        ["(SECOND DEFENDANT)"] = PartyRole.Defendant,
-        ["Applicants/Defendants"] = PartyRole.Defendant,
-        ["Defendant / Counterclaimant"] = PartyRole.Defendant,
         ["Defendant"] = PartyRole.Defendant,
-        ["Defendant/Part 20 Claimant"] = PartyRole.Defendant,
         ["Defendants"] = PartyRole.Defendant,
-        ["First Defendant"] = PartyRole.Defendant,
-        ["Second Defendant"] = PartyRole.Defendant,
-        ["Third Defendant"] = PartyRole.Defendant,
+        ["DEFENDANT’S SOLICITOR"] = PartyRole.Defendant, // EWCA/Civ/2006/1032
 
-        ["(INTERESTED PARTIES)"] = PartyRole.InterestedParty,
-        ["(INTERESTED PARTY)"] = PartyRole.InterestedParty,
         ["Interested Parties"] = PartyRole.InterestedParty,
         ["Interested Party"] = PartyRole.InterestedParty,
-        ["Interested parties"] = PartyRole.InterestedParty,
-        ["Second Interested Party"] = PartyRole.InterestedParty,
-        ["Third Interested Party"] = PartyRole.InterestedParty,
 
         ["Intervener"] = PartyRole.Intervener,
         ["Interveners"] = PartyRole.Intervener,
@@ -1008,51 +948,20 @@ internal class PartyEnricher : Enricher
 
         ["requesting state"] = PartyRole.RequestingState,
 
-        ["(RESPONDENT)"] = PartyRole.Respondent,
-        ["(RESPONDENTS)"] = PartyRole.Respondent,
-        ["1st Respondent"] = PartyRole.Respondent,
-        ["2nd Respondent"] = PartyRole.Respondent,
-        ["3rd Respondent"] = PartyRole.Respondent, // EWCA/Civ/2012/378
-        ["Claimant / Respondent"] = PartyRole.Respondent,
-        ["Claimant/ Respondent"] = PartyRole.Respondent,
-        ["Claimant/Respondent"] = PartyRole.Respondent,
-        ["Claimants/Respondents"] = PartyRole.Respondent,
-        ["Clamaints/ Respondents"] = PartyRole.Respondent,
-        ["Defendant / Respondent"] = PartyRole.Respondent,
-        ["Defendant/ Respondent"] = PartyRole.Respondent,
-        ["Defendant/Respondent"] = PartyRole.Respondent,
-        ["Defendants/ Respondents"] = PartyRole.Respondent,
-        ["Defendants/Respondents"] = PartyRole.Respondent,
-        ["First Respondent"] = PartyRole.Respondent,
-        ["Fourth Respondent"] = PartyRole.Respondent,
-        ["Petitioner/Respondent"] = PartyRole.Respondent,
         ["Respond-ent"] = PartyRole.Respondent,
         ["Respond-ents"] = PartyRole.Respondent,
-        ["Respond-ents/ Defendants"] = PartyRole.Respondent,
-        ["Respondent / Defendant"] = PartyRole.Respondent,
         ["Respondent"] = PartyRole.Respondent, // EWCA/Civ/2003/1686
-        ["Respondent/ Claimant"] = PartyRole.Respondent,
-        ["Respondent/ First Defendant"] = PartyRole.Respondent,
-        ["Respondent/Claimant"] = PartyRole.Respondent,
-        ["Respondent/Defendants"] = PartyRole.Respondent,
-        ["Respondent/Petitioner"] = PartyRole.Respondent, // [2021] EWCA Civ 1792
-        ["Respondent/Respondent"] = PartyRole.Respondent,
-        ["Respondents / Claimants"] = PartyRole.Respondent,
-        ["Respondents Second and Third/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2004/1249
+        ["Respondents Second and Third"] = PartyRole.Respondent,
         ["Respondents"] = PartyRole.Respondent,
-        ["Respondents/ Defendants"] = PartyRole.Respondent, // EWCA/Civ/2015/377, EWHC/QB/2006/582
-        ["Respondents/Claimants"] = PartyRole.Respondent,
-        ["Respondents/Defendants"] = PartyRole.Respondent,
-        ["Respondents/Respondents"] = PartyRole.Respondent,
         ["Respondnet"] = PartyRole.Respondent, // EWHC/Admin/2010/3393
-        ["Second Respondent"] = PartyRole.Respondent,
-        ["Third Respondent"] = PartyRole.Respondent,
+        ["Respondnets"] = PartyRole.Respondent,
+
         ["Third Party"] = PartyRole.ThirdParty
     };
 
     private static bool IsPartyRole(string s)
     {
-        return TryGetPartyRole(s, out _);
+        return TryGetPartyRole(out _, s);
     }
 
     private static bool IsPartyRole(WLine line)
@@ -1063,7 +972,7 @@ internal class PartyEnricher : Enricher
 
     private static PartyRole GetPartyRole(string s)
     {
-        return TryGetPartyRole(s, out var role) ? role : throw new Exception();
+        return TryGetPartyRole(out var role, s) ? role : throw new Exception();
     }
 
     private static PartyRole GetPartyRole(WLine line)
@@ -1402,35 +1311,51 @@ internal class PartyEnricher : Enricher
         return row;
     }
 
-    public static bool TryGetPartyRole(string s, out PartyRole role)
+    public static bool TryGetPartyRole(WCell cell, out PartyRole role)
     {
-        var parts = s.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (parts.Length < 2)
-        {
-            parts = s.Split(" and ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        }
+        var lineContents = cell.Contents
+                               .OfType<WLine>()
+                               .Where(LineHasContent)
+                               .Select(l => l.NormalizedContent)
+                               .ToArray();
+        return TryGetPartyRole(out role, lineContents);
+    }
 
-        var cleanedParts = parts.Select(p => p.CleanWhitespace()
-                                              .Trim('(', ')')
-                                              .Trim());
-
-        var cleanedPartsWithoutPrefixes = cleanedParts.Select(p =>
-            p.Equals("Third Party", StringComparison.OrdinalIgnoreCase)
-                ? p
-                : StripRolePrefix(p)).ToArray();
-
-        if (!cleanedPartsWithoutPrefixes.All(PartyRoles.ContainsKey))
+    public static bool TryGetPartyRole(out PartyRole role, params string[] inputRoleStrings)
+    {
+        if (!TryGetPartyRoleParts(inputRoleStrings, out var roleParts))
         {
             role = default;
             return false;
         }
 
-        var roleParts = cleanedPartsWithoutPrefixes.Select(p => PartyRoles[p]).ToArray();
+        bool AllRolesAre(PartyRole role) => roleParts.All(r => r == role);
+        bool OneRoleIs(PartyRole role) => roleParts.Any(r => r == role);
 
         PartyRole? result = roleParts switch
         {
             [var partyRole] => partyRole,
-            { Length: > 1 } when TryGetPartyRoleForCombinedLabels(out var partyRole, roleParts) => partyRole,
+            [var partyRole, ..] when AllRolesAre(partyRole) => partyRole, // All roles are the same
+
+            [PartyRole.Appellant, PartyRole.Respondent] => PartyRole.Respondent, // [2020] EWHC 3409 (QB)
+            [PartyRole.Respondent, PartyRole.Appellant] => PartyRole.Appellant, // [2021] EWCA Civ 1961
+
+            [PartyRole.Respondent, PartyRole.Applicant] => PartyRole.Applicant,
+
+            { Length: 2 } when OneRoleIs(PartyRole.Appellant) => PartyRole.Appellant,
+            { Length: 2 } when OneRoleIs(PartyRole.Respondent) => PartyRole.Respondent,
+
+            [PartyRole.Claimant, PartyRole.Defendant] => PartyRole.Claimant,
+
+            [PartyRole.Applicant, PartyRole.Defendant] => PartyRole.Defendant,
+            [PartyRole.Defendant, PartyRole.Applicant] => PartyRole.Applicant, // [2019] EWHC 3963 (QB)
+
+            { Length: 2 } when OneRoleIs(PartyRole.Defendant) => PartyRole.Defendant,
+            { Length: 2 } when OneRoleIs(PartyRole.Applicant) => PartyRole.Applicant,
+
+            [PartyRole.Defendant, PartyRole.Claimant, PartyRole.Appellant] => PartyRole.Appellant,
+            [PartyRole.Respondent, PartyRole.Appellant, PartyRole.Respondent] => PartyRole.Respondent,
+
             _ => null
         };
 
@@ -1444,14 +1369,46 @@ internal class PartyEnricher : Enricher
         return false;
     }
 
+    private static bool TryGetPartyRoleParts(string[] inputRoleStrings, out PartyRole[] roleParts)
+    {
+        var parts = inputRoleStrings
+                    .SelectMany(s => s.Split('/',
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    .ToArray();
+        if (parts.Length < 2)
+        {
+            parts = inputRoleStrings
+                    .SelectMany(s => s.Split(" and ",
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    .ToArray();
+        }
+
+        var cleanedParts = parts.Select(p => p.CleanWhitespace()
+                                              .Trim('(', ')')
+                                              .Trim());
+
+        var cleanedPartsWithoutPrefixes = cleanedParts
+                                          .Select(p => p.Equals("Third Party", StringComparison.OrdinalIgnoreCase)
+                                              ? p
+                                              : StripRolePrefix(p))
+                                          .ToArray();
+
+        if (!cleanedPartsWithoutPrefixes.All(PartyRoles.ContainsKey))
+        {
+            roleParts = null;
+            return false;
+        }
+
+        roleParts = cleanedPartsWithoutPrefixes.Select(p => PartyRoles[p]).ToArray();
+        return true;
+    }
+
     private static string StripRolePrefix(string s)
     {
-        foreach (var prefix in PrefixesToStrip)
+        foreach (var prefix in
+                 PrefixesToStrip.Where(prefix => s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
         {
-            if (s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                s = s.Remove(0, prefix.Length).Trim();
-            }
+            s = s.Remove(0, prefix.Length).Trim();
         }
 
         s = Regex.Replace(s, @"^\d+(st|nd|rd|th)", "", RegexOptions.IgnoreCase).Trim();
@@ -1468,71 +1425,17 @@ internal class PartyEnricher : Enricher
         "Fifth",
         "Sixth",
 
-        "Part 20",
-        "Inquiry" // [2022] EWHC 189 (Pat)
+        "Additional",
+        "Inquiry", // [2022] EWHC 189 (Pat)
+        "Part 20"
     ];
-
-    public static bool TryGetPartyRole(WCell cell, out PartyRole role)
-    {
-        var lineContents = cell.Contents
-                               .OfType<WLine>()
-                               .Where(LineHasContent)
-                               .Select(l => l.NormalizedContent.ToLower())
-                               .ToArray();
-        switch (lineContents)
-        {
-            case [var one] when TryGetPartyRole(one, out role):
-                return true;
-
-            case ["defendant/", var two] when two.EndsWith("claimant"): // EWHC/Ch/2008/2079
-                role = PartyRole.Defendant;
-                return true;
-
-            case ["claimant/", var two] when two.EndsWith("defendant"): // EWHC/Ch/2008/2079
-                role = PartyRole.Claimant;
-                return true;
-
-            case ["respondents", var two] when two.StartsWith("respondent"): // EWHC/Fam/2013/1956
-                role = PartyRole.Respondent;
-                return true;
-
-            case [var one, var two] when TwoLinePartyRoles.TryGetValue((one, two), out role)
-                || TryGetPartyRoleForCombinedLabels(one, two, out role):
-                return true;
-
-            case ["defendants", "part 20 claimant/", "appellant"]:
-                role = PartyRole.Appellant;
-                return true;
-
-            case ["respondents", "appellant", "respondent"]: // EWCA/Civ/2010/180
-                role = PartyRole.Respondent;
-                return true;
-
-            case { Length: >= 2 } when cell.Contents.All(block => block is WLine):
-                foreach (var (pattern, patternRole) in NLinePartyRolePatterns)
-                {
-                    if (lineContents.All(pattern.IsMatch))
-                    {
-                        role = patternRole;
-                        return true;
-                    }
-                }
-
-                role = default;
-                return false;
-
-            default:
-                role = default;
-                return false;
-        }
-    }
 
     private static bool TryGetTwoDifferentRoles(WCell cell, out (PartyRole first, PartyRole second) roles)
     {
         var linesWithContent = cell.Contents.OfType<WLine>().Where(LineHasContent).ToArray();
         if (linesWithContent.Length == 2
-            && TryGetPartyRole(linesWithContent[0].NormalizedContent, out var role1)
-            && TryGetPartyRole(linesWithContent[1].NormalizedContent, out var role2)
+            && TryGetPartyRole(out var role1, linesWithContent[0].NormalizedContent)
+            && TryGetPartyRole(out var role2, linesWithContent[1].NormalizedContent)
             && role1 != role2)
         {
             roles = (role1, role2);
@@ -1553,57 +1456,6 @@ internal class PartyEnricher : Enricher
                                                            new WRole { Role = role, Contents = line.Contents }
                                                        ])));
     }
-
-    private static readonly Dictionary<(string one, string two), PartyRole> TwoLinePartyRoles =
-        new(new OrdinalIgnoreCaseTupleComparer())
-        {
-            [("Defendant/", "Appellant")] = PartyRole.Appellant, // EWCA/Civ/2011/1383
-            [("Claimant/", "Appellant")] = PartyRole.Appellant, // EWCA/Civ/2011/1277
-            [("Appellants/", "Defendants")] = PartyRole.Appellant,
-            [("Appellants/", "Defendants & Counterclaimants")] = PartyRole.Appellant, // EWCA/Civ/2017/97
-            [("Appellants/", "Claimants")] = PartyRole.Appellant, // EWCA/Civ/2015/377
-            [("Appellants", "Claimants")] = PartyRole.Appellant, // EWCA/Civ/2018/601
-            [("Appellant/", "Claimant")] = PartyRole.Appellant, // EWHC/Ch/2017/541
-            [("Appellant", "/Claimant")] = PartyRole.Appellant, // [2021] EWHC 3453 (QB)
-            [("Appellant/", "Defendant")] = PartyRole.Appellant, // EWHC/QB/2013/196
-            [("Claimants/", "Appellants")] = PartyRole.Appellant, // EWHC/Admin/2016/321
-            [("Defendants/", "Appellants")] = PartyRole.Appellant, // EWCA/Civ/2004/277
-            [("Respondent/", "Appellant")] = PartyRole.Appellant, // [2021] EWCA Civ 1961
-
-            [("Defendant/", "Applicant")] = PartyRole.Applicant, // EWHC/Ch/2017/916
-            [("Defendants/", "Applicants")] = PartyRole.Applicant, // [2021] EWHC 2684 (Comm)
-
-            [("First Defendant", "Second Defendant")] = PartyRole.Defendant, // EWHC/Admin/2010/2
-            [("Defendant/Part 20 Claimant", "Part 20 Claimant")] = PartyRole.Defendant, // EWHC/Ch/2003/812
-            [("1st Defendant/Part 20 Claimant", "2nd Defendant/Part 20 Defendant")] =
-                PartyRole.Defendant, // EWHC/QB/2004/1260
-            [("Defendant/", "Cross appellant")] = PartyRole.Defendant, // EWHC/QB/2013/652 ??? other role is Appellant
-
-            [("Claimant/", "Respondent")] = PartyRole.Respondent, // EWCA/Civ/2008/183
-            [("Claimants/", "Respondents")] = PartyRole.Respondent, // EWHC/Ch/2017/916
-            [("Respondent/", "Claimant")] = PartyRole.Respondent, // EWCA/Civ/2017/97
-            [("Respondent", "Intervener")] = PartyRole.Respondent, // EWCA/Civ/2016/176
-            [("Respondent/", "Defendant")] = PartyRole.Respondent, // EWHC/Ch/2017/541
-            [("Respondent", "Defendant")] = PartyRole.Respondent, // EWCA/Civ/2018/601
-            [("1st Respondent", "/Defendant")] = PartyRole.Respondent, // [2021] EWHC 3453 (QB)
-            [("Defendant/", "Respondent")] = PartyRole.Respondent, // EWHC/Admin/2015/1639
-            [("Defendants/", "Respondents")] = PartyRole.Respondent, // EWHC/Admin/2016/321
-            [("1st Respondent", "2nd Respondent")] = PartyRole.Respondent, // EWHC/Fam/2017/364, EWHC/Fam/2013/1864?
-            [("1st Respondent", "2ndRespondent")] = PartyRole.Respondent, // EWCA/Civ/2011/1253
-            [("Applicant/", "Respondent")] = PartyRole.Respondent, // [2021] EWCA Civ 1725
-            [("Appellant/", "Respondent")] = PartyRole.Respondent // [2020] EWHC 3409 (QB)
-        };
-
-    private static readonly (Regex Pattern, PartyRole Role)[] NLinePartyRolePatterns =
-    [
-        (new Regex(@"^\d(st|nd|rd|th)? Defendant$", RegexOptions.IgnoreCase), PartyRole.Defendant),
-        (new Regex(@"^(First|Second|Third|Fourth) Defendant$", RegexOptions.IgnoreCase),
-            PartyRole.Defendant), // EWHC/Fam/2003/365
-        (new Regex(@"^\d(st|nd|rd|th)? Appellant$", RegexOptions.IgnoreCase), PartyRole.Appellant),
-        (new Regex(@"^(\d(st|nd|rd|th)? ?)?Respondent$", RegexOptions.IgnoreCase),
-            PartyRole.Respondent), // EWFC/HCJ/2014/34, no space in EWHC/Fam/2013/1864
-        (new Regex(@"^(First|Second|Third|Fourth) Respondent$", RegexOptions.IgnoreCase), PartyRole.Respondent)
-    ];
 
     private static IBlock EnrichBlockWithParty(IBlock block, PartyRole role)
     {
@@ -1927,41 +1779,5 @@ internal class PartyEnricher : Enricher
                 => WLine.Make(line, [new WDocTitle(wText)]),
             _ => line
         };
-    }
-
-    private static bool TryGetPartyRoleForCombinedLabels(string s1, string s2, out PartyRole role)
-    {
-        if (TryGetPartyRole(s1, out var role1)
-            && TryGetPartyRole(s2, out var role2)
-            && TryGetPartyRoleForCombinedLabels(out role, role1, role2))
-        {
-            return true;
-        }
-
-        role = default;
-        return false;
-    }
-
-    private static bool TryGetPartyRoleForCombinedLabels(out PartyRole resulty, params PartyRole[] rolesToCombine)
-    {
-        PartyRole? result = rolesToCombine switch
-        {
-            [var role1, var role2] when role1 == PartyRole.Appellant || role2 == PartyRole.Appellant
-                => PartyRole.Appellant,
-            [var role1, var role2] when role1 == PartyRole.Respondent || role2 == PartyRole.Respondent
-                => PartyRole.Respondent,
-            [PartyRole.Claimant, PartyRole.Defendant] => PartyRole.Claimant, // [2022] EWCA Civ 102
-            [PartyRole.Defendant, PartyRole.Applicant] => PartyRole.Applicant, // [2019] EWHC 3963 (QB)
-            _ => null
-        };
-
-        if (result.HasValue)
-        {
-            resulty = result.Value;
-            return true;
-        }
-
-        resulty = default;
-        return false;
     }
 }

--- a/test/ApiTests/TestParser_Judgments.cs
+++ b/test/ApiTests/TestParser_Judgments.cs
@@ -15,21 +15,22 @@ using Parser = UK.Gov.NationalArchives.Judgments.Api.Parser;
 
 namespace test.ApiTests;
 
-public class Tests
+public class TestParser_Judgments
 {
     private const int Total = 99;
 
-    public static readonly IEnumerable<int> Indices = Enumerable.Range(1, 10).Concat(
-            Enumerable.Range(12, 16).Concat(
-                Enumerable.Range(29, Total - 29 + 1)));
-    
+    private static readonly IEnumerable<int> Indices = Enumerable.Range(1, 10).Concat(
+        Enumerable.Range(12, 16).Concat(
+            Enumerable.Range(29, Total - 29 + 1)));
+
     public static readonly TheoryData<int> IndicesTheoryData = new(Indices);
 
     private readonly Parser parser = new(new MockLogger<Parser>().Object, new Validator());
 
     [Theory]
     [MemberData(nameof(IndicesTheoryData))]
-    public void Test(int i) {
+    public void Parse_WithNoMetadata_ReturnsExpectedXml(int i)
+    {
         var docx = DocumentHelpers.ReadDocx(i);
 
         var actual = parser.Parse(new Api.Request { Content = docx }).Xml;
@@ -41,12 +42,14 @@ public class Tests
     }
 
     [Theory]
-    [InlineData(11,"order")]
-    public void TestWithAttachment(int i, string name) {
+    [InlineData(11, "order")]
+    public void Parse_WithAttachment_ReturnsExpectedXml(int i, string name)
+    {
         var main = DocumentHelpers.ReadDocx(i, "main");
         var attach = DocumentHelpers.ReadDocx(i, name);
         Api.AttachmentType type;
-        switch (name) {
+        switch (name)
+        {
             case "order":
                 type = Api.AttachmentType.Order;
                 break;
@@ -66,7 +69,8 @@ public class Tests
 
     [Theory]
     [InlineData(28)]
-    public void TestWithImages(int i) {
+    public void Parse_JudgmentWithImages_ReturnsImagesInResponse(int i)
+    {
         var docx = DocumentHelpers.ReadDocx(i);
 
         var response = parser.Parse(new Api.Request { Content = docx });
@@ -77,12 +81,39 @@ public class Tests
         expectedXml = DocumentHelpers.RemoveNonDeterministicMetadata(expectedXml);
         Assert.Equal(expectedXml, actualXml);
         var assembly = Assembly.GetExecutingAssembly();
-        foreach (var actual in response.Images) {
-            using Stream stream = assembly.GetManifestResourceStream($"test.judgments.test{ i }-{ actual.Name }");
-            using MemoryStream ms = new MemoryStream();
+        foreach (var actual in response.Images)
+        {
+            using var stream = assembly.GetManifestResourceStream($"test.judgments.test{i}-{actual.Name}");
+            using var ms = new MemoryStream();
             stream.CopyTo(ms);
-            byte[] expected = ms.ToArray();
+            var expected = ms.ToArray();
             Assert.Equal(expected, actual.Content);
         }
+    }
+
+    [Theory]
+    [InlineData(6)]
+    [InlineData(8)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(84)]
+    public void Parse_JudgmentWithKingOnTheApplicationOf_SuppressesPartiesOnReparseWithCaseName(int i)
+    {
+        var docx = DocumentHelpers.ReadDocx(i);
+
+        var cleanRunResponse = parser.Parse(new Api.Request { Content = docx });
+
+        var runWithExternalMetadataResponse = parser.Parse(new Api.Request
+        {
+            Content = docx,
+            Meta = cleanRunResponse.Meta,
+            Hint = Api.Hint.EWHC
+        });
+
+        var cleanRunResponseXml = DocumentHelpers.RemoveNonDeterministicMetadata(cleanRunResponse.Xml);
+        var runWithExternalMetadataResponseXml =
+            DocumentHelpers.RemoveNonDeterministicMetadata(runWithExternalMetadataResponse.Xml);
+
+        Assert.Equal(cleanRunResponseXml, runWithExternalMetadataResponseXml);
     }
 }

--- a/test/TRE/TestNoChange.cs
+++ b/test/TRE/TestNoChange.cs
@@ -1,4 +1,8 @@
+#nullable enable
+
 using System.Linq;
+
+using Shouldly;
 
 using test.ApiTests;
 
@@ -8,58 +12,59 @@ using Xunit;
 
 using Api = UK.Gov.NationalArchives.Judgments.Api;
 
-namespace test.TRE
+namespace test.TRE;
+
+public class TestNoChange
 {
-    public class TestNoChange
+    private static readonly int[] FailingTestsToSkip = [6, 8, 31, 32];
+    public static readonly TheoryData<int> PassingTests = new(Tests.Indices.Except(FailingTestsToSkip));
+
+    [Theory]
+    [MemberData(nameof(PassingTests))]
+    public void TestJudgments_WithMetadataFromOutputOfCleanRun_AreTheSameAsOutputFromCleanRun(int i)
     {
-        private static readonly int[] FailingTestsToSkip = [6, 8, 31, 32];
-        public static readonly TheoryData<int> PassingTests = new(Tests.Indices.Except(FailingTestsToSkip));
+        var docx = DocumentHelpers.ReadDocx(i);
+        var cleanRunResponse = TestInputInjection.LambdaTest(docx, null);
 
-        [Theory]
-        [MemberData(nameof(PassingTests))]
-        public void TestJudgments_WithMetadataFromOutputOfCleanRun_AreTheSameAsOutputFromCleanRun(int i)
+        var externalMetadataFromCleanRun = new ParserInputs
         {
-            byte[] docx = DocumentHelpers.ReadDocx(i);
-            Api.Response response1 = TestInputInjection.LambdaTest(docx, null);
-            ParserInputs inputs = new()
+            DocumentType = cleanRunResponse.Meta.DocumentType,
+            Metadata = new InputMetadata
             {
-                DocumentType = response1.Meta.DocumentType,
-                Metadata = new InputMetadata()
-                {
-                    URI = Api.URI.ExtractShortURIComponent(response1.Meta.Uri),
-                    Cite = response1.Meta.Cite,
-                    Court = response1.Meta.Court,
-                    Date = response1.Meta.Date,
-                    Name = response1.Meta.Name
-                }
-            };
-            Api.Response response2 = TestInputInjection.LambdaTest(docx, inputs);
-            Assert.Equal(response1.Meta.Uri, response2.Meta.Uri);
-            Assert.Equal(response1.Meta.Cite, response2.Meta.Cite);
-            Assert.Equal(response1.Meta.Court, response2.Meta.Court);
-            Assert.Equal(response1.Meta.Date, response2.Meta.Date);
-            Assert.Equal(response1.Meta.Name, response2.Meta.Name);
-            string actual = DocumentHelpers.RemoveNonDeterministicMetadata(response1.Xml, Xslt);
-            string expected = DocumentHelpers.RemoveNonDeterministicMetadata(response2.Xml, Xslt);
-            Assert.Equal(expected, actual);
-        }
+                URI = Api.URI.ExtractShortURIComponent(cleanRunResponse.Meta.Uri),
+                Cite = cleanRunResponse.Meta.Cite,
+                Court = cleanRunResponse.Meta.Court,
+                Date = cleanRunResponse.Meta.Date,
+                Name = cleanRunResponse.Meta.Name
+            }
+        };
 
-        /// <summary>
-        /// if the parser is given a date, it can't tell whether it's a 'decision' or a 'hearing' date
-        /// </summary>
-        private const string Xslt = @"<?xml version='1.0'?>
-<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0' xmlns:akn='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn'>
-  <xsl:template match='akn:FRBRManifestation/akn:FRBRdate/@date'/>
-  <xsl:template match=""akn:FRBRdate/@name[.='hearing']"">
-    <xsl:attribute name=""name"">decision</xsl:attribute>
-  </xsl:template>
-  <xsl:template match='@*|node()'>
-    <xsl:copy>
-      <xsl:apply-templates select='@*|node()'/>
-    </xsl:copy>
-  </xsl:template>
-</xsl:stylesheet>";
+        var runWithExternalMetadataResponse = TestInputInjection.LambdaTest(docx, externalMetadataFromCleanRun);
 
+        runWithExternalMetadataResponse.Meta.ShouldBeEquivalentTo(cleanRunResponse.Meta);
+
+        var cleanRunResponseXml = DocumentHelpers.RemoveNonDeterministicMetadata(cleanRunResponse.Xml, Xslt);
+        var runWithExternalMetadataResponseXml =
+            DocumentHelpers.RemoveNonDeterministicMetadata(runWithExternalMetadataResponse.Xml, Xslt);
+
+        Assert.Equal(cleanRunResponseXml, runWithExternalMetadataResponseXml);
     }
 
+    /// <summary>
+    /// if the parser is given a date, it can't tell whether it's a 'decision' or a 'hearing' date
+    /// </summary>
+    private const string Xslt = """
+                                <?xml version='1.0'?>
+                                <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0' xmlns:akn='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn'>
+                                  <xsl:template match='akn:FRBRManifestation/akn:FRBRdate/@date'/>
+                                  <xsl:template match="akn:FRBRdate/@name[.='hearing']">
+                                    <xsl:attribute name="name">decision</xsl:attribute>
+                                  </xsl:template>
+                                  <xsl:template match='@*|node()'>
+                                    <xsl:copy>
+                                      <xsl:apply-templates select='@*|node()'/>
+                                    </xsl:copy>
+                                  </xsl:template>
+                                </xsl:stylesheet>
+                                """;
 }

--- a/test/TRE/TestNoChange.cs
+++ b/test/TRE/TestNoChange.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System.Linq;
-
 using Shouldly;
 
 using test.ApiTests;
@@ -16,11 +14,10 @@ namespace test.TRE;
 
 public class TestNoChange
 {
-    private static readonly int[] FailingTestsToSkip = [6, 8, 31, 32];
-    public static readonly TheoryData<int> PassingTests = new(Tests.Indices.Except(FailingTestsToSkip));
+    public static readonly TheoryData<int> IndicesTheoryData = TestParser_Judgments.IndicesTheoryData;
 
     [Theory]
-    [MemberData(nameof(PassingTests))]
+    [MemberData(nameof(IndicesTheoryData))]
     public void TestJudgments_WithMetadataFromOutputOfCleanRun_AreTheSameAsOutputFromCleanRun(int i)
     {
         var docx = DocumentHelpers.ReadDocx(i);

--- a/test/judgments/test84.xml
+++ b/test/judgments/test84.xml
@@ -10,6 +10,7 @@
           <FRBRauthor href="#ewhc-kbd-admin" />
           <FRBRcountry value="GB-UKM" />
           <FRBRnumber value="1094" />
+          <FRBRname value="L (R on the application of) v THE SERVICE COMPLAINTS OMBUDSMAN FOR THE ARMED FORCES" />
         </FRBRWork>
         <FRBRExpression>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/admin/2024/1094" />
@@ -21,7 +22,7 @@
         <FRBRManifestation>
           <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/admin/2024/1094/data.xml" />
           <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/admin/2024/1094/data.xml" />
-          <FRBRdate date="2026-01-22T09:58:21" name="transform" />
+          <FRBRdate date="2026-09-02T10:31:18" name="transform" />
           <FRBRauthor href="#tna" />
           <FRBRformat value="application/xml" />
         </FRBRManifestation>
@@ -33,10 +34,12 @@
         <TLCOrganization eId="ewhc-kbd-admin" href="https://www.gov.uk/courts-tribunals/administrative-court" showAs="The Administrative Court (King's Bench Division)" />
         <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives" />
         <TLCEvent eId="judgment" href="#" showAs="judgment" />
-        <TLCPerson eId="the-king" href="" showAs="THE KING" />
-        <TLCPerson eId="-on-the-application-of-" href="" showAs="-on the application of-" />
         <TLCPerson eId="l" href="" showAs="L" />
+        <TLCPerson eId="the-service-complaints-ombudsman-for-the-armed-forces" href="" showAs="THE SERVICE COMPLAINTS OMBUDSMAN FOR THE ARMED FORCES" />
+        <TLCPerson eId="ministry-of-defence" href="" showAs="MINISTRY OF DEFENCE" />
         <TLCRole eId="claimant" href="" showAs="Claimant" />
+        <TLCRole eId="defendant" href="" showAs="Defendant" />
+        <TLCRole eId="interested-party" href="" showAs="Interested Party" />
         <TLCPerson eId="judge-mr-james-strachan-kc" href="/judge-mr-james-strachan-kc" showAs="Mr James Strachan KC" />
       </references>
       <proprietary source="#">
@@ -45,7 +48,7 @@
         <uk:number>1094</uk:number>
         <uk:cite>[2024] EWHC 1094 (Admin)</uk:cite>
         <uk:caseNumber>AC-2023-LON-002285</uk:caseNumber>
-        <uk:parser>1.4.0</uk:parser>
+        <uk:parser>1.12.0</uk:parser>
         <uk:hash>c606bf07e81eb0066f5c7522fd00f56c299299aca6d1dd8aa152363be59b4595</uk:hash>
       </proprietary>
       <presentation source="#">
@@ -134,8 +137,8 @@
             <p />
           </td>
           <td>
-            <p style="text-align:center"><party refersTo="#the-king" as="#claimant" style="font-weight:bold">THE KING</party></p>
-            <p style="text-align:center"><party refersTo="#-on-the-application-of-" as="#claimant" style="font-weight:bold">-on the application of-</party></p>
+            <p style="text-align:center"><span style="font-weight:bold">THE KING</span></p>
+            <p style="text-align:center"><span style="font-weight:bold">-on the application of-</span></p>
             <p style="text-align:center"><party refersTo="#l" as="#claimant" style="font-weight:bold">L </party></p>
           </td>
           <td>
@@ -152,10 +155,10 @@
             <p style="text-align:center" />
             <p style="text-align:center"><span style="font-weight:bold">- and -</span></p>
             <p style="text-align:center" />
-            <p style="text-align:center"><span style="font-weight:bold">THE SERVICE COMPLAINTS OMBUDSMAN FOR THE ARMED FORCES</span></p>
+            <p style="text-align:center"><party refersTo="#the-service-complaints-ombudsman-for-the-armed-forces" as="#defendant" style="font-weight:bold">THE SERVICE COMPLAINTS OMBUDSMAN FOR THE ARMED FORCES</party></p>
             <p style="text-align:center" />
             <p style="text-align:center"><span style="font-weight:bold">-and-</span></p>
-            <p style="text-align:center"><span style="font-weight:bold">MINISTRY OF DEFENCE </span></p>
+            <p style="text-align:center"><party refersTo="#ministry-of-defence" as="#interested-party" style="font-weight:bold">MINISTRY OF DEFENCE </party></p>
             <p style="text-align:right" />
             <p style="text-align:center" />
           </td>

--- a/test/parsers/common/enrich/TestPartyEnricher_Enrich.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_Enrich.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace test.parsers.common.enrich;
 
-public class TestPartyEnricher
+public partial class TestPartyEnricher
 {
     private static readonly PartyEnricher PartyEnricher = new();
 
@@ -50,94 +50,6 @@ public class TestPartyEnricher
     private static WTable TableOf(WRow[] rows)
     {
         return new WTable(null, null, null, rows);
-    }
-
-    [Theory]
-    [InlineData("Claimant", PartyRole.Claimant)]
-    [InlineData("Claimants", PartyRole.Claimant)]
-    [InlineData("CLAIMANT", PartyRole.Claimant)]
-    [InlineData("(Claimant)", PartyRole.Claimant)]
-    [InlineData("First Claimant", PartyRole.Claimant)]
-    [InlineData("1st Defendant", PartyRole.Defendant)]
-    [InlineData("Third Respondent", PartyRole.Respondent)]
-    [InlineData("Sixth Appellant", PartyRole.Appellant)]
-    [InlineData("Applicant", PartyRole.Applicant)]
-    [InlineData("Petitioner", PartyRole.Petitioner)]
-    [InlineData("Interested Party", PartyRole.InterestedParty)]
-    [InlineData("Interested Parties", PartyRole.InterestedParty)]
-    [InlineData("Intervener", PartyRole.Intervener)]
-    [InlineData("Interveners", PartyRole.Intervener)]
-    [InlineData("Requested Person", PartyRole.RequestedPerson)]
-    [InlineData("Requesting State", PartyRole.RequestingState)]
-    [InlineData("Third Party", PartyRole.ThirdParty)]
-    [InlineData("Part 20 Defendant", PartyRole.Defendant)]
-    [InlineData("Claimant/Defendant", PartyRole.Claimant)]
-    [InlineData("Appellant/Respondent", PartyRole.Appellant)]
-    [InlineData("Respondent/Appellant", PartyRole.Appellant)]
-    [InlineData("Defendant/Applicant", PartyRole.Applicant)]
-    [InlineData("Claimant and Defendant", PartyRole.Claimant)]
-    [InlineData("Not A Role", null)]
-    [InlineData("Claimant/NotARole", null)]
-    public void GetPartyRole_ParsesRoleFromFreeText(string text, PartyRole? expected)
-    {
-        var found = PartyEnricher.TryGetPartyRole(text, out var actual);
-
-        found.ShouldBe(expected is not null);
-        if (expected is not null)
-        {
-            actual.ShouldBe(expected.Value);
-        }
-    }
-
-    [Theory]
-    [InlineData("Appellant", PartyRole.Appellant)]
-    [InlineData("Claimant", PartyRole.Claimant)]
-    [InlineData("Applicant", PartyRole.Applicant)]
-    [InlineData("Defendant", PartyRole.Defendant)]
-    [InlineData("Respondent", PartyRole.Respondent)]
-    [InlineData("Petitioner", PartyRole.Petitioner)]
-    [InlineData("Interested Party", PartyRole.InterestedParty)]
-    [InlineData("1st Claimant", PartyRole.Claimant)]
-    [InlineData("Jane Doe", null)]
-    public void GetPartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText(string text, PartyRole? expected)
-    {
-        var cell = CellOf(text);
-
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
-
-        found.ShouldBe(expected is not null);
-        if (expected is not null)
-        {
-            actual.ShouldBe(expected.Value);
-        }
-    }
-
-    [Theory]
-    [InlineData("Claimant/", "Respondent", PartyRole.Respondent)]
-    [InlineData("Appellants/", "Claimants", PartyRole.Appellant)]
-    [InlineData("Respondent", "Defendant", PartyRole.Respondent)]
-    [InlineData("1st Respondent", "2nd Respondent", PartyRole.Respondent)]
-    [InlineData("Defendant/", "Applicant", PartyRole.Applicant)]
-    public void GetPartyRole_Cell_WithTwoNonEmptyLines_ParsesRoleFromCombinedText(string first, string second,
-        PartyRole expected)
-    {
-        var cell = CellOf(first, second);
-
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
-
-        found.ShouldBeTrue();
-        actual.ShouldBe(expected);
-    }
-
-    [Fact]
-    public void GetPartyRole_Cell_WithThreeOrdinalDefendantLines_ReturnsDefendant()
-    {
-        var cell = CellOf("1st Defendant", "2nd Defendant", "3rd Defendant");
-
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
-
-        found.ShouldBeTrue();
-        actual.ShouldBe(PartyRole.Defendant);
     }
 
     [Theory]
@@ -254,7 +166,8 @@ public class TestPartyEnricher
 
         result[0].ShouldBeSameAs(beforeMarker);
 
-        result[1].Contents.ShouldHaveSingleItem().ShouldBeOfType<WDocTitle>().Text.ShouldBe("IN THE MATTER OF SOME TRUST");
+        result[1].Contents.ShouldHaveSingleItem().ShouldBeOfType<WDocTitle>().Text
+                 .ShouldBe("IN THE MATTER OF SOME TRUST");
 
         result[2].ShouldBeSameAs(afterMarker);
     }

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetPartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetPartyRole.cs
@@ -36,7 +36,7 @@ public partial class TestPartyEnricher
     [InlineData("Appellant / Third Defendant", PartyRole.Appellant)]
     [InlineData("Appellant", PartyRole.Appellant)]
     [InlineData("Appellant/ Defendant", PartyRole.Appellant)]
-    [InlineData("Appellant/ Respondent", PartyRole.Appellant)]
+    [InlineData("Appellant/Respondent", PartyRole.Respondent)]
     [InlineData("Appellant/Appellant", PartyRole.Appellant)]
     [InlineData("Appellant/Applicant", PartyRole.Appellant)]
     [InlineData("Appellant/Claimant", PartyRole.Appellant)]
@@ -128,7 +128,6 @@ public partial class TestPartyEnricher
     [InlineData("requested persons", PartyRole.RequestedPerson)]
     [InlineData("requesting state", PartyRole.RequestingState)]
     [InlineData("1st Defendant", PartyRole.Defendant)]
-    [InlineData("Appellant/Respondent", PartyRole.Appellant)]
     [InlineData("CLAIMANT", PartyRole.Claimant)]
     [InlineData("Claimant and Defendant", PartyRole.Claimant)]
     [InlineData("Claimant/Defendant", PartyRole.Claimant)]
@@ -139,7 +138,7 @@ public partial class TestPartyEnricher
     [InlineData("Sixth Appellant", PartyRole.Appellant)]
     public void TryGetPartyRole_ParsesRoleFromFreeText(string text, PartyRole expected)
     {
-        var found = PartyEnricher.TryGetPartyRole(text, out var actual);
+        var found = PartyEnricher.TryGetPartyRole(out var actual, text);
 
         found.ShouldBeTrue();
         actual.ShouldBe(expected);
@@ -153,7 +152,7 @@ public partial class TestPartyEnricher
     [InlineData("Not A Role")]
     public void TryGetPartyRole_ReturnsFalseWhenNotRole(string text)
     {
-        var found = PartyEnricher.TryGetPartyRole(text, out _);
+        var found = PartyEnricher.TryGetPartyRole(out _, text);
 
         found.ShouldBe(false);
     }

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetPartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetPartyRole.cs
@@ -1,0 +1,211 @@
+using Shouldly;
+
+using UK.Gov.Legislation.Judgments;
+using UK.Gov.Legislation.Judgments.Parse;
+
+using Xunit;
+
+namespace test.parsers.common.enrich;
+
+public partial class TestPartyEnricher
+{
+    [Theory]
+    [InlineData("(1st DEFENDANT)", PartyRole.Defendant)]
+    [InlineData("(2nd DEFENDANT)", PartyRole.Defendant)]
+    [InlineData("(3rd DEFENDANT)", PartyRole.Defendant)]
+    [InlineData("(APPELLANT)", PartyRole.Appellant)]
+    [InlineData("(APPELLANTS)", PartyRole.Appellant)]
+    [InlineData("(CLAIMANTS)", PartyRole.Claimant)]
+    [InlineData("(Claimant)", PartyRole.Claimant)]
+    [InlineData("(DEFENDANTS)", PartyRole.Defendant)]
+    [InlineData("(Defendant)", PartyRole.Defendant)]
+    [InlineData("(FIRST DEFENDANT)", PartyRole.Defendant)]
+    [InlineData("(INTERESTED PARTIES)", PartyRole.InterestedParty)]
+    [InlineData("(INTERESTED PARTY)", PartyRole.InterestedParty)]
+    [InlineData("(RESPONDENT)", PartyRole.Respondent)]
+    [InlineData("(RESPONDENTS)", PartyRole.Respondent)]
+    [InlineData("(SECOND DEFENDANT)", PartyRole.Defendant)]
+    [InlineData("1st Appellant", PartyRole.Appellant)]
+    [InlineData("1st Applicant", PartyRole.Applicant)]
+    [InlineData("1st Respondent", PartyRole.Respondent)]
+    [InlineData("2nd Applicant", PartyRole.Applicant)]
+    [InlineData("2nd Respondent", PartyRole.Respondent)]
+    [InlineData("3rd Respondent", PartyRole.Respondent)]
+    [InlineData("Additional Claimant", PartyRole.Claimant)]
+    [InlineData("Appellant / Claimant", PartyRole.Appellant)]
+    [InlineData("Appellant / Third Defendant", PartyRole.Appellant)]
+    [InlineData("Appellant", PartyRole.Appellant)]
+    [InlineData("Appellant/ Defendant", PartyRole.Appellant)]
+    [InlineData("Appellant/ Respondent", PartyRole.Appellant)]
+    [InlineData("Appellant/Appellant", PartyRole.Appellant)]
+    [InlineData("Appellant/Applicant", PartyRole.Appellant)]
+    [InlineData("Appellant/Claimant", PartyRole.Appellant)]
+    [InlineData("Appellant/Defendant", PartyRole.Appellant)]
+    [InlineData("Appellant/First Defendant", PartyRole.Appellant)]
+    [InlineData("Appellants / Defendants", PartyRole.Appellant)]
+    [InlineData("Appellants", PartyRole.Appellant)]
+    [InlineData("Appellants/ Claimants", PartyRole.Appellant)]
+    [InlineData("Appellants/Claimants", PartyRole.Appellant)]
+    [InlineData("Applicant", PartyRole.Applicant)]
+    [InlineData("Applicant/ Claimant", PartyRole.Applicant)]
+    [InlineData("Applicant/Appellant", PartyRole.Appellant)]
+    [InlineData("Applicants", PartyRole.Applicant)]
+    [InlineData("Applicants/Claimants", PartyRole.Applicant)]
+    [InlineData("Applicants/Defendants", PartyRole.Defendant)]
+    [InlineData("Claimant / Appellant", PartyRole.Appellant)]
+    [InlineData("Claimant / Defendant to Counterclaim", PartyRole.Claimant)]
+    [InlineData("Claimant / Respondent", PartyRole.Respondent)]
+    [InlineData("Claimant", PartyRole.Claimant)]
+    [InlineData("Claimant/ Appellant", PartyRole.Appellant)]
+    [InlineData("Claimant/ Respondent", PartyRole.Respondent)]
+    [InlineData("Claimant/Appellant", PartyRole.Appellant)]
+    [InlineData("Claimant/Applicant", PartyRole.Applicant)]
+    [InlineData("Claimant/Part 20 Defendant", PartyRole.Claimant)]
+    [InlineData("Claimant/Respondent", PartyRole.Respondent)]
+    [InlineData("Claimants", PartyRole.Claimant)]
+    [InlineData("Claimants/ Appellants", PartyRole.Appellant)]
+    [InlineData("Claimants/Appellants", PartyRole.Appellant)]
+    [InlineData("Claimants/Respondents", PartyRole.Respondent)]
+    [InlineData("Clamaints/ Respondents", PartyRole.Respondent)]
+    [InlineData("Defendant / Counterclaimant", PartyRole.Defendant)]
+    [InlineData("Defendant / Respondent", PartyRole.Respondent)]
+    [InlineData("Defendant", PartyRole.Defendant)]
+    [InlineData("Defendant/ Appellant", PartyRole.Appellant)]
+    [InlineData("Defendant/ Applicant", PartyRole.Applicant)]
+    [InlineData("Defendant/ Respondent", PartyRole.Respondent)]
+    [InlineData("Defendant/Appellant", PartyRole.Appellant)]
+    [InlineData("Defendant/Part 20 Claimant", PartyRole.Defendant)]
+    [InlineData("Defendant/Respondent", PartyRole.Respondent)]
+    [InlineData("Defendants / Appellants", PartyRole.Appellant)]
+    [InlineData("Defendants", PartyRole.Defendant)]
+    [InlineData("Defendants/ Appellants", PartyRole.Appellant)]
+    [InlineData("Defendants/ Respondents", PartyRole.Respondent)]
+    [InlineData("Defendants/Appellants", PartyRole.Appellant)]
+    [InlineData("Defendants/Appellants/", PartyRole.Appellant)]
+    [InlineData("Defendants/Respondents", PartyRole.Respondent)]
+    [InlineData("FIRST DEFENDANT’S SOLICITOR/APPELLANT", PartyRole.Appellant)]
+    [InlineData("First Claimant", PartyRole.Claimant)]
+    [InlineData("First Defendant", PartyRole.Defendant)]
+    [InlineData("First Respondent", PartyRole.Respondent)]
+    [InlineData("Fourth Respondent", PartyRole.Respondent)]
+    [InlineData("Interested Parties", PartyRole.InterestedParty)]
+    [InlineData("Interested Party", PartyRole.InterestedParty)]
+    [InlineData("Interested parties", PartyRole.InterestedParty)]
+    [InlineData("Intervener", PartyRole.Intervener)]
+    [InlineData("Interveners", PartyRole.Intervener)]
+    [InlineData("Petitioner", PartyRole.Petitioner)]
+    [InlineData("Petitioner/Respondent", PartyRole.Respondent)]
+    [InlineData("Petitioners", PartyRole.Petitioner)]
+    [InlineData("Respond-ents/ Defendants", PartyRole.Respondent)]
+    [InlineData("Respondent / Defendant", PartyRole.Respondent)]
+    [InlineData("Respondent", PartyRole.Respondent)]
+    [InlineData("Respondent/ Claimant", PartyRole.Respondent)]
+    [InlineData("Respondent/ First Defendant", PartyRole.Respondent)]
+    [InlineData("Respondent/Appellant", PartyRole.Appellant)]
+    [InlineData("Respondent/Applicant", PartyRole.Applicant)]
+    [InlineData("Respondent/Claimant", PartyRole.Respondent)]
+    [InlineData("Respondent/Defendants", PartyRole.Respondent)]
+    [InlineData("Respondent/Petitioner", PartyRole.Respondent)]
+    [InlineData("Respondent/Respondent", PartyRole.Respondent)]
+    [InlineData("Respondents / Claimants", PartyRole.Respondent)]
+    [InlineData("Respondents Second and Third/ Defendants", PartyRole.Respondent)]
+    [InlineData("Respondents", PartyRole.Respondent)]
+    [InlineData("Respondents/ Defendants", PartyRole.Respondent)]
+    [InlineData("Respondents/Claimants", PartyRole.Respondent)]
+    [InlineData("Respondents/Defendants", PartyRole.Respondent)]
+    [InlineData("Respondents/Respondents", PartyRole.Respondent)]
+    [InlineData("Respondnet", PartyRole.Respondent)]
+    [InlineData("Second Claimant", PartyRole.Claimant)]
+    [InlineData("Second Defendant", PartyRole.Defendant)]
+    [InlineData("Second Interested Party", PartyRole.InterestedParty)]
+    [InlineData("Second Respondent", PartyRole.Respondent)]
+    [InlineData("Third Defendant", PartyRole.Defendant)]
+    [InlineData("Third Interested Party", PartyRole.InterestedParty)]
+    [InlineData("Third Party", PartyRole.ThirdParty)]
+    [InlineData("Third Party/Appellant", PartyRole.Appellant)]
+    [InlineData("Third Respondent", PartyRole.Respondent)]
+    [InlineData("requested person", PartyRole.RequestedPerson)]
+    [InlineData("requested persons", PartyRole.RequestedPerson)]
+    [InlineData("requesting state", PartyRole.RequestingState)]
+    [InlineData("1st Defendant", PartyRole.Defendant)]
+    [InlineData("Appellant/Respondent", PartyRole.Appellant)]
+    [InlineData("CLAIMANT", PartyRole.Claimant)]
+    [InlineData("Claimant and Defendant", PartyRole.Claimant)]
+    [InlineData("Claimant/Defendant", PartyRole.Claimant)]
+    [InlineData("Defendant/Applicant", PartyRole.Applicant)]
+    [InlineData("Part 20 Defendant", PartyRole.Defendant)]
+    [InlineData("Requested Person", PartyRole.RequestedPerson)]
+    [InlineData("Requesting State", PartyRole.RequestingState)]
+    [InlineData("Sixth Appellant", PartyRole.Appellant)]
+    public void TryGetPartyRole_ParsesRoleFromFreeText(string text, PartyRole expected)
+    {
+        var found = PartyEnricher.TryGetPartyRole(text, out var actual);
+
+        found.ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Claimant/NotARole")]
+    [InlineData("NotARole/Appellant")]
+    [InlineData("Third not a role")]
+    [InlineData("4th not and a role")]
+    [InlineData("Not A Role")]
+    public void TryGetPartyRole_ReturnsFalseWhenNotRole(string text)
+    {
+        var found = PartyEnricher.TryGetPartyRole(text, out _);
+
+        found.ShouldBe(false);
+    }
+
+    [Theory]
+    [InlineData("Appellant", PartyRole.Appellant)]
+    [InlineData("Claimant", PartyRole.Claimant)]
+    [InlineData("Applicant", PartyRole.Applicant)]
+    [InlineData("Defendant", PartyRole.Defendant)]
+    [InlineData("Respondent", PartyRole.Respondent)]
+    [InlineData("Petitioner", PartyRole.Petitioner)]
+    [InlineData("Interested Party", PartyRole.InterestedParty)]
+    [InlineData("1st Claimant", PartyRole.Claimant)]
+    [InlineData("Jane Doe", null)]
+    public void TryGetPartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText(string text, PartyRole? expected)
+    {
+        var cell = CellOf(text);
+
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+
+        found.ShouldBe(expected is not null);
+        if (expected is not null)
+        {
+            actual.ShouldBe(expected.Value);
+        }
+    }
+
+    [Theory]
+    [InlineData("Claimant/", "Respondent", PartyRole.Respondent)]
+    [InlineData("Appellants/", "Claimants", PartyRole.Appellant)]
+    [InlineData("Respondent", "Defendant", PartyRole.Respondent)]
+    [InlineData("1st Respondent", "2nd Respondent", PartyRole.Respondent)]
+    [InlineData("Defendant/", "Applicant", PartyRole.Applicant)]
+    public void TryGetPartyRole_Cell_WithTwoNonEmptyLines_ParsesRoleFromCombinedText(string first, string second,
+        PartyRole expected)
+    {
+        var cell = CellOf(first, second);
+
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+
+        found.ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryGetPartyRole_Cell_WithThreeOrdinalDefendantLines_ReturnsDefendant()
+    {
+        var cell = CellOf("1st Defendant", "2nd Defendant", "3rd Defendant");
+
+        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+
+        found.ShouldBeTrue();
+        actual.ShouldBe(PartyRole.Defendant);
+    }
+}

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
@@ -169,27 +169,25 @@ public partial class TestPartyEnricher
         found.ShouldBe(false);
     }
 
-    [Theory]
-    [InlineData("Appellant", PartyRole.Appellant)]
-    [InlineData("Claimant", PartyRole.Claimant)]
-    [InlineData("Applicant", PartyRole.Applicant)]
-    [InlineData("Defendant", PartyRole.Defendant)]
-    [InlineData("Respondent", PartyRole.Respondent)]
-    [InlineData("Petitioner", PartyRole.Petitioner)]
-    [InlineData("Interested Party", PartyRole.InterestedParty)]
-    [InlineData("1st Claimant", PartyRole.Claimant)]
-    [InlineData("Jane Doe", null)]
-    public void TryGetSinglePartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText(string text, PartyRole? expected)
+    [Fact]
+    public void TryGetSinglePartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText()
     {
-        var cell = CellOf(text);
+        var cell = CellOf("1st Claimant");
 
         var found = PartyEnricher.TryGetSinglePartyRole(cell, out var actual);
 
-        found.ShouldBe(expected is not null);
-        if (expected is not null)
-        {
-            actual.ShouldBe(expected.Value);
-        }
+        found.ShouldBeTrue();
+        actual.ShouldBe(PartyRole.Claimant);
+    }
+
+    [Fact]
+    public void TryGetSinglePartyRole_Cell_WithOneLineNonRoleText_ReturnsFalse()
+    {
+        var cell = CellOf("I am not a role");
+
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out _);
+
+        found.ShouldBeFalse();
     }
 
     [Theory]
@@ -198,7 +196,7 @@ public partial class TestPartyEnricher
     [InlineData("Respondent", "Defendant", PartyRole.Respondent)]
     [InlineData("1st Respondent", "2nd Respondent", PartyRole.Respondent)]
     [InlineData("Defendant/", "Applicant", PartyRole.Applicant)]
-    public void TryGetSinglePartyRole_Cell_WithTwoNonEmptyLines_ParsesRoleFromCombinedText(string first, string second,
+    public void TryGetSinglePartyRole_Cell_WithTwoRoleLines_ParsesRoleFromCombinedText(string first, string second,
         PartyRole expected)
     {
         var cell = CellOf(first, second);
@@ -207,6 +205,27 @@ public partial class TestPartyEnricher
 
         found.ShouldBeTrue();
         actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryGetSinglePartyRole_Cell_WithARoleAndNonRoleLine_ReturnsFalse()
+    {
+        var cell = CellOf("I am not a role", "Defendant");
+
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out _);
+
+        found.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryGetSinglePartyRole_Cell_WithEmptyLines_ParsesRoleFromNonEmptyLines()
+    {
+        var cell = CellOf(string.Empty, string.Empty, "Claimant", string.Empty, "Applicant", string.Empty);
+
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out var actual);
+
+        found.ShouldBeTrue();
+        actual.ShouldBe(PartyRole.Applicant);
     }
 
     [Fact]

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
@@ -138,7 +138,7 @@ public partial class TestPartyEnricher
     [InlineData("Sixth Appellant", PartyRole.Appellant)]
     public void TryGetSinglePartyRole_ParsesRoleFromFreeText(string text, PartyRole expected)
     {
-        var found = PartyEnricher.TryGetSinglePartyRole(out var actual, text);
+        var found = PartyEnricher.TryGetSinglePartyRole(text, out var actual);
 
         found.ShouldBeTrue();
         actual.ShouldBe(expected);
@@ -152,7 +152,7 @@ public partial class TestPartyEnricher
     [InlineData("Not A Role")]
     public void TryGetSinglePartyRole_ReturnsFalseWhenNotRole(string text)
     {
-        var found = PartyEnricher.TryGetSinglePartyRole(out _, text);
+        var found = PartyEnricher.TryGetSinglePartyRole(text, out _);
 
         found.ShouldBe(false);
     }
@@ -164,7 +164,7 @@ public partial class TestPartyEnricher
     [InlineData("Respondents/Defendants", "Interested parties")]
     public void TryGetSinglePartyRole_ReturnsFalseWhenLastRoleCannotBeCombined(params string[] inputRoleStrings)
     {
-        var found = PartyEnricher.TryGetSinglePartyRole(out _, inputRoleStrings);
+        var found = PartyEnricher.TryGetSinglePartyRole(inputRoleStrings, out _);
 
         found.ShouldBe(false);
     }

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
@@ -136,9 +136,9 @@ public partial class TestPartyEnricher
     [InlineData("Requested Person", PartyRole.RequestedPerson)]
     [InlineData("Requesting State", PartyRole.RequestingState)]
     [InlineData("Sixth Appellant", PartyRole.Appellant)]
-    public void TryGetPartyRole_ParsesRoleFromFreeText(string text, PartyRole expected)
+    public void TryGetSinglePartyRole_ParsesRoleFromFreeText(string text, PartyRole expected)
     {
-        var found = PartyEnricher.TryGetPartyRole(out var actual, text);
+        var found = PartyEnricher.TryGetSinglePartyRole(out var actual, text);
 
         found.ShouldBeTrue();
         actual.ShouldBe(expected);
@@ -150,9 +150,10 @@ public partial class TestPartyEnricher
     [InlineData("Third not a role")]
     [InlineData("4th not and a role")]
     [InlineData("Not A Role")]
-    public void TryGetPartyRole_ReturnsFalseWhenNotRole(string text)
+    public void TryGetSinglePartyRole_ReturnsFalseWhenNotRole(string text)
     {
         var found = PartyEnricher.TryGetPartyRole(out _, text);
+        var found = PartyEnricher.TryGetSinglePartyRole(out _, text);
 
         found.ShouldBe(false);
     }
@@ -167,11 +168,11 @@ public partial class TestPartyEnricher
     [InlineData("Interested Party", PartyRole.InterestedParty)]
     [InlineData("1st Claimant", PartyRole.Claimant)]
     [InlineData("Jane Doe", null)]
-    public void TryGetPartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText(string text, PartyRole? expected)
+    public void TryGetSinglePartyRole_Cell_WithOneNonEmptyLine_ParsesRoleFromCellText(string text, PartyRole? expected)
     {
         var cell = CellOf(text);
 
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out var actual);
 
         found.ShouldBe(expected is not null);
         if (expected is not null)
@@ -186,23 +187,23 @@ public partial class TestPartyEnricher
     [InlineData("Respondent", "Defendant", PartyRole.Respondent)]
     [InlineData("1st Respondent", "2nd Respondent", PartyRole.Respondent)]
     [InlineData("Defendant/", "Applicant", PartyRole.Applicant)]
-    public void TryGetPartyRole_Cell_WithTwoNonEmptyLines_ParsesRoleFromCombinedText(string first, string second,
+    public void TryGetSinglePartyRole_Cell_WithTwoNonEmptyLines_ParsesRoleFromCombinedText(string first, string second,
         PartyRole expected)
     {
         var cell = CellOf(first, second);
 
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out var actual);
 
         found.ShouldBeTrue();
         actual.ShouldBe(expected);
     }
 
     [Fact]
-    public void TryGetPartyRole_Cell_WithThreeOrdinalDefendantLines_ReturnsDefendant()
+    public void TryGetSinglePartyRole_Cell_WithThreeOrdinalDefendantLines_ReturnsDefendant()
     {
         var cell = CellOf("1st Defendant", "2nd Defendant", "3rd Defendant");
 
-        var found = PartyEnricher.TryGetPartyRole(cell, out var actual);
+        var found = PartyEnricher.TryGetSinglePartyRole(cell, out var actual);
 
         found.ShouldBeTrue();
         actual.ShouldBe(PartyRole.Defendant);

--- a/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
+++ b/test/parsers/common/enrich/TestPartyEnricher_TryGetSinglePartyRole.cs
@@ -152,8 +152,19 @@ public partial class TestPartyEnricher
     [InlineData("Not A Role")]
     public void TryGetSinglePartyRole_ReturnsFalseWhenNotRole(string text)
     {
-        var found = PartyEnricher.TryGetPartyRole(out _, text);
         var found = PartyEnricher.TryGetSinglePartyRole(out _, text);
+
+        found.ShouldBe(false);
+    }
+
+    [Theory]
+    [InlineData("Claimant", "Interested Party")]
+    [InlineData("Appellant", "Third party")]
+    [InlineData("Respondents", "Third party")]
+    [InlineData("Respondents/Defendants", "Interested parties")]
+    public void TryGetSinglePartyRole_ReturnsFalseWhenLastRoleCannotBeCombined(params string[] inputRoleStrings)
+    {
+        var found = PartyEnricher.TryGetSinglePartyRole(out _, inputRoleStrings);
 
         found.ShouldBe(false);
     }


### PR DESCRIPTION
This PR merges together the different ways to determine party roles into the `TryGetPartyRole` method and adds some more unit tests to this area.

Rather than using multiple competing sets of string comparisons to find the primary role for a party with multiple roles, the code now finds the role candidates for each part of a multi-role string and does a simple switch to determine the overall winning role.